### PR TITLE
Patch 94

### DIFF
--- a/WoWPro/WoWPro_Mapping.lua
+++ b/WoWPro/WoWPro_Mapping.lua
@@ -381,23 +381,28 @@ function WoWPro.DistanceToStep(i)
 end
 
 function WoWPro:ValidateMapCoords(guide,action,step,coords)
-	local numcoords = select("#", string.split(";", coords))
-	for j=1,numcoords do
-		local jcoord = select(numcoords-j+1, string.split(";", coords))
-		if not jcoord or jcoord == "" then
-		    WoWPro:Error("Missing coordinate, %d/%d in guide %s, line [%s %s].",numcoords-j+1,numcoords,guide,action,step)
-		    return
+	if coords then
+		local numcoords = select("#", string.split(";", coords))
+		for j=1,numcoords do
+			local jcoord = select(numcoords-j+1, string.split(";", coords))
+			if not jcoord or jcoord == "" then
+				WoWPro:Error("Missing coordinate, %d/%d in guide %s, line [%s %s].",numcoords-j+1,numcoords,guide,action,step)
+				return
+			end
+			local x = tonumber(jcoord:match("([^|]*),"))
+			if not x or x > 100  then
+				WoWPro:Error("Bad X coordinate %s, %d/%d in guide %s, line [%s %s].",jcoord,numcoords-j+1,numcoords,guide,action,step)
+				return
+			end
+			local y = tonumber(jcoord:match(",([^|]*)"))
+			if not y or y > 100 then
+				WoWPro:Error("Bad Y coordinate %s, %d/%d in guide %s, line [%s %s].",jcoord,numcoords-j+1,numcoords,guide,action,step)
+				return
+			end
 		end
-		local x = tonumber(jcoord:match("([^|]*),"))
-		if not x or x > 100  then
-		    WoWPro:Error("Bad X coordinate %s, %d/%d in guide %s, line [%s %s].",jcoord,numcoords-j+1,numcoords,guide,action,step)
-		    return
-		end
-		local y = tonumber(jcoord:match(",([^|]*)"))
-		if not y or y > 100 then
-		    WoWPro:Error("Bad Y coordinate %s, %d/%d in guide %s, line [%s %s].",jcoord,numcoords-j+1,numcoords,guide,action,step)
-		    return
-		end
+	else
+		WoWPro:Error("Map table is nil, %d/%d in guide %s, line [%s %s].",1,1,guide,action,step)
+		return
 	end
 end
 

--- a/WoWPro/WoWPro_Parser.lua
+++ b/WoWPro/WoWPro_Parser.lua
@@ -525,8 +525,9 @@ function WoWPro.ParseQuestLine(faction, zone, i, text)
 			else
 				WoWPro.map[i]= nil
 			end
+		else
+			WoWPro:ValidateMapCoords(GID,WoWPro.action[i],WoWPro.step[i],WoWPro.map[i])
 		end
-	    WoWPro:ValidateMapCoords(GID,WoWPro.action[i],WoWPro.step[i],WoWPro.map[i])
 	end
 	WoWPro.zone[i] = WoWPro.zone[i] or (WoWPro.map[i] and zone)
 	if WoWPro.zone[i] and WoWPro.map[i] and not WoWPro:ValidZone(WoWPro.zone[i]) then


### PR DESCRIPTION
Told parse to not use validatemapcoords if the PLAYER tag is used

Also fixed validatemapcoords, which was unrelated to the PLAYER tag to also check if the coords are nil before trying to run a split on them, which breaks the addon. Just added the safety net.

Please review ludo. wanna make sure this was done right.