### PR TITLE
Allow mapIDs in place of zone names

### DIFF
--- a/WoWPro/WoWPro.lua
+++ b/WoWPro/WoWPro.lua
@@ -639,21 +639,26 @@ function WoWPro:Timeless()
 end
 
 
-function WoWPro:RegisterGuide(GIDvalue, gtype, zonename, authorname, faction, release)
+function WoWPro:RegisterGuide(GIDvalue, gtype, zone, authorname, faction, release)
     if not WoWPro[gtype] then
         WoWPro:Error("WoWPro:RegisterGuide(%s,%s,...) has bad gtype",GIDvalue,tostring(gtype))
     end
-    -- Check for funky zones line 'Shadowglen (NightElf)'
-    local trueZone = zonename:match("([^%(]+)"):trim()
-    local name = nil
-    if trueZone ~= zonename then
-        name = zonename -- the zonename is really the guide name
-        zonename = trueZone -- the real zone name is the unparenthesized portion
+
+    local name
+    if type(zone) == "number" then
+        name = WoWPro.HBD.mapData[zone].name
+    else
+        -- Check for funky zones line 'Shadowglen (NightElf)'
+        local trueZone = zone:match("([^%(]+)"):trim()
+        if trueZone ~= zone then
+            name = zone -- the zone is really the guide name
+            zone = trueZone -- the real zone name is the unparenthesized portion
+        end
     end
 
     local guide = {
         guidetype = gtype,
-        zone = zonename,
+        zone = zone,
         author = authorname,
         faction = faction,
         name = name,

--- a/WoWPro/WoWPro_Mapping.lua
+++ b/WoWPro/WoWPro_Mapping.lua
@@ -449,7 +449,7 @@ function WoWPro:MapPoint(row)
     end
     local desc = WoWPro.step[stepIndex]
     local zone
-    zone = WoWPro.zone[stepIndex] or WoWPro.Guides[GID].zone:match("([^%(]+)"):trim()
+    zone = WoWPro.zone[stepIndex] or WoWPro.Guides[GID].name:match("([^%(]+)"):trim()
     autoarrival = WoWPro.waypcomplete[stepIndex]
 
     -- Loading Blizzard Coordinates for this objective, if coordinates aren't provided --

--- a/WoWPro/WoWPro_Parser.lua
+++ b/WoWPro/WoWPro_Parser.lua
@@ -381,9 +381,10 @@ function WoWPro.EmitStep(i)
         elseif tag == "CS" or tag == "CN" then
             line = line
         elseif tag == "Z" then
+            local zone = WoWPro.zone[i]
             -- Suppress zone tags that are dupes of the master zone
-            if WoWPro.zone[i] and WoWPro.zone[i] ~= WoWPro.Guides[GID].zone then
-                line = addTagValue(line, tag, WoWPro.zone[i])
+            if zone and zone ~= WoWPro.Guides[GID].zone then
+                line = addTagValue(line, tag, WoWPro.ConvertZone(zone))
             end
         elseif tag and WoWPro.TagTable[tag].vtype == "boolean" then
             -- No value

--- a/WoWPro/WoWPro_Parser.lua
+++ b/WoWPro/WoWPro_Parser.lua
@@ -788,7 +788,7 @@ function WoWPro.ParseSteps(steps)
     local _, myclass = _G.UnitClass("player")
     local _, myrace = _G.UnitRace("player")
     local myFaction = WoWPro.Faction:upper()
-    local zone = (WoWPro.Guides[GID].zone or ""):match("([^%(]+)"):trim()
+    local zone = (WoWPro.Guides[GID].name or ""):match("([^%(]+)"):trim()
 
     if WoWPro.Recorder then
         i = 1 -- No extra steps for recorder guides

--- a/WoWPro/WoWPro_Zones.lua
+++ b/WoWPro/WoWPro_Zones.lua
@@ -619,3 +619,12 @@ function WoWPro.Functionalize(release)
     LogBox:Show()
     WoWPro:Print("WoWPro:Functionalize(): 2")
 end
+
+local _
+function WoWPro.ConvertZone(zone)
+    if type(zone) ~= "number" then
+        _, zone = WoWPro:ValidZone(zone)
+    end
+    return zone
+end
+

--- a/WoWPro_Leveling/Alliance/INTRO_VoidElf.lua
+++ b/WoWPro_Leveling/Alliance/INTRO_VoidElf.lua
@@ -1,4 +1,4 @@
-local guide = WoWPro:RegisterGuide("LudoTelogrus", "Leveling", "Telogrus Rift!Instance971", "Ludovicus", "Alliance")
+local guide = WoWPro:RegisterGuide("LudoTelogrus", "Leveling", 971, "Ludovicus", "Alliance")
 WoWPro:GuideLevels(guide, 10, 10)
 WoWPro:GuideSort(guide, 14)
 WoWPro:GuideContent(guide, "Intro")
@@ -9,12 +9,12 @@ WoWPro:GuideNextGuide(guide, "Chromie Time")
 WoWPro:GuideSteps(guide, function()
 return
 [[
-A For the Alliance|QID|49788|M|28.54,22.27|Z|VoidElfHub|N|From Alleria Windrunner.|
-P Stormwind City|ACTIVE|49788|M|27.99, 21.50|Z|VoidElfHub|N|Click on the void portal to go to Stormwind.|
-T For the Alliance|QID|49788|M|53.07,15.25|Z|Stormwind City|N|To Ambassador Moorgard.|
-A Stranger in a Strange Land|QID|50305|PRE|49788|M|53.07,15.25|Z|Stormwind City|N|From Ambassador Moorgard.|
-C Hero's Call board|QID|50305|M|62.25,29.94|Z|Stormwind City|N|Click on the Hero's Call Board but don't choose anything just yet.|
-T Stranger in a Strange Land|QID|50305|M|62.49,29.74|Z|Stormwind City|N|To Keira Onyxraven.|
-N It's Chromie Time!|QID|62567|M|62.25,29.93|Z|Stormwind City|JUMP|Chromie Time|LVL|10|N|Congratulations on hitting level 10.\n\nYou can now accept Chromies call at the Hero's Call board in Stormwind. This will allow you to choose which expansion you want to level in.\n\n Click the guide button next to this frame to direct you to Chromie!|
+A For the Alliance|QID|49788|M|28.54,22.27|Z|971|N|From Alleria Windrunner.|
+P Stormwind City|ACTIVE|49788|M|27.99, 21.50|Z|971|N|Click on the void portal to go to Stormwind.|
+T For the Alliance|QID|49788|M|53.07,15.25|Z|84|N|To Ambassador Moorgard.|
+A Stranger in a Strange Land|QID|50305|PRE|49788|M|53.07,15.25|Z|84|N|From Ambassador Moorgard.|
+C Hero's Call board|QID|50305|M|62.25,29.94|Z|84|N|Click on the Hero's Call Board but don't choose anything just yet.|
+T Stranger in a Strange Land|QID|50305|M|62.49,29.74|Z|84|N|To Keira Onyxraven.|
+N It's Chromie Time!|QID|62567|M|62.25,29.93|Z|84|JUMP|Chromie Time|LVL|10|N|Congratulations on hitting level 10.\n\nYou can now accept Chromies call at the Hero's Call board in Stormwind. This will allow you to choose which expansion you want to level in.\n\n Click the guide button next to this frame to direct you to Chromie!|
 ]]
 end)

--- a/WoWPro_Recorder/WoWPro_Recorder.lua
+++ b/WoWPro_Recorder/WoWPro_Recorder.lua
@@ -570,8 +570,8 @@ function WoWPro.Recorder:CheckpointCurrentGuide(why)
     end
     local header = "local guide = WoWPro:RegisterGuide('"
         ..GID.."', '"
-        ..WoWPro.Guides[GID].guidetype.."', '"
-        ..WoWPro.Guides[GID].zone.."', '"
+        ..WoWPro.Guides[GID].guidetype.."', "
+        ..WoWPro.ConvertZone(WoWPro.Guides[GID].zone)..", '"
         ..WoWPro.Guides[GID].author.."', '"
         ..WoWPro.Guides[GID].faction.."')\n"
 		..'WoWPro:GuideName(guide,"'


### PR DESCRIPTION
This is baseline support for mapIDs in `RegisterGuide()` as well as switching recorder save output to mapIDs instead of zone names.