### PR TITLE
Ran guides from 51-60 Emmaleah/WoW-Pro-Guides through TourGuide-Utils

### DIFF
--- a/WoWPro_Leveling/Classic/Horde/51_53_Un'Goro_Crater.lua
+++ b/WoWPro_Leveling/Classic/Horde/51_53_Un'Goro_Crater.lua
@@ -1,0 +1,142 @@
+
+TourGuide:RegisterGuide( "Un'Goro Crater (51-53)", "Burning Steppes (53-54)", "Horde", function()
+return [[
+
+; === guides/51_53_Un'Goro_Crater.lua ===
+; --- FIXME: Coords found in N tag, using: 26.00,52.00
+R Un'Goro Crater|M|26.00,52.00|Z|Tanaris|N|Southewest corner of the zone (26,52)|
+N Look for loot...|N|There are many loot nodes scattered across this zone. You'll need 7 of each color of power crystals. Also loot any dirt piles or sprouts you find.|
+
+; --- FIXME: Coords found in N tag, using: 69.00,77.00
+A The Apes of Un'Goro|M|69.00,77.00|N|Tauren on the hill to the left of the ramp from Tanaris (69,77)|
+A The Fare of Lar'korwi|
+
+; --- FIXME: Coords found in N tag, using: 63.04,68.54
+A It's a Secret to Everybody (Part 1)|M|63.04,68.54|N|Find the wrecked raft (63.04, 68.54)|
+T It's a Secret to Everybody (Part 1)|N|Just underwater nearby|
+A It's a Secret to Everybody (Part 2)|
+; --- FIXME: Coords found in N tag, using: 68.80,56.70
+C The Fare of Lar'korwi|M|68.80,56.70|N|Find the Threshadon Carcass (68.8, 56.7) amongst the raptors.|
+
+T The Fare of Lar'korwi|
+A The Scent of Lar'korwi|
+; --- FIXME: Coords found in N tag, using: 60.00,72.00
+C The Scent of Lar'korwi|M|60.00,72.00|N|Find the egg nests and stand on them (60,72) (62,65) (63,77) (67,73) (67,67) (58,78) (70,61)|
+T The Scent of Lar'korwi|
+A The Bait for Lar'korwi|
+A Williden's Journal|U|11116|N|Kill raptors until the journal drops to start this quest|
+
+N Find 7 Red power crystals|L|11186 7|
+N Find 7 Yellow power crystals|L|11188 7|
+N Find 7 Green power crystals|L|11185 7|
+N Find 7 Blue power crystals|L|11184 7|
+
+; --- FIXME: Coords found in N tag, using: 46.00,13.00
+A Chasing A-Me 01|M|46.00,13.00|N|At the entrance to Marshal's Refuge (46,13)|
+A Shizzle's Flyer|
+A Lost!|N|Near the sign|
+A Beware of Pterrordax|
+A Roll the Bones|
+A Alien Ecology|
+T Williden's Journal|
+A Expedition Salvation|
+T It's a Secret to Everybody (Part 2)|
+A It's a Secret to Everybody (Part 3)|
+A Larion and Muigin|N|Hidden on the north side of the valley|
+f Get flight point|N|Up on the hill, easy to miss|
+A Crystals of Power|N|In the back of the cave|
+T Crystals of Power|
+A The Northern Pylon|
+A The Eastern Pylon|
+A The Western Pylon|
+
+N Kill stuff...|N|Kill any bloodpetals, diametradons, and pterrordaxes you come across|
+
+; --- FIXME: Coords found in N tag, using: 56.46,12.48
+C The Northern Pylon|M|56.46,12.48|N|Along the north edge of the zone to the east (56.46, 12.48). Kill pterrordaxes here.|
+; --- FIXME: Coords found in N tag, using: 63.00,17.00
+T Chasing A-Me 01|M|63.00,17.00|N|East in the gorilla cave (63,17). Skip the follow-up.|
+C The Apes of Un'Goro|
+C Super Sticky|N|At the tarpits in the north half of the zone|
+; --- FIXME: Coords found in N tag, using: 68.52,36.59
+N Find [Crate of Foodstuffs]|L|11113|M|68.52,36.59|N|At the abandoned camp in the east side of the zone (68.52, 36.59)|
+C Larion and Muigin|N|Kill lasher around the camp area. Also kill any diemetradons or pterrordaxes you come across|
+; --- FIXME: Coords found in N tag, using: 76.00,51.00
+C The Eastern Pylon|M|76.00,51.00|N|To the east, of course (76,51)|
+; --- FIXME: Coords found in N tag, using: 79.90,49.90
+C The Bait for Lar'korwi|U|11568|M|79.90,49.90|N|Use the meat and mixture at the flat rock behind the east pylon (79.9, 49.9)|
+T The Bait for Lar'korwi|
+T The Apes of Un'Goro|S|N|Skip the follow-up|
+
+; --- FIXME: Coords found in N tag, using: 50.00,77.00
+C Alien Ecology|U|11132|M|50.00,77.00|N|Down in the Slithering Scar (50,77). Head left inside to the big room (48.62, 85.33), use the vial|
+N Kill bugs for [Gorishi Scent Gland]|L|11837|
+; --- FIXME: Coords found in N tag, using: 38.50,66.00
+C Expedition Salvation|M|38.50,66.00|N|At the other camp (38.5, 66.0)|
+; --- FIXME: Coords found in N tag, using: 23.00,59.00
+C The Western Pylon|M|23.00,59.00|N|(23,59)|
+; --- FIXME: Coords found in N tag, using: 30.90,50.40
+A Finding the Source|M|30.90,50.40|N|From a goblin near the hot springs (30.9, 50.4)|
+C Bone-Bladed Weapons|
+
+C Roll the Bones|N|Scattered all over the west half of the zone and drop from diemetradons. Kill pterrordaxes over here too.|
+C Beware of Pterrordax|N|You can find the Frenzied Pterrordaxes all over the west half of the zone, more towards the northwest part. Normal Pterrordaxes are in the south half of the zone, and a few near the North pylon.|
+C Shizzle's Flyer|N|Kill diemetradons and pterrordaxes, all over the zone.|
+
+C Finding the Source|U|12472|N|At the volcano in the center of the zone. Use the thermometer at "Hot Spots" until you complete the quest.|
+C Volcanic Activity|N|Kill elementals, mainly around the cave on the south side of the volcano.|
+; --- FIXME: Coords found in N tag, using: 51.00,49.00
+T Lost!|M|51.00,49.00|N|In the cave on the south side of the volcano (51,49)|
+; --- FIXME: Unknown tag 'NODEBUG'
+A A Little Help From My Friends|
+; --- FIXME: Unknown tag 'NODEBUG'
+C A Little Help From My Friends|U|11804|N|Use the canteen on him if he faints. Run back to Marshal's Refuge.|
+; --- FIXME: Unknown tag 'NODEBUG'
+T A Little Help From My Friends|
+T Beware of Pterrordax|
+T Shizzle's Flyer|
+T Roll the Bones|
+T Alien Ecology|
+T Expedition Salvation|
+T Larion and Muigin|
+T The Northern Pylon|
+T The Eastern Pylon|
+T The Western Pylon|
+A Making Sense of It|
+T Making Sense of It|
+
+; --- FIXME: Coords found in N tag, using: 30.90,50.40
+T Finding the Source|M|30.90,50.40|N|Back at the hot springs (30.9, 50.4)|
+A The New Springs|
+
+K Oozes|L|12235 30|
+
+; --- FIXME: Coords found in N tag, using: 29.00,22.00
+R Silithus|M|29.00,22.00|N|Take the path up out of the crater in the northwest corner of the zone (29,22)|
+R Cenarion Hold|N|Follow the road|
+F Gadgetzan|N|FP is up the big hill|
+T Bungle in the Jungle|S|N|Skip the follow-up|
+T Super Sticky|
+
+H Thunder Bluff|
+A Un'Goro Soil|N|On Elder Rise|
+T Un'Goro Soil|
+A Morrowgrain Research|
+T Morrowgrain Research|
+
+F The Crossroads|
+h The Crossroads|
+
+F Ratchet|
+T Volcanic Activity|
+T Marvon's Workshop|
+
+b Booty Bay|
+T Whiskey Slim's Lost Grog|
+
+F Kargath|
+T Vivian Lagrave|
+A Dreadmaul Rock|
+A The Rise of the Machines (Part 1)|
+]]
+end)

--- a/WoWPro_Leveling/Classic/Horde/53_54_Burning_Steppes.lua
+++ b/WoWPro_Leveling/Classic/Horde/53_54_Burning_Steppes.lua
@@ -1,0 +1,50 @@
+TourGuide:RegisterGuide("Burning Steppes (53-54)", "Felwood (54)", "Horde", function()
+return [[
+
+; === guides/53_54_Burning_Steppes.lua ===
+F Kargath|
+T Vivian Lagrave|QID|4133|
+A Dreadmaul Rock|QID|3821|
+; --- FIXME: Updated TITLE from 'The Rise of the Machines (Part 1)' to 'The Rise of the Machines'
+A The Rise of the Machines|QID|4061|
+
+F Burning Steppes|
+A Broodling Essence|QID|4726|
+A Tablet of the Seven|QID|4296|
+
+C Broodling Essence|QID|4726|N|To the East, grind on the dragon whelps|
+
+; --- FIXME: Coords found in N tag, using: 94.00,31.00
+A A Taste of Flame|QID|4024|PRE|4023|M|94.00,31.00|N|In the cave (94,31)|
+T A Taste of Flame|QID|4024|
+; --- FIXME: Coords found in N tag, using: 79.00,45.00
+T Dreadmaul Rock|QID|3821|M|79.00,45.00|N|At (79,45)|
+A Krom'Grul|QID|3822|PRE|3821|
+
+C Krom'Grul|QID|3822|N|He has two spawn points in either cave|
+; --- FIXME: Updated TITLE from 'The Rise of the Machines (Part 1)' to 'The Rise of the Machines'
+C The Rise of the Machines|QID|4061|
+C Tablet of the Seven|QID|4296|
+
+T Tablet of the Seven|QID|4296|
+T Broodling Essence|QID|4726|
+A Felnok Steelspring|QID|4808|PRE|4726|
+
+F Kargath|
+T Krom'Grul|QID|3822|
+; --- FIXME: Updated TITLE from 'The Rise of the Machines (Part 1)' to 'The Rise of the Machines'
+T The Rise of the Machines|QID|4061|
+; --- FIXME: Updated TITLE from 'The Rise of the Machines (Part 2)' to 'The Rise of the Machines'
+A The Rise of the Machines|QID|4062|PRE|4061|
+; --- FIXME: Updated TITLE from 'The Rise of the Machines (Part 2)' to 'The Rise of the Machines'
+C The Rise of the Machines|QID|4062|
+; --- FIXME: Updated TITLE from 'The Rise of the Machines (Part 2)' to 'The Rise of the Machines'
+; --- FIXME: Coords found in N tag, using: 25.00,44.00
+T The Rise of the Machines|QID|4062|M|25.00,44.00|Z|Badlands|N|In the Badlands (25,44)|
+
+H The Crossroads|
+F Orgrimmar|
+; --- FIXME: Coords found in N tag, using: 52.00,34.00
+T Bone-Bladed Weapons|QID|4300|M|52.00,34.00|Z|Orgrimmar|N|(52,34)|
+]]
+end)

--- a/WoWPro_Leveling/Classic/Horde/54_55_Winterspring.lua
+++ b/WoWPro_Leveling/Classic/Horde/54_55_Winterspring.lua
@@ -1,0 +1,82 @@
+TourGuide:RegisterGuide("Winterspring (54-55)", "Western Plaguelands (56)", "Horde", function()
+return [[
+
+; === guides/54_55_Winterspring.lua ===
+R Everlook|N|Follow the road east.|
+; --- FIXME: Updated TITLE from 'Are We There, Yeti? (Part 1)' to 'Are We There, Yeti?'
+A Are We There, Yeti?|QID|3783|
+A The Everlook Report|QID|6029|
+A Duke Nicholas Zverenhoff|QID|6030|
+A Sister Pamela|QID|5601|
+A Ursius of the Shardtooth|QID|5054|
+T Felnok Steelspring|QID|4808|
+A Chillwind Horns|QID|4809|PRE|4808|
+h Everlook|
+
+C Ursius of the Shardtooth|QID|5054|N|Grind mobs north of everlook til he shows up|
+T Ursius of the Shardtooth|QID|5054|
+A Brumeran of the Chillwind|QID|5055|PRE|5054|
+; --- FIXME: Coords found in N tag, using: 60.00,60.00
+C Brumeran of the Chillwind|QID|5055|M|60.00,60.00|N|Pats near (60,60)|
+
+; --- FIXME: Coords found in N tag, using: 59.00,73.00
+C Strange Sources|QID|4842|M|59.00,73.00|N|Take the road south to Darkwhisper Gorge (59,73)|
+
+H Everlook|
+T Brumeran of the Chillwind|QID|5055|
+; --- FIXME: Updated TITLE from 'Are We There, Yeti? (Part 1)' to 'Are We There, Yeti?'
+C Are We There, Yeti?|QID|3783|
+C Threat of the Winterfall|QID|5082|
+C Wild Guardians|QID|4741|N|Ragged Owls are west of Everlook, Raging are just north|
+; --- FIXME: Coords found in N tag, using: 66.00,29.00
+C Chillwind Horns|QID|4809|M|66.00,29.00|N|Large Chimera concentration around (66,29)|
+
+; --- FIXME: Coords found in N tag, using: 31.00,45.00
+T Threat of the Winterfall|QID|5082|M|31.00,45.00|N|at (31,45)|
+T Strange Sources|QID|4842|
+A Winterfall Firewater|QID|5083|U|12771|
+T Winterfall Firewater|QID|5083|
+A Falling to Corruption|QID|5084|PRE|5083|
+
+; --- FIXME: Updated TITLE from 'Are We There, Yeti? (Part 1)' to 'Are We There, Yeti?'
+; --- FIXME: Coords found in N tag, using: 61.00,38.00
+T Are We There, Yeti?|QID|3783|M|61.00,38.00|N|Everlook (61,38)|
+; --- FIXME: Updated TITLE from 'Are We There, Yeti? (Part 2)' to 'Are We There, Yeti?'
+A Are We There, Yeti?|QID|977|PRE|3783|
+T Chillwind Horns|QID|4809|
+
+; --- FIXME: Coords found in N tag, using: 67.00,37.00
+C Winterfall Activity|QID|8464|M|67.00,37.00|N|(67,37)|
+; --- FIXME: Updated TITLE from 'Are We There, Yeti? (Part 2)' to 'Are We There, Yeti?'
+; --- FIXME: Coords found in N tag, using: 66.00,43.00
+C Are We There, Yeti?|QID|977|M|66.00,43.00|N|pristine horns (66,43)|
+
+H Everlook|
+; --- FIXME: Updated TITLE from 'Are We There, Yeti? (Part 2)' to 'Are We There, Yeti?'
+T Are We There, Yeti?|QID|977|
+
+F Bloodvenom Post|
+T Wild Guardians|QID|4741|S|N|Skip the follow-up|
+
+F Emerald Sanctuary|
+T Collection of the Corrupt Water|QID|5157|S|N|Skip the follow-up|
+T Verifying the Corruption|QID|5156|
+T Cleansing Felwood|QID|4102|N|North along the road|
+
+C Corrupted Sabers|QID|4506|
+T Corrupted Sabers|QID|4506|N|First talk to the cat|
+
+; --- FIXME: Coords found in N tag, using: 60.00,5.00
+T Falling to Corruption|QID|5084|M|60.00,5.00|Z|Felwood|N|The cauldron at (60,5)|
+A Mystery Goo|QID|5085|PRE|5084|
+A Deadwood Ritual Totem|QID|8470|U|20741|O|
+T Deadwood Ritual Totem|QID|8470|O|N|Turn-in at a furblog halfway thru the hold|
+
+R Winterspring|
+T Winterfall Activity|QID|8464|
+; --- FIXME: Coords found in N tag, using: 31.00,45.00
+T Mystery Goo|QID|5085|M|31.00,45.00|Z|Winterspring|N|(31,45) in Winterspring, skip the follow-up|
+
+H Everlook|
+]]
+end)

--- a/WoWPro_Leveling/Classic/Horde/54_Felwood.lua
+++ b/WoWPro_Leveling/Classic/Horde/54_Felwood.lua
@@ -1,0 +1,66 @@
+
+TourGuide:RegisterGuide("Felwood (54)", "Winterspring (54-55)", "Horde", function()
+return [[
+
+; === guides/54_Felwood.lua ===
+F Splintertree Post|
+
+; --- FIXME: Coords found in N tag, using: 55.75,29.50
+R Felwood|M|55.75,29.50|Z|Ashenvale|N|Head west out of town. At the fork near the retreat head north out of the zone (55.75, 29.50)|
+
+; --- FIXME: Coords found in N tag, using: 51.00,81.00
+R Emerald Sanctuary|M|51.00,81.00|N|Just ahead, north of the road (51,81)|
+A Forces of Jaedenar|QID|5155|
+A Verifying the Corruption|QID|5156|
+; --- FIXME: Coords found in N tag, using: 51.00,85.00
+A Timbermaw Ally|QID|8460|M|51.00,85.00|N|Down by the road (51,85)|
+
+; --- FIXME: Coords found in N tag, using: 46.80,83.10
+A Cleansing Felwood|QID|4102|M|46.80,83.10|N|On the west side of the road to the north (46.8, 83.1)|
+
+; --- FIXME: Coords found in N tag, using: 34.00,52.00
+R Bloodvenom Post|M|34.00,52.00|N|(34,52)|
+A Well of Corruption|QID|4505|
+A A Husband's Last Battle|QID|6162|
+
+; --- FIXME: Coords found in N tag, using: 37.00,59.00
+C Forces of Jaedenar|QID|5155|M|37.00,59.00|N|To the west, outside the caves (37,59)|
+; --- FIXME: Coords found in N tag, using: 32.00,66.00
+C Well of Corruption|QID|4505|M|32.00,66.00|N|To the west at the far west end of the ruins (32,66)|
+
+C A Husband's Last Battle|QID|6162|
+C Timbermaw Ally|QID|8460|
+
+T Timbermaw Ally|QID|8460|
+A Speak to Nafien|QID|8462|PRE|8460|
+T Forces of Jaedenar|QID|5155|
+A Collection of the Corrupt Water|QID|5157|PRE|5155|
+
+T Well of Corruption|QID|4505|
+A Corrupted Sabers|QID|4506|PRE|4505|
+T A Husband's Last Battle|QID|6162|
+A Wild Guardians|QID|4741|PRE|4521|
+
+; --- FIXME: Coords found in N tag, using: 35.25,59.75
+C Collection of the Corrupt Water|QID|5157|U|12922|M|35.25,59.75|N|Fill the vial at the corrupted moonwell in Jaedenar (35.25, 59.75)|
+C Verifying the Corruption|QID|5156|
+C Cleansing Felwood|QID|4102|
+
+; --- FIXME: Coords found in N tag, using: 64.80,8.20
+T Speak to Nafien|QID|8462|M|64.80,8.20|N|North, at the end of the road (64.8,8.2)|
+A Deadwood of the North|QID|8461|
+C Deadwood of the North|QID|8461|
+T Deadwood of the North|QID|8461|
+A Speak to Salfa|QID|8465|
+
+R Winterspring|N|Thru the cave!|
+T Speak to Salfa|QID|8465|
+A Winterfall Activity|QID|8464|
+; --- FIXME: Coords found in N tag, using: 31.27,45.20
+T The New Springs|QID|980|M|31.27,45.20|Z|Winterspring|N|To the south near the hot springs (31.27, 45.20)|
+A Strange Sources|QID|4842|PRE|980|
+; --- FIXME: Updated TITLE from 'It's a Secret to Everybody (Part 3)' to 'It's a Secret to Everybody'
+T It's a Secret to Everybody|QID|3908|
+A Threat of the Winterfall|QID|5082|
+]]
+end)

--- a/WoWPro_Leveling/Classic/Horde/56_57_Eastern_Plaguelands.lua
+++ b/WoWPro_Leveling/Classic/Horde/56_57_Eastern_Plaguelands.lua
@@ -1,0 +1,72 @@
+
+TourGuide:RegisterGuide("Eastern Plaguelands (56-57)", "Western Plaguelands (57-59)", "Horde", function()
+return [[
+
+; === guides/56_57_Eastern_Plaguelands.lua ===
+; --- FIXME: Coords found in N tag, using: 4.56,38.29
+A Demon Dogs|QID|5542|M|4.56,38.29|N|Fly to the east edge of WPL, run across the bridge into EPL and follow the river north (4.56, 38.29).|
+A Blood Tinged Skies|QID|5543|
+A Carrion Grubbage|QID|5544|
+
+N Kill crap...|N|Kill any plaguehounds, carrion worms, and plaguebats you encounter.|
+; --- FIXME: Coords found in N tag, using: 23.00,68.17
+A Un-Life's Little Annoyances|QID|6042|M|23.00,68.17|N|Follow the road east to the Marris Stead (23.00, 68.17).|
+A To Kill With Purpose|QID|6022|
+
+T Sister Pamela|QID|5601|
+A Pamela's Doll|QID|5149|
+C Pamela's Doll|QID|5149|N|Parts are found in the houses nearby. Ghosts spawn when you get near them.|
+T Pamela's Doll|QID|5149|
+A Auntie Marlene|QID|5152|PRE|5149|
+A Uncle Carlin|QID|5241|PRE|5149|
+
+; --- FIXME: Convert QO tag 'Plaguehound Runt slain: 20/20' to number
+K Plaguehounds|QID|5542|QO|Plaguehound Runt slain: 20/20|N|All over the southwestern section of the zone|
+C Blood Tinged Skies|QID|5543|
+
+; --- FIXME: Coords found in N tag, using: 81.00,58.00
+T Uncle Carlin|QID|5241|M|81.00,58.00|N|East at Light's Hope Chapel (81,58)|
+A Defenders of Darrowshire|QID|5211|PRE|5241|
+A The Restless Souls|QID|5281|
+T Duke Nicholas Zverenhoff|QID|6030|
+h Light's Hope Chapel|
+; --- FIXME: Coords found in N tag, using: 79.00,63.00
+A Zaeldarr the Outcast|QID|6021|M|79.00,63.00|N|Southwest near the corpse pits (79,63)|
+
+N Free Spirits...|N|Kill any cannibal ghouls, gibbering ghouls and diseased flayers you come across. Speak to any ghosts that spawn for "Defenders of Darrowshire".|
+C Demon Dogs|QID|5542|
+; --- FIXME: Updated TITLE from 'A Plague Upon Thee (Part 1)' to 'A Plague Upon Thee'
+C A Plague Upon Thee|QID|5901|
+
+C To Kill With Purpose|QID|6022|
+C Defenders of Darrowshire|QID|5211|
+C Carrion Grubbage|QID|5544|
+C Un-Life's Little Annoyances|QID|6042|
+
+T The Restless Souls|QID|5281|
+A Augustus' Receipt Book|QID|6164|
+C Augustus' Receipt Book|QID|6164|
+T Augustus' Receipt Book|QID|6164|
+
+H Light's Hope Chapel|
+T Defenders of Darrowshire|QID|5211|
+
+T Demon Dogs|QID|5542|N|Fly back over to the border of WPL/EPL, of course.|
+T Blood Tinged Skies|QID|5543|
+T Carrion Grubbage|QID|5544|
+A Redemption|QID|5742|PRE|5542|
+C Redemption|QID|5742|N|Blah blah blah... he talks to much.|
+T Redemption|QID|5742|
+A Of Forgotten Memories|QID|5781|PRE|5742|
+
+T To Kill With Purpose|QID|6022|
+T Un-Life's Little Annoyances|QID|6042|
+
+; --- FIXME: Coords found in N tag, using: 24.60,80.00
+C Of Forgotten Memories|QID|5781|M|24.60,80.00|N|South at the Undercroft (24.6,80). Talk to the grave and Mercutio and his adds will walk in (not spawn). Try to pull him away from the adds, kill and loot him, and get out. You might need help.|
+; --- FIXME: Coords found in N tag, using: 23.80,78.40
+C Zaeldarr the Outcast|QID|6021|M|23.80,78.40|N|Inside the crypt at the bottom (23.8,78.4)|
+
+T Of Forgotten Memories|QID|5781|
+]]
+end)

--- a/WoWPro_Leveling/Classic/Horde/56_Western_Plaguelands.lua
+++ b/WoWPro_Leveling/Classic/Horde/56_Western_Plaguelands.lua
@@ -1,0 +1,108 @@
+TourGuide:RegisterGuide("Western Plaguelands (56)", "Eastern Plaguelands (56-57)", "Horde", function()
+return [[
+
+; === guides/56_Western_Plaguelands.lua ===
+F Undercity|
+A A Call to Arms: The Plaguelands!|QID|5094|N|From Harbinger Balthazad, he patrols around the center and middle rings of the city.|
+h Undercity|
+
+R The Bulwark|
+T A Call to Arms: The Plaguelands!|QID|5094|
+A Scarlet Diversions|QID|5096|
+N Get a Flame in a Bottle|L|12814|N|From the Box of Incendiaries|
+T The Everlook Report|QID|6029|
+N Get a Commission|L|12846|N|Talk to the quartermaster and get a commission, you should have this equipped any time you are in the plaguelands. Turn in any scourgestones you get when you are in town if you have a full stack.|
+A The So-Called Mark of the Lightbringer|QID|9443|
+; --- FIXME: Updated TITLE from 'A Plague Upon Thee (Part 1)' to 'A Plague Upon Thee'
+A A Plague Upon Thee|QID|5901|
+
+C Scarlet Diversions|QID|5096|N|Burn the tent, plant the banner. Note that if you have a partner he will not get credit, you must wait for the tent to respawn.|
+
+T Scarlet Diversions|QID|5096|N|Back at the Bulwark|
+A All Along the Watchtowers|QID|5098|PRE|5096|
+A The Scourge Cauldrons|QID|5228|PRE|5096|
+T The Scourge Cauldrons|QID|5228|
+A Target: Felstone Field|QID|5229|PRE|5228|
+
+C Target: Felstone Field|QID|5229|
+T Target: Felstone Field|QID|5229|
+; --- FIXME: Updated TITLE from 'Return to the Bulwark (Part 1)' to 'Return to the Bulwark'
+A Return to the Bulwark|QID|5230|PRE|5229|
+
+; --- FIXME: Updated TITLE from 'Better Late Than Never (Part 1)' to 'Better Late Than Never'
+; --- FIXME: Coords found in N tag, using: 38.00,54.00
+A Better Late Than Never|QID|5021|M|38.00,54.00|N|In the house on the northeast side of the field (38,54), upstairs|
+; --- FIXME: Updated TITLE from 'Better Late Than Never (Part 1)' to 'Better Late Than Never'
+; --- FIXME: Coords found in N tag, using: 38.80,55.20
+T Better Late Than Never|QID|5021|M|38.80,55.20|N|Next door in the barn, talk to the box (38.8, 55.2)|
+; --- FIXME: Updated TITLE from 'Better Late Than Never (Part 2)' to 'Better Late Than Never'
+A Better Late Than Never|QID|5023|PRE|5021|
+
+H Undercity|
+T Better Late Than Never|QID|5023|
+A The Jeremiah Blues|QID|5049|PRE|5023|
+T The Jeremiah Blues|QID|5049|
+A Good Luck Charm|QID|5050|
+
+; --- FIXME: Updated TITLE from 'Return to the Bulwark (Part 1)' to 'Return to the Bulwark'
+T Return to the Bulwark|QID|5230|
+A Target: Dalson's Tears|QID|5231|PRE|5230|
+
+T Good Luck Charm|QID|5050|
+A Two Halves Become One|QID|5051|PRE|5050|
+C Two Halves Become One|QID|5051|N|Go out in the field and kill the Jabbering Ghoul (only one with a pitchfork), then combine the pieces.|
+T Two Halves Become One|QID|5051|
+
+C Target: Dalson's Tears|QID|5231|
+T Target: Dalson's Tears|QID|5231|
+; --- FIXME: Updated TITLE from 'Return to the Bulwark (Part 2)' to 'Return to the Bulwark'
+A Return to the Bulwark|QID|5232|PRE|5231|
+
+; --- FIXME: Coords found in N tag, using: 47.80,50.70
+N Read Mrs. Dalson's Diary|M|47.80,50.70|N|On the floor in the barn (47.8, 50.7). Nothing to accept, just read the book.|
+K Wandering Skeleton|L|12738|N|Patrols around the house and barn, you are looking for the outhouse key. Scarlets might kill this mob.|
+K Farmer Dalson|L|12739|N|Open the outhouse, get his key|
+N Open cabinet|L|13474|N|Locked cabinet upstairs in the house.|
+
+; --- FIXME: Updated TITLE from 'Return to the Bulwark (Part 2)' to 'Return to the Bulwark'
+T Return to the Bulwark|QID|5232|
+A Target: Writhing Haunt|QID|5233|PRE|5232|
+
+C Target: Writhing Haunt|QID|5233|
+T Target: Writhing Haunt|QID|5233|
+; --- FIXME: Updated TITLE from 'Return to the Bulwark (Part 3)' to 'Return to the Bulwark'
+A Return to the Bulwark|QID|5234|PRE|5233|
+
+; --- FIXME: Updated TITLE from 'The Wildlife Suffers Too (Part 1)' to 'The Wildlife Suffers Too'
+; --- FIXME: Coords found in N tag, using: 54.00,65.00
+A The Wildlife Suffers Too|QID|4984|M|54.00,65.00|N|In the house by the field (54,65)|
+; --- FIXME: Updated TITLE from 'The Wildlife Suffers Too (Part 1)' to 'The Wildlife Suffers Too'
+C The Wildlife Suffers Too|QID|4984|
+; --- FIXME: Updated TITLE from 'The Wildlife Suffers Too (Part 1)' to 'The Wildlife Suffers Too'
+T The Wildlife Suffers Too|QID|4984|
+; --- FIXME: Updated TITLE from 'The Wildlife Suffers Too (Part 2)' to 'The Wildlife Suffers Too'
+A The Wildlife Suffers Too|QID|4985|PRE|4984|
+; --- FIXME: Updated TITLE from 'The Wildlife Suffers Too (Part 2)' to 'The Wildlife Suffers Too'
+C The Wildlife Suffers Too|QID|4985|
+
+; --- FIXME: Coords found in N tag, using: 69.20,49.70
+f New flight point!|M|69.20,49.70|N|There is now a flight point on the east end of the road (69.2, 49.7). Zip over there and fly back to the WARK!|
+; --- FIXME: Updated TITLE from 'Return to the Bulwark (Part 3)' to 'Return to the Bulwark'
+T Return to the Bulwark|QID|5234|
+A Target: Gahrron's Withering|QID|5235|PRE|5234|
+
+C Target: Gahrron's Withering|QID|5235|
+T Target: Gahrron's Withering|QID|5235|
+; --- FIXME: Updated TITLE from 'Return to the Bulwark (Part 4)' to 'Return to the Bulwark'
+A Return to the Bulwark|QID|5236|PRE|5235|
+
+; --- FIXME: Updated TITLE from 'The Wildlife Suffers Too (Part 2)' to 'The Wildlife Suffers Too'
+T The Wildlife Suffers Too|QID|4985|
+
+; --- FIXME: Updated TITLE from 'Return to the Bulwark (Part 4)' to 'Return to the Bulwark'
+T Return to the Bulwark|QID|5236|
+A Scholomance|QID|838|PRE|5098|
+T Scholomance|QID|838|
+A Skeletal Fragments|QID|964|PRE|838|
+]]
+end)

--- a/WoWPro_Leveling/Classic/Horde/57_59_Western_Plaguelands.lua
+++ b/WoWPro_Leveling/Classic/Horde/57_59_Western_Plaguelands.lua
@@ -1,0 +1,77 @@
+
+TourGuide:RegisterGuide("Western Plaguelands (57-59)", nil, "Horde", function()
+return [[
+
+; === guides/57_59_Western_Plaguelands.lua ===
+; --- FIXME: Updated TITLE from 'A Plague Upon Thee (Part 1)' to 'A Plague Upon Thee'
+T A Plague Upon Thee|QID|5901|
+; --- FIXME: Updated TITLE from 'A Plague Upon Thee (Part 2)' to 'A Plague Upon Thee'
+A A Plague Upon Thee|QID|5902|PRE|5901|
+
+; --- FIXME: Updated TITLE from 'A Plague Upon Thee (Part 2)' to 'A Plague Upon Thee'
+T A Plague Upon Thee|QID|5902|
+; --- FIXME: Updated TITLE from 'A Plague Upon Thee (Part 3)' to 'A Plague Upon Thee'
+A A Plague Upon Thee|QID|6390|PRE|5902|
+
+; --- FIXME: Updated TITLE from 'Unfinished Business (Part 1)' to 'Unfinished Business'
+; --- FIXME: Coords found in N tag, using: 51.00,28.00
+A Unfinished Business|QID|6004|M|51.00,28.00|N|(51,28)|
+
+; --- FIXME: Updated TITLE from 'Unfinished Business (Part 1)' to 'Unfinished Business'
+C Unfinished Business|QID|6004|
+; --- FIXME: Updated TITLE from 'Unfinished Business (Part 1)' to 'Unfinished Business'
+T Unfinished Business|QID|6004|
+; --- FIXME: Updated TITLE from 'Unfinished Business (Part 2)' to 'Unfinished Business'
+A Unfinished Business|QID|6023|PRE|6004|
+
+; --- FIXME: Updated TITLE from 'Unfinished Business (Part 2)' to 'Unfinished Business'
+C Unfinished Business|QID|6023|
+C The So-Called Mark of the Lightbringer|QID|9443|
+; --- FIXME: Updated TITLE from 'Unfinished Business (Part 2)' to 'Unfinished Business'
+T Unfinished Business|QID|6023|
+; --- FIXME: Updated TITLE from 'Unfinished Business (Part 3)' to 'Unfinished Business'
+A Unfinished Business|QID|6025|PRE|6023|
+; --- FIXME: Updated TITLE from 'Unfinished Business (Part 3)' to 'Unfinished Business'
+C Unfinished Business|QID|6025|
+; --- FIXME: Updated TITLE from 'Unfinished Business (Part 3)' to 'Unfinished Business'
+T Unfinished Business|QID|6025|
+
+; --- FIXME: Updated TITLE from 'A Plague Upon Thee (Part 3)' to 'A Plague Upon Thee'
+T A Plague Upon Thee|QID|6390|
+T The So-Called Mark of the Lightbringer|QID|9443|
+A Defiling Uther's Tomb|QID|9444|PRE|9443|
+
+T Auntie Marlene|QID|5152|
+A A Strange Historian|QID|5153|PRE|5152|
+
+C A Strange Historian|QID|5153|
+C Defiling Uther's Tomb|QID|9444|N|You'll need to equip the quest item at the tomb.|
+
+T A Strange Historian|QID|5153|
+A The Annals of Darrowshire|QID|5154|PRE|5153|
+A A Matter of Time|QID|4971|
+
+C A Matter of Time|QID|4971|U|12627|N|Find the blue glowy silos around the edges of Andorhal and use the horn.|
+C The Annals of Darrowshire|QID|5154|
+; --- FIXME: Coords found in N tag, using: 47.00,71.00
+C All Along the Watchtowers|QID|5098|U|12815|M|47.00,71.00|N|Mark each tower in Andorhal, you can get close enough to mark without aggroing mobs inside if you are careful. (47,71) (40,71) (42,66) (44,63)|
+
+T A Matter of Time|QID|4971|
+A Counting Out Time|QID|4973|PRE|4972|
+T The Annals of Darrowshire|QID|5154|
+A Brother Carlin|QID|5210|PRE|5154|
+
+C Counting Out Time|QID|4973|N|Find lunchboxes in the houses all around Andorhal.|
+C Skeletal Fragments|QID|964|N|Kill undead all over Andorhal.|
+
+T Counting Out Time|QID|4973|
+
+H Light's Hope Chapel|
+T Zaeldarr the Outcast|QID|6021|
+T Brother Carlin|QID|5210|
+
+T Skeletal Fragments|QID|964|
+T Defiling Uther's Tomb|QID|9444|
+T All Along the Watchtowers|QID|5098|
+]]
+end)


### PR DESCRIPTION
This should be a no-disruptive pull since these are are new files created using TourGuide-Utils on Version 1 guide files.

The original files for 51-60 were copied from https://github.com/Emmaleah/WoW-Pro-Guides/tree/master/WoWPro_Leveling/Classic/Horde
