### PR TITLE
initial profession rework for per-expansion professions & classic

### DIFF
--- a/WoWPro/WoWPro.lua
+++ b/WoWPro/WoWPro.lua
@@ -480,7 +480,7 @@ function WoWPro:OnEnable()
 	    WoWPro:RegisterBucketEvent({"CRITERIA_UPDATE"}, 0.250, WoWPro.AutoCompleteCriteria)
 	end
 	WoWPro:RegisterBucketEvent({"LOOT_CLOSED"}, 0.250, WoWPro.AutoCompleteChest)
-	WoWPro:RegisterBucketEvent({"TRADE_SKILL_LIST_UPDATE"}, 0.250, WoWPro.ScanTrade)
+	WoWPro:RegisterBucketEvent({"TRADE_SKILL_SHOW", "TRADE_SKILL_LIST_UPDATE"}, 0.250, WoWPro.ScanTrade)
 	WoWPro:RegisterBucketMessage("WoWPro_LoadGuide",0.25,WoWPro.LoadGuideReal)
 	WoWPro:RegisterBucketMessage("WoWPro_LoadGuideSteps",0.25,WoWPro.LoadGuideStepsReal)
 	WoWPro:RegisterBucketMessage("WoWPro_GuideSetup",0.25,WoWPro.SetupGuideReal)

--- a/WoWPro/WoWPro_Broker.lua
+++ b/WoWPro/WoWPro_Broker.lua
@@ -1509,75 +1509,61 @@ function WoWPro.NextStep(k,i)
         end
 
         -- WoWPro:dbp("Checkpoint Beth for step %d",k)
-
+         
 		-- Skipping profession quests if their requirements aren't met --
-		if WoWPro.prof[k] and not skip then
-			local prof, profnum, proflvl, profmaxlvl, profmaxskill = string.split(";",WoWPro.prof[k])
-			if proflvl == '*' then proflvl = 801 end -- Set to the maximum level obtainable in the expansion plus 1
-			proflvl = tonumber(proflvl) or 1
-			profmaxlvl = tonumber(profmaxlvl) or 0
-			profmaxskill = tonumber(profmaxskill) or 0
-			if WoWProCharDB.ProfessionalfOffset and WoWPro.Guides[GID].BuyersGuide then
-                proflvl = proflvl - WoWProCharDB.ProfessionalfOffset
-                if 	proflvl < 1 then
-                    proflvl = 1
+        if WoWPro.prof[k] and not skip then
+            local profName, profID, proflvl, profmaxlvl, profmaxskill = string.split(";", WoWPro.prof[k])
+            profID = tonumber(profID) or 0
+            if proflvl == '*' then
+                -- Set to the maximum level obtainable in the expansion plus 1
+                proflvl = 801
+            end
+            proflvl = tonumber(proflvl) or 1
+            profmaxlvl = tonumber(profmaxlvl) or 0
+            profmaxskill = tonumber(profmaxskill) or 0
+            if type(WoWProCharDB.Tradeskills) == 'table' and profID > 0 then
+                skip = true -- Profession steps skipped by default
+                local tradeskill = WoWProCharDB.Tradeskills[profID]
+                if tradeskill then
+                    if WoWPro.action[k] == 'M' and tradeskill.skillMod then
+                        proflvl = math.max(proflvl - tradeskill.skillMod, 1)
+                        profmaxlvl = math.max(profmaxlvl - tradeskill.skillMod, 1)
+                    end
+                    if (profmaxlvl == 0) and (tradeskill.skillLvl >= proflvl) then
+                        WoWPro.why[k] = "NextStep(): profmaxlvl == 0 and skillRank >= proflvl"
+                        WoWPro:dbp(WoWPro.why[k])
+                        skip = false
+                    end
+                    if (profmaxlvl > 0) and (tradeskill.skillLvl < proflvl) then
+                        WoWPro.why[k] = "NextStep(): profmaxlvl > 0 and skillRank < proflvl"
+                        WoWPro:dbp(WoWPro.why[k])
+                        skip = false
+                    end
+                    if (profmaxskill > 0) and (profmaxskill < tradeskill.skillMax) then
+                        WoWPro.why[k] = "NextStep(): profmaxlvl > 0 and profmaxskill < maxskill"
+                        WoWPro:dbp(WoWPro.why[k])
+                        skip = true
+                    end
+                    WoWPro:dbp("prof skip = %s", tostring(skip))
+
+                    -- zero proflvl special unskip logic
+                elseif proflvl == 0 then
+                    WoWPro:dbp("Prof unskip qid %s for no %s for provlvl == 0", WoWPro.QID[k] or "unknown", profName)
+                    skip = false
+
+                    -- If they do not have the profession, mark the step and quest as skipped
+                elseif WoWPro.action[k] == "A" then
+                    WoWPro.why[k] = "NextStep(): Permanently skipping step because player does not have the profession."
+                    WoWProCharDB.Guide[GID].skipped[k] = true
+                    WoWPro:SetQIDsInTable(QID, WoWProCharDB.skippedQIDs)
+                    WoWPro:dbp("Prof permaskip qid %s for no %s", WoWPro.QID[k], prof)
+                    skip = true
+                    break
                 end
-			end
-			if type(prof) == "string" and type(proflvl) == "number" and not WoWPro.CLASSIC then
-				local hasProf = false
-				skip = true --Profession steps skipped by default
-				local profs = {}
-				profs[1], profs[2], profs[3], profs[4], profs[5], profs[6] = GetProfessions()
-				for p=1,6 do
-					if profs[p] then
-						local skillName, texture, skillRank, maxskill, numSpells, spellOffset, skillnum, rankModifier, specializationIndex, specializationOffset, skillLineName = GetProfessionInfo(profs[p])
--- 02003 ~ 082959 WoWPro: Prof prof=Tailoring,197 level=75, max_level=0, max_skill=0
--- 02004 ~ 082959 WoWPro: GetProfessionInfo() = Tailoring, skillRank=1, maxskill=100, skillnum=197
-						if (tonumber(skillnum) == tonumber(profnum)) then
-							hasProf = true
-							if WoWPro.action[k] == "M" then
-							    proflvl = math.max(proflvl-rankModifier,1)
-							    profmaxlvl = math.max(profmaxlvl-rankModifier,1)
-							end
-							WoWPro:dbp("Prof prof=%s,%d proflvl=%d, profmaxlvl=%d, profmaxskill=%d",  prof, profnum, proflvl, profmaxlvl, profmaxskill)
-							WoWPro:dbp("GetProfessionInfo() = %s, skillRank=%d, maxskill=%d, skillnum=%d", skillName, skillRank, maxskill, skillnum)
-							if (profmaxlvl == 0) and (skillRank >= proflvl) then
-							    WoWPro.why[k] = "NextStep(): profmaxlvl == 0 and skillRank >= proflvl"
-							    WoWPro:dbp( WoWPro.why[k])
-							    skip = false
-							end
-							if (profmaxlvl > 0) and (skillRank < profmaxlvl) then
-							    WoWPro.why[k] = "NextStep(): profmaxlvl > 0 and skillRank < profmaxlvl"
-							    WoWPro:dbp( WoWPro.why[k])
-							    skip = false
-							end
-							if (profmaxskill > 0) and (profmaxskill < maxskill) then
-							    WoWPro.why[k] = "NextStep(): profmaxlvl > 0 and profmaxskill < maxskill"
-							    WoWPro:dbp( WoWPro.why[k])
-							    skip = true
-							end
-							WoWPro:dbp("prof skip = %s", tostring(skip))
-						end
-					end
-				end
-				-- Zero proflvl special skip logic
-				if (hasProf == false) and (proflvl == 0) then
-				    WoWPro:dbp("Prof unskip qid %s for no %s for proflvl == 0",WoWPro.QID[k],prof)
-				    skip = false
-				end
-				if WoWPro.action[k] == "A" and not hasProf then
-				    -- If they do not have the profession, mark the step and quest as skipped
-				    WoWPro.why[k] = "NextStep(): Permanently skipping step because player does not have a profession."
-				    WoWProCharDB.Guide[GID].skipped[k] = true
-				    WoWPro:SetQIDsInTable(QID,WoWProCharDB.skippedQIDs)
-				    WoWPro:dbp("Prof permaskip qid %s for no %s",WoWPro.QID[k],prof)
-				    skip = true 
-				    break
-				end
-			else
-			    WoWPro:Error("Warning: malformed profession tag [%s] at step %d",WoWPro.prof[k],k)
-			end
-		end
+            else
+                WoWPro:Error("Warning: malformed profession tag [%s] at step %d", WoWPro.prof[k], k)
+            end
+        end
 
 		-- Skipping reputation quests if their requirements are met --
 		if WoWPro.rep and WoWPro.rep[k] and not skip then

--- a/WoWPro/WoWPro_Events.lua
+++ b/WoWPro/WoWPro_Events.lua
@@ -401,6 +401,7 @@ WoWPro.RegisterEventHandler("PLAYER_ENTERING_WORLD", function (event,...)
 		WoWPro.Titlebar:Show()
 		WoWPro.Hidden = nil
 	end
+	WoWPro:UpdateTradeSkills()
     end)
 
 -- Locking event processong till after things get settled --
@@ -828,6 +829,12 @@ WoWPro.RegisterEventHandler("QUEST_ACCEPTED", function (event,...)
     end
     end)
 
+-- scan skill lines when they change
+WoWPro.RegisterEventHandler("SKILL_LINES_CHANGED", function(event, ...)
+	WoWPro.UpdateTradeSkills(...)
+end)
+
+-- register newly learned recipes
 WoWPro.RegisterEventHandler("NEW_RECIPE_LEARNED", function (event,...)
     WoWPro.LearnRecipe(...)
     end)

--- a/WoWPro/WoWPro_Trade.lua
+++ b/WoWPro/WoWPro_Trade.lua
@@ -2,56 +2,412 @@
 --      WoWPro_Profession_Trade     --
 --------------------------------------
 
-function WoWPro.ScanTrade()
-    -- local tradeskillName, rank, maxLevel = GetTradeSkillLine()
-    local tradeSkillID, skillLineName, skillLineRank, skillLineMaxRank, skillLineModifier =  C_TradeSkillUI.GetTradeSkillLine();
-    
-    if not skillLineName then
-        -- Got event when not in Trade window. Ignore
+-- list of all available professions and their skillLine ID
+WoWPro.ProfessionSkillLines = {
+     [164] = { name = 'Blacksmithing' },
+    [2437] = { exp = 7, parent = 164, name = 'Battle for Azeroth Blacksmithing' },
+    [2454] = { exp = 6, parent = 164, name = 'Legion Blacksmithing' },
+    [2472] = { exp = 5, parent = 164, name = 'Draenor Blacksmithing' },
+    [2473] = { exp = 4, parent = 164, name = 'Pandaria Blacksmithing' },
+    [2474] = { exp = 3, parent = 164, name = 'Cataclysm Blacksmithing' },
+    [2475] = { exp = 2, parent = 164, name = 'Northrend Blacksmithing' },
+    [2476] = { exp = 1, parent = 164, name = 'Outland Blacksmithing' },
+    [2477] = { exp = 0, parent = 164, name = 'Blacksmithing' },
+
+     [165] = { name = 'Leatherworking' },
+    [2525] = { exp = 7, parent = 165, name = 'Battle for Azeroth Leatherworking' },
+    [2526] = { exp = 6, parent = 165, name = 'Legion Leatherworking' },
+    [2527] = { exp = 5, parent = 165, name = 'Draenor Leatherworking' },
+    [2528] = { exp = 4, parent = 165, name = 'Pandaria Leatherworking' },
+    [2529] = { exp = 3, parent = 165, name = 'Cataclysm Leatherworking' },
+    [2530] = { exp = 2, parent = 165, name = 'Northrend Leatherworking' },
+    [2531] = { exp = 1, parent = 165, name = 'Outland Leatherworking' },
+    [2532] = { exp = 0, parent = 165, name = 'Leatherworking' },
+
+     [171] = { name = 'Alchemy' },
+    [2478] = { exp = 7, parent = 171, name = 'Battle for Azeroth Alchemy' },
+    [2479] = { exp = 6, parent = 171, name = 'Legion Alchemy' },
+    [2480] = { exp = 5, parent = 171, name = 'Draenor Alchemy' },
+    [2481] = { exp = 4, parent = 171, name = 'Pandaria Alchemy' },
+    [2482] = { exp = 3, parent = 171, name = 'Cataclysm Alchemy' },
+    [2483] = { exp = 2, parent = 171, name = 'Northrend Alchemy' },
+    [2484] = { exp = 1, parent = 171, name = 'Outland Alchemy' },
+    [2485] = { exp = 0, parent = 171, name = 'Alchemy' },
+
+     [182] = { name = 'Herbalism' },
+    [2549] = { exp = 7, parent = 182, name = 'Battle for Azeroth Herbalism' },
+    [2550] = { exp = 6, parent = 182, name = 'Legion Herbalism' },
+    [2551] = { exp = 5, parent = 182, name = 'Draenor Herbalism' },
+    [2552] = { exp = 4, parent = 182, name = 'Pandaria Herbalism' },
+    [2553] = { exp = 3, parent = 182, name = 'Cataclysm Herbalism' },
+    [2554] = { exp = 2, parent = 182, name = 'Northrend Herbalism' },
+    [2555] = { exp = 1, parent = 182, name = 'Outland Herbalism' },
+    [2556] = { exp = 0, parent = 182, name = 'Herbalism' },
+
+    -- Cooking is not included in GetTradeSkillLineInfoByID()
+     [185] = { name = 'Cooking' },
+    [2541] = { exp = 7, parent = 185, name = 'Battle for Azeroth Cooking' },
+    [2542] = { exp = 6, parent = 185, name = 'Legion Cooking' },
+    [2543] = { exp = 5, parent = 185, name = 'Draenor Cooking' },
+    [2544] = { exp = 4, parent = 185, name = 'Pandaria Cooking' },
+    [2545] = { exp = 3, parent = 185, name = 'Cataclysm Cooking' },
+    [2546] = { exp = 2, parent = 185, name = 'Northrend Cooking' },
+    [2547] = { exp = 1, parent = 185, name = 'Outland Cooking' },
+    [2548] = { exp = 0, parent = 185, name = 'Cooking' },
+
+    -- Cooking Pandaria Specializations
+     [975] = { exp = 4, parent = 185, name = 'Way of the Grill' },
+     [976] = { exp = 4, parent = 185, name = 'Way of the Wok' },
+     [977] = { exp = 4, parent = 185, name = 'Way of the Pot' },
+     [978] = { exp = 4, parent = 185, name = 'Way of the Steamer' },
+     [979] = { exp = 4, parent = 185, name = 'Way of the Oven' },
+     [980] = { exp = 4, parent = 185, name = 'Way of the Brew' },
+
+     [186] = { name = 'Mining' },
+    [2565] = { exp = 7, parent = 186, name = 'Battle for Azeroth Mining' },
+    [2566] = { exp = 6, parent = 186, name = 'Legion Mining' },
+    [2567] = { exp = 5, parent = 186, name = 'Draenor Mining' },
+    [2568] = { exp = 4, parent = 186, name = 'Pandaria Mining' },
+    [2569] = { exp = 3, parent = 186, name = 'Cataclysm Mining' },
+    [2570] = { exp = 2, parent = 186, name = 'Northrend Mining' },
+    [2571] = { exp = 1, parent = 186, name = 'Outland Mining' },
+    [2572] = { exp = 0, parent = 186, name = 'Mining' },
+
+     [197] = { name = 'Tailoring' },
+    [2533] = { exp = 7, parent = 197, name = 'Battle for Azeroth Tailoring' },
+    [2534] = { exp = 6, parent = 197, name = 'Legion Tailoring' },
+    [2535] = { exp = 5, parent = 197, name = 'Draenor Tailoring' },
+    [2536] = { exp = 4, parent = 197, name = 'Pandaria Tailoring' },
+    [2537] = { exp = 3, parent = 197, name = 'Cataclysm Tailoring' },
+    [2538] = { exp = 2, parent = 197, name = 'Northrend Tailoring' },
+    [2539] = { exp = 1, parent = 197, name = 'Outland Tailoring' },
+    [2540] = { exp = 0, parent = 197, name = 'Tailoring' },
+
+     [202] = { name = 'Engineering' },
+    [2499] = { exp = 7, parent = 202, name = 'Battle for Azeroth Engineering' },
+    [2500] = { exp = 6, parent = 202, name = 'Legion Engineering' },
+    [2501] = { exp = 5, parent = 202, name = 'Draenor Engineering' },
+    [2502] = { exp = 4, parent = 202, name = 'Pandaria Engineering' },
+    [2503] = { exp = 3, parent = 202, name = 'Cataclysm Engineering' },
+    [2504] = { exp = 2, parent = 202, name = 'Northrend Engineering' },
+    [2505] = { exp = 1, parent = 202, name = 'Outland Engineering' },
+    [2506] = { exp = 0, parent = 202, name = 'Engineering' },
+
+     [333] = { name = 'Enchanting' },
+    [2486] = { exp = 7, parent = 333, name = 'Battle for Azeroth Enchanting' },
+    [2487] = { exp = 6, parent = 333, name = 'Legion Enchanting' },
+    [2488] = { exp = 5, parent = 333, name = 'Draenor Enchanting' },
+    [2489] = { exp = 4, parent = 333, name = 'Pandaria Enchanting' },
+    [2491] = { exp = 3, parent = 333, name = 'Cataclysm Enchanting' },
+    [2492] = { exp = 2, parent = 333, name = 'Northrend Enchanting' },
+    [2493] = { exp = 1, parent = 333, name = 'Outland Enchanting' },
+    [2494] = { exp = 0, parent = 333, name = 'Enchanting' },
+
+    -- Fishing is not included in GetTradeSkillLineInfoByID()
+     [356] = { name = 'Fishing' },
+    [2585] = { exp = 8, parent = 356, name = 'Battle for Azeroth Fishing' },
+    [2586] = { exp = 7, parent = 356, name = 'Legion Fishing' },
+    [2587] = { exp = 5, parent = 356, name = 'Draenor Fishing' },
+    [2588] = { exp = 4, parent = 356, name = 'Pandaria Fishing' },
+    [2589] = { exp = 3, parent = 356, name = 'Cataclysm Fishing' },
+    [2590] = { exp = 2, parent = 356, name = 'Northrend Fishing' },
+    [2591] = { exp = 1, parent = 356, name = 'Outland Fishing' },
+    [2592] = { exp = 0, parent = 356, name = 'Fishing' },
+
+     [393] = { name = 'Skinning' },
+    [2557] = { exp = 7, parent = 393, name = 'Battle for Azeroth Skinning' },
+    [2558] = { exp = 6, parent = 393, name = 'Legion Skinning' },
+    [2559] = { exp = 5, parent = 393, name = 'Draenor Skinning' },
+    [2560] = { exp = 4, parent = 393, name = 'Pandaria Skinning' },
+    [2561] = { exp = 3, parent = 393, name = 'Cataclysm Skinning' },
+    [2562] = { exp = 2, parent = 393, name = 'Northrend Skinning' },
+    [2563] = { exp = 1, parent = 393, name = 'Outland Sknning' },
+    [2564] = { exp = 0, parent = 393, name = 'Skinning' },
+
+     [755] = { name = 'Jewelcrafting' },
+    [2517] = { exp = 7, parent = 755, name = 'Battle for Azeroth Jewelcrafting' },
+    [2518] = { exp = 6, parent = 755, name = 'Legion Jewelcrafting' },
+    [2519] = { exp = 5, parent = 755, name = 'Draenor Jewelcrafting' },
+    [2520] = { exp = 4, parent = 755, name = 'Pandaria Jewelcrafting' },
+    [2521] = { exp = 3, parent = 755, name = 'Cataclysm Jewelcrafting' },
+    [2522] = { exp = 2, parent = 755, name = 'Northrend Jewelcrafting' },
+    [2523] = { exp = 1, parent = 755, name = 'Outland Jewelcrafting' },
+    [2524] = { exp = 0, parent = 755, name = 'Jewelcrafting' },
+
+     [773] = { name = 'Inscription' },
+    [2507] = { exp = 7, name = 'Battle for Azeroth Inscription' },
+    [2508] = { exp = 6, name = 'Legion Inscription' },
+    [2509] = { exp = 5, name = 'Draenor Inscription' },
+    [2510] = { exp = 4, name = 'Pandaria Inscription' },
+    [2511] = { exp = 3, name = 'Cataclysm Inscription' },
+    [2512] = { exp = 2, name = 'Northrend Inscription' },
+    [2513] = { exp = 1, name = 'Outland Inscription' },
+    [2514] = { exp = 0, name = 'Inscription' },
+
+    --  Archaeology is not included in GetTradeSkillLineInfoByID()
+     [794] = { name = 'Archaeology' }
+}
+
+-- mapping of profession categories to tradeskill lines we are interested in
+WoWPro.ProfessionCategories = {
+    -- Cooking Pandaria Specializations
+    [64] = 975,     -- Way of the Grill
+    [65] = 976,     -- Way of the Wok
+    [66] = 977,     -- Way of the Pot
+    [67] = 978,     -- Way of the Steamer
+    [68] = 979,     -- Way of the Oven
+    [69] = 980,     -- Way of the Brew
+
+    -- Cooking
+    [1016] = 2548,  -- Classic
+    [1017] = 2547,  -- Outland
+    [1018] = 2548,  -- Northrend
+    [1019] = 2545,  -- Cataclysm
+    [1015] = 2544,  -- Pandaria
+    [1013] = 2543,  -- Draenor
+    [1014] = 2542,  -- Legion
+    [1117] = 2541,  -- Battle for Azeroth
+
+    -- Fishing
+    [1099] = 2592,  -- Classic
+    [1101] = 2591,  -- Outland
+    [1103] = 2590,  -- Northrend
+    [1105] = 2589,  -- Cataclysm
+    [1107] = 2588,  -- Pandaria
+    [1109] = 2587,  -- Draenor
+    [1111] = 2586,  -- Legion
+    [1113] = 2585   -- Battle for Azeroth
+}
+
+
+-- special handling for Classic because of the reduced addon API
+if WoWPro.CLASSIC then
+
+    -- list of all available professions and SpellIDs with their names
+    WoWPro.ProfessionSpellIDs = {
+        ['Alchemy'] = 2259,
+        ['Archaeology'] = 78670,
+        ['Blacksmithing'] = 2018,
+        ['Cooking'] = 2550,
+        ['Enchanting'] = 7411,
+        ['Engineering'] = 4036,
+        ['First Aid'] = 3273,
+        ['Fishing'] = 7620,
+        ['Herbalism'] = 9134,
+        ['Inscription'] = 45357,
+        ['Jewelcrafting'] = 25229,
+        ['Leatherworking'] = 2108,
+        ['Mining'] = 2575,
+        ['Skinning'] = 8613,
+        ['Tailoring'] = 3908
+    }
+
+    -- generate a list of localized profession names via GetSpellInfo()
+    WoWPro.ProfessionLocalNames = {}
+    for profName, spellID in pairs(WoWPro.ProfessionSpellIDs) do
+        local localName = GetSpellInfo(spellID)
+        if localName ~= nil then
+            WoWPro.ProfessionLocalNames[localName] = profName
+        end
+    end
+
+    -- generate a lookup table for profession names to profession skill lines
+    WoWPro.ProfessionNameToSkillLine = {}
+    for profID, profession in pairs(WoWPro.ProfessionSkillLines) do
+        if not profession.exp then
+            WoWPro.ProfessionNameToSkillLine[profession.name] = profID
+        end
+    end
+
+    -- get tradeskill information from skill lines
+    function WoWPro.UpdateTradeSkills()
+        local scanned = 0
+        local tradeskills = {}
+
+        for idx = 1, GetNumSkillLines() do
+            local localName, header, _, skillLevel, _, skillModifier, skillMaxRank = GetSkillLineInfo(idx)
+            local skillName = WoWPro.ProfessionLocalNames[localName]
+            local profID = WoWPro.ProfessionNameToSkillLine[skillName]
+            if not header and profID and skillName then
+                tradeskills[profID] = {
+                    name = skillName,
+                    skillLvl = skillLevel,
+                    skillMod = skillModifier,
+                    skillMax = skillMaxRank
+                }
+                scanned = scanned + 1
+            end
+        end
+
+        WoWPro.UpdateTradeSkillsTable(tradeskills)
+        WoWPro:dbp("UpdateTradeSkills() for Classic scanned %d tradeskills", scanned)
+    end
+else
+    -- get tradeskill information from GetProfession/GetProfessionInfo
+    function WoWPro.UpdateTradeSkills()
+        local scanned = 0
+        local tradeskills = {}
+
+        -- first scan all profession tradeskill lines that are learned
+        for _, skillLineID in ipairs(C_TradeSkillUI.GetAllProfessionTradeSkillLines()) do
+            local _, skillLineRank, skillLineMaxRank, skillLineModifier, parentSkillLineID = C_TradeSkillUI.GetTradeSkillLineInfoByID(skillLineID)
+            if skillLineRank > 0 and WoWPro.ProfessionSkillLines[skillLineID] then
+                tradeskills[skillLineID] = {
+                    name = WoWPro.ProfessionSkillLines[skillLineID].name,
+                    skillLvl = skillLineRank,
+                    skillMax = skillLineMaxRank,
+                    skillMod = skillLineModifier
+                }
+                scanned = scanned + 1
+            end
+        end
+
+        -- scan with GetProfessions()
+        for _, profID in ipairs({GetProfessions()}) do
+            local name, _, skillLineRank, skillLineMaxRank, _, _, skillLineID, skillLineModifier, _, _, subName = GetProfessionInfo(profID)
+
+            -- skillLineID is always the parent ID, so once you learn an expansion
+            -- GetProfessionInfo() is no longer useful except for Archaeology
+            if WoWPro.ProfessionSkillLines[skillLineID] and (not subName or name == subName) then
+                tradeskills[skillLineID] = {
+                    name = WoWPro.ProfessionSkillLines[skillLineID].name,
+                    skillLvl = skillLineRank,
+                    skillMax = skillLineMaxRank,
+                    skillMod = skillLineModifier
+                }
+                scanned = scanned + 1
+            end
+        end
+
+        WoWPro.UpdateTradeSkillsTable(tradeskills)
+        WoWPro:dbp("UpdateTradeSkills() scanned %d tradeskills", scanned)
+    end
+end
+
+
+-- update WoWProCharDB.Tradeskill map so we don't forget detailed ScanTrade() info
+function WoWPro.UpdateTradeSkillsTable(tradeskills)
+    if not WoWProCharDB.Tradeskills then
+        WoWProCharDB.Tradeskills = tradeskills
         return
     end
 
-    WoWPro:dbp("Opened %s window",skillLineName)
-    WoWProCharDB.Trades = WoWProCharDB.Trades or {}
-    local Trade = WoWProCharDB.Trades 
-    
-    -- Scan trade skills, saving state of headers
-    local recipeIDs = C_TradeSkillUI.GetAllRecipeIDs({})
-    WoWPro:dbp("Located %d recipeIDs",#recipeIDs)
-    
-    for i, recipeID in ipairs(recipeIDs) do
-		local recipeInfo = C_TradeSkillUI.GetRecipeInfo(recipeID)
-		if recipeInfo.type == "recipe" then
-		    if recipeInfo.learned then
---		        WoWPro:Print("Scanning %d:%s",recipeID,recipeInfo.name)
+    -- remove unlearned/unavailable professions, except for cooking or fishing
+    for trade in pairs(WoWProCharDB.Tradeskills) do
+        local skillLine = WoWPro.ProfessionSkillLines[trade]
+        if not skillLine then
+            WoWProCharDB.Tradeskills[trade] = nil
+        elseif tradeskills[trade] == nil and trade ~= 185 and skillLine.parent ~= 185 and trade ~= 356 and skillLine.parent ~= 356 then
+            WoWProCharDB.Tradeskills[trade] = nil
+        end
+    end
+
+    -- add/update learned professions
+    for trade, info in pairs(tradeskills) do
+        if WoWProCharDB.Tradeskills[trade] == nil then
+            WoWProCharDB.Tradeskills[trade] = info
+        else
+            for key, val in ipairs(info) do
+                WoWProCharDB.Tradeskills[trade][key] = val
+            end
+        end
+    end
+end
+
+
+-- special handling for Classic because of the reduced addon API
+if WoWPro.CLASSIC then
+    -- scan Tradeskill information and recipes on Classic
+    function WoWPro.ScanTrade()
+        WoWPro:dbp("ScanTrade() for Classic")
+
+        -- FIXME: find a way to scan recipes without C_TradeSkillUI and
+        -- GetSpellInfo("name", "") doesn't return information for tradeskills
+        -- GetTradeSkillItemLink() returns the resulting item, not the spellID
+        -- skillName, skillType, numAvailable = GetTradeSkillInfo(index)
+    end
+else
+    -- scan Tradeskill information and recipes on Live
+    function WoWPro.ScanTrade()
+        -- read tradeskill information from GetTradeSkillLine()
+        local skillLineID, skillLineName, skillLineRank, skillLineMaxRank, skillLineModifier = C_TradeSkillUI.GetTradeSkillLine();
+        if not skillLineID then
+            return
+        end
+
+        -- don't scan other players tradeskills
+        if C_TradeSkillUI.IsTradeSkillLinked() then
+            return
+        end
+        WoWPro:dbp("ScanTrade() opened %s window", skillLineName)
+
+        -- update tradeskill information directly
+        local tradeInfo = WoWProCharDB.Tradeskills[skillLineID] or {}
+        tradeInfo.name = WoWPro.ProfessionSkillLines[skillLineID].name
+        tradeInfo.skillLvl = skillLineRank
+        tradeInfo.skillMax = skillLineMaxRank
+        tradeInfo.skillMod = skillLineModifier
+        WoWProCharDB.Tradeskills[skillLineID] = tradeInfo
+
+        -- scan catgegories
+        local catInfo = {}
+        for _, catID in ipairs({C_TradeSkillUI.GetCategories()}) do
+
+            -- only scan category IDs we are interested in
+            local skillLineID = WoWPro.ProfessionSkillLines[catID]
+            if skillLineID then
+                C_TradeSkillUI.GetCategoryInfo(catID, catInfo)
+                if catInfo.hasProgressBar and catInfo.skillLineCurrentLevel and catInfo.skillLineMaxLevel then
+                    local tradeInfo = WoWProCharDB.Tradeskills[skillLineID] or {}
+                    tradeInfo.name = WoWPro.ProfessionSkillLines[skillLineID].name
+                    tradeInfo.skillLvl = skillLineRank
+                    tradeInfo.skillMax = skillLineMaxRank
+                    tradeInfo.skillMod = skillLineModifier
+                    WoWProCharDB.Tradeskills[skillLineID] = tradeInfo
+                end
+            end
+        end
+
+        -- scan all recipes available and store them
+        WoWProCharDB.Trades = WoWProCharDB.Trades or {}
+        local Trades = WoWProCharDB.Trades
+        local recipes = 0
+        local learned = 0
+        local recipeInfo = {}
+        for _, recipeID in pairs(C_TradeSkillUI.GetAllRecipeIDs()) do
+            C_TradeSkillUI.GetRecipeInfo(recipeID, recipeInfo)
+            if recipeInfo.type == 'recipe' and recipeInfo.learned then
                 local link = C_TradeSkillUI.GetRecipeLink(recipeID)
-                local _, _, spellId = link:find("^|%x+|Henchant:(.+)|h%[.+%]");
+                local _, _, spellId = link:find("^|%x+|Henchant:(.+)|h%[.+%]")
                 spellId = tonumber(spellId)
                 if not spellId then
                     local safe_link = link:gsub("|", "¦")
-                    WoWPro:Error("Error scanning recipeID %d for [%s]: %s",recipeID, recipeInfo.name, safe_link)
+                    WoWPro:Error("Error scanning recipeID %d for [%s]: %s", recipeID, recipeInfo.name, safe_link)
                 else
-                    if not Trade[spellId] then
-                        Trade[spellId] = true
-                        WoWPro:dbp("Newly learned %s:%d",recipeInfo.name, spellId)
+                    if not Trades[spellId] then
+                        Trades[spellId] = true
+                        WoWPro:dbp("Newly learned %s:%d", recipeInfo.name, spellId)
+                        learned = learned + 1
                     end
+                    recipes = recipes + 1
                 end
             end
-		end
-	end
-
-    WoWProCharDB.Trades  = Trade
+        end
+        WoWPro:dbp("ScanTrade() recorded %d known recipes, %d learned", recipes, learned)
+    end
 end
 
-function WoWPro.LearnRecipe(which)
-    local which = tonumber(which)
-    if which then
-        if WoWProCharDB.Trades[which] then
+
+-- learn recipe from NEW_RECIPE_LEARNED event
+function WoWPro.LearnRecipe(spellID)
+    local spellID = tonumber(spellID)
+    if spellID then
+        if WoWProCharDB.Trades[spellID] then
             -- You managed to learn something you already knew?
-            WoWPro:Warning("Recipe %d was already recorded as learned.",which)
+            WoWPro:Warning("Recipe %d was already recorded as learned.", spellID)
         else
             WoWProCharDB.Trades[which] = true
-            WoWPro:dbp("Newly learned %d", which)
+            WoWPro:dbp("Newly learned %d", spellID)
         end
     end
 end


### PR DESCRIPTION
Most changes are in WoWPro_Trade.lua, with documentation inside the file of the profession IDs per expansion.

The Spell IDs for Classic are used for localization, as the API only allows scanning skill lines and those are only available as localized names.

Information is stored in WoWProCharDB.Tradeskills.