### PR TITLE
Update WoWPro_Parser.lua

### DIFF
--- a/WoWPro/WoWPro_Parser.lua
+++ b/WoWPro/WoWPro_Parser.lua
@@ -519,7 +519,9 @@ function WoWPro.ParseQuestLine(faction, zone, i, text)
 	if WoWPro.map[i] then
 		if (WoWPro.map[i] == "PLAYER") then
 			local x, y, z = WoWPro:GetPlayerZonePosition()
-			WoWPro.map[i]= string.format("%.2f",x*100) .. ',' .. string.format("%.2f",y*100)
+			if (x ~= nil and y ~= nil) then
+				WoWPro.map[i]= string.format("%.2f",x*100) .. ',' .. string.format("%.2f",y*100)
+			end
 		end
 	    WoWPro:ValidateMapCoords(GID,WoWPro.action[i],WoWPro.step[i],WoWPro.map[i])
 	end

--- a/WoWPro/WoWPro_Parser.lua
+++ b/WoWPro/WoWPro_Parser.lua
@@ -519,7 +519,7 @@ function WoWPro.ParseQuestLine(faction, zone, i, text)
 	if WoWPro.map[i] then
 		if (WoWPro.map[i] == "PLAYER") then
 			local x, y, z = WoWPro:GetPlayerZonePosition()
-			if (x ~= nil and y ~= nil) then
+			if (x  and y) then
 				WoWPro.map[i]= string.format("%.2f",x*100) .. ',' .. string.format("%.2f",y*100)
 			end
 		end


### PR DESCRIPTION
Fix for PLAYER map coord when their coords report nil like when in a dungeon.