### PR TITLE
Recorder, Class, Race and _G fixes

### DIFF
--- a/WoWPro/WoWPro_Broker.lua
+++ b/WoWPro/WoWPro_Broker.lua
@@ -825,6 +825,19 @@ function WoWPro:RowUpdate(offset)
         local item = WoWPro.item[k]
         local completion = WoWProCharDB.Guide[GID].completion
 
+
+		 if coord then
+			if (coord == "PLAYER") then
+				local x, y = WoWPro:GetPlayerZonePosition()
+				if (x  and y) then
+					coord = ("%.2f"):format(x * 100) .. ',' .. ("%.2f"):format(y * 100)
+				else
+					coord = nil
+				end
+			else
+				WoWPro:ValidateMapCoords(GID,action,step,coord)
+			end
+		end
         -- Unstickying stickies --
         if unsticky and (not sticky) and i == WoWPro.ActiveStickyCount+1 then
             for n, row in ipairs(WoWPro.rows) do

--- a/WoWPro/WoWPro_Broker.lua
+++ b/WoWPro/WoWPro_Broker.lua
@@ -1295,7 +1295,11 @@ function WoWPro.UpdateGuideReal(From)
     WoWProCharDB.Guide[GID].total = WoWPro.stepcount - WoWPro.stickycount - WoWPro.optionalcount
 
     -- TODO: make next lines module specific
-    WoWPro.TitleText:SetText((WoWPro.Guides[GID].name or WoWPro.Guides[GID].zone).."   ("..WoWProCharDB.Guide[GID].progress.."/"..WoWProCharDB.Guide[GID].total..")")
+	if WoWPro.Recorder then
+		WoWPro.TitleText:SetText((GID or WoWPro.Guides[GID].zone).."   ("..WoWProCharDB.Guide[GID].progress.."/"..WoWProCharDB.Guide[GID].total..")")
+	else
+		WoWPro.TitleText:SetText((WoWPro.Guides[GID].name or WoWPro.Guides[GID].zone).."   ("..WoWProCharDB.Guide[GID].progress.."/"..WoWProCharDB.Guide[GID].total..")")
+	end
 
     -- If the guide is complete, loading the next guide --
     if (WoWProCharDB.Guide[GID].progress == WoWProCharDB.Guide[GID].total or WoWProCharDB.Guide[GID].done)
@@ -2219,7 +2223,7 @@ function WoWPro.NextStep(guideIndex, rowIndex)
             end
 			if WoWPro.playerclass and WoWPro.playerclass[guideIndex] then
 				local _, myclass = _G.UnitClass("player")
-				if WoWPro.playerclass[guideIndex] ~= myclass and (stepAction == "A" or stepAction == "T") then
+				if WoWPro.playerclass[guideIndex]:gsub(" ", ""):upper() ~= myclass and (stepAction == "A" or stepAction == "T") then
 					WoWPro.CompleteStep(guideIndex, "NextStep(): You are not playing a " .. WoWPro.playerclass[guideIndex] .. ".")
 					 skip = true
 				end
@@ -2227,7 +2231,7 @@ function WoWPro.NextStep(guideIndex, rowIndex)
 
 			if WoWPro.playerrace and WoWPro.playerrace[guideIndex] then
 				local _, myrace = _G.UnitRace("player")
-				if WoWPro.playerrace[guideIndex] ~= myrace and (stepAction == "A" or stepAction == "T") then
+				if WoWPro.playerrace[guideIndex]:gsub(" ", "") ~= myrace and (stepAction == "A" or stepAction == "T") then
 					WoWPro.CompleteStep(guideIndex, "NextStep(): You are not playing a " .. WoWPro.playerrace[guideIndex] .. ".")
 					 skip = true
 				end

--- a/WoWPro/WoWPro_Events.lua
+++ b/WoWPro/WoWPro_Events.lua
@@ -1,5 +1,5 @@
--- luacheck: globals tostring tonumber
--- luacheck: globals select ipairs next tinsert
+-- luacheck: globals tostring tonumber string
+-- luacheck: globals select foreach ipairs pairs next tinsert
 
 --------------------------
 --  WoWPro_Events.lua   --
@@ -668,12 +668,13 @@ end)
 WoWPro.RegisterEventHandler("CHAT_MSG_ADDON", function (event,...)
 	local _, prefix, text, _, sender = event, ...
 	if successfulRequest and prefix == "WoWPro" then
-		local synctype, message = _G.string.split(" ", text, 2)
-		local gname = _G.string.split("-", sender, 2)
+		local synctype, message = string.split(" ", text, 2)
+		local gname = string.split("-", sender, 2)
+		print(gname .. ": " .. message)
 		--WoWPro.playerGroup["Caylassa-Anasterian"]["track"][7]
 		if gname ~= _G.UnitName("Player") then
 			if synctype == "group" then
-				local gclass, grace, ggender, gstep = _G.string.split(" ", message, 4)
+				local gclass, grace, ggender, gstep = string.split(" ", message, 4)
 				if WoWPro.playerGroup[sender] == nil then
 					WoWPro.playerGroup[sender] = {
 						pname = gname,
@@ -687,16 +688,16 @@ WoWPro.RegisterEventHandler("CHAT_MSG_ADDON", function (event,...)
 				end
 			elseif synctype == "steps" then
 				if (WoWPro.playerGroup[sender] ~= nil) then
-					local tbl = {_G.string.split(" ", message)}
+					local tbl = {string.split(" ", message)}
 					WoWPro.playerGroup[sender]["step"] = {}
-					_G.foreach(tbl, function(k,v)
+					foreach(tbl, function(k,v)
 						if (v ~= "") then
 							WoWPro.playerGroup[sender]["step"][tonumber(v)] = true
 						end
 					end);
 					WoWPro.mygroupsteps = {}
-					for index,gvalue in _G.pairs(WoWPro.playerGroup) do
-						_G.foreach(gvalue["step"], function(gkey,gval)
+					for index,gvalue in pairs(WoWPro.playerGroup) do
+						foreach(gvalue["step"], function(gkey,gval)
 							WoWPro.mygroupsteps[tonumber(gkey)] = true
 						end);
 					end
@@ -706,11 +707,11 @@ WoWPro.RegisterEventHandler("CHAT_MSG_ADDON", function (event,...)
 				WoWPro:UpdateGuide(event)
 			elseif synctype == "track" then
 				if (WoWPro.playerGroup[sender] ~= nil) then
-					local gindex, gtrack = _G.string.split(" ", message, 2)
+					local gindex, gtrack = string.split(" ", message, 2)
 					WoWPro.playerGroup[sender]["track"][tonumber(gindex)] = gtrack
 					WoWPro.myGroupTrack = {}
-					for index,gvalue in _G.pairs(WoWPro.playerGroup) do
-						_G.foreach(gvalue["track"], function(gkey,gval)
+					for index,gvalue in pairs(WoWPro.playerGroup) do
+						foreach(gvalue["track"], function(gkey,gval)
 							WoWPro.myGroupTrack[tonumber(gkey)] = (WoWPro.myGroupTrack[tonumber(gkey)] or "") .. "\n" .. gval .. " - " .. gname
 						end);
 					end

--- a/WoWPro/WoWPro_Events.lua
+++ b/WoWPro/WoWPro_Events.lua
@@ -264,8 +264,8 @@ function WoWPro:AutoCompleteQuestUpdate(questComplete)
     for i=1,#WoWPro.action do
         local action = WoWPro.action[i]
         local completion = WoWProCharDB.Guide[GID].completion[i]
-		if WoWPro.mygroupsteps[i]  and (action == "C" or action == "K") then
-			return
+		if (WoWPro.mygroupsteps[i] and action == "C") then
+			--return
 		end
         if WoWPro.QID[i] then
             local numQIDs = select("#", ("^&"):split(WoWPro.QID[i]))
@@ -294,7 +294,11 @@ function WoWPro:AutoCompleteQuestUpdate(questComplete)
 
                 -- Quest AutoComplete --
                 if questComplete and (action == "A" or action == "C" or action == "T" or action == "N") and QID == questComplete then
-                    WoWPro.CompleteStep(i, "AutoCompleteQuestUpdate: AutoComplete")
+					if WoWPro.mygroupsteps[i] and action == "C" and not WoWPro.QID[i]:find("^",1,true) then
+						return
+					else
+						WoWPro.CompleteStep(i, "AutoCompleteQuestUpdate: AutoComplete")
+					end
                 end
                 -- Quest Accepts --
                 if WoWPro.newQuest == QID and action == "A" and not completion then
@@ -304,9 +308,13 @@ function WoWPro:AutoCompleteQuestUpdate(questComplete)
 
                 -- Quest Completion via QuestLog--
                 if WoWPro.QuestLog[QID] and action == "C" and not completion and WoWPro.QuestLog[QID].complete then
-                    WoWPro.CompleteStep(i, "AutoCompleteQuestUpdate: via QuestLog")
-                    WoWPro.oldQuests[QID] = WoWPro.oldQuests[QID] or {}
-                    WoWPro.oldQuests[QID].complete = true -- We got it, dont let the recorder get it!
+					if WoWPro.mygroupsteps[i] and action == "C" and not WoWPro.QID[i]:find("^",1,true) then
+						return
+					else
+						WoWPro.CompleteStep(i, "AutoCompleteQuestUpdate: via QuestLog")
+						WoWPro.oldQuests[QID] = WoWPro.oldQuests[QID] or {}
+						WoWPro.oldQuests[QID].complete = true -- We got it, dont let the recorder get it!
+					end
                 end
 
                 -- Partial Completion --

--- a/WoWPro/WoWPro_Events.lua
+++ b/WoWPro/WoWPro_Events.lua
@@ -264,9 +264,6 @@ function WoWPro:AutoCompleteQuestUpdate(questComplete)
     for i=1,#WoWPro.action do
         local action = WoWPro.action[i]
         local completion = WoWProCharDB.Guide[GID].completion[i]
-		if (WoWPro.mygroupsteps[i] and action == "C") then
-			--return
-		end
         if WoWPro.QID[i] then
             local numQIDs = select("#", ("^&"):split(WoWPro.QID[i]))
             for j=1,numQIDs do

--- a/WoWPro/WoWPro_Events.lua
+++ b/WoWPro/WoWPro_Events.lua
@@ -670,7 +670,6 @@ WoWPro.RegisterEventHandler("CHAT_MSG_ADDON", function (event,...)
 	if successfulRequest and prefix == "WoWPro" then
 		local synctype, message = string.split(" ", text, 2)
 		local gname = string.split("-", sender, 2)
-		print(gname .. ": " .. message)
 		--WoWPro.playerGroup["Caylassa-Anasterian"]["track"][7]
 		if gname ~= _G.UnitName("Player") then
 			if synctype == "group" then

--- a/WoWPro/WoWPro_Events.lua
+++ b/WoWPro/WoWPro_Events.lua
@@ -265,7 +265,7 @@ function WoWPro:AutoCompleteQuestUpdate(questComplete)
         local action = WoWPro.action[i]
         local completion = WoWProCharDB.Guide[GID].completion[i]
 		if WoWPro.mygroupsteps[i]  and (action == "C" or action == "K") then
-			break
+			return
 		end
         if WoWPro.QID[i] then
             local numQIDs = select("#", ("^&"):split(WoWPro.QID[i]))

--- a/WoWPro/WoWPro_Mapping.lua
+++ b/WoWPro/WoWPro_Mapping.lua
@@ -448,17 +448,17 @@ function WoWPro:MapPoint(row)
         coords = nil
     end
 	if coords then
-			if (coords == "PLAYER") then
-				local x, y = WoWPro:GetPlayerZonePosition()
-				if (x  and y) then
-					coords = ("%.2f"):format(x * 100) .. ',' .. ("%.2f"):format(y * 100)
-				else
-					coords = nil
-				end
+		if (coords == "PLAYER") then
+			local x, y = WoWPro:GetPlayerZonePosition()
+			if (x  and y) then
+				coords = ("%.2f"):format(x * 100) .. ',' .. ("%.2f"):format(y * 100)
 			else
-				WoWPro:ValidateMapCoords(GID,WoWPro.action[stepIndex],stepIndex,coords)
+				coords = nil
 			end
+		else
+			WoWPro:ValidateMapCoords(GID,WoWPro.action[stepIndex],stepIndex,coords)
 		end
+	end
 
     local desc = WoWPro.step[stepIndex]
     local zone

--- a/WoWPro/WoWPro_Mapping.lua
+++ b/WoWPro/WoWPro_Mapping.lua
@@ -447,6 +447,19 @@ function WoWPro:MapPoint(row)
     else
         coords = nil
     end
+	if coords then
+			if (coords == "PLAYER") then
+				local x, y = WoWPro:GetPlayerZonePosition()
+				if (x  and y) then
+					coords = ("%.2f"):format(x * 100) .. ',' .. ("%.2f"):format(y * 100)
+				else
+					coords = nil
+				end
+			else
+				WoWPro:ValidateMapCoords(GID,WoWPro.action[stepIndex],stepIndex,coords)
+			end
+		end
+
     local desc = WoWPro.step[stepIndex]
     local zone
     zone = WoWPro.zone[stepIndex] or WoWPro.Guides[GID].zone:match("([^%(]+)"):trim()
@@ -695,4 +708,3 @@ function WoWPro:LogLocation()
         WoWPro:print("Player [%.2f,%.2f@%d] WPZone=%q, Zone=%q, SubZone=%q", x*100 , y*100, mapId, WoWPro.GetZoneText(), _G.GetZoneText(), _G.GetSubZoneText() )
     end
 end
-

--- a/WoWPro/WoWPro_Parser.lua
+++ b/WoWPro/WoWPro_Parser.lua
@@ -536,18 +536,6 @@ function WoWPro.ParseQuestLine(faction, zone, i, text)
     if WoWPro.action[i] == "h" then
         WoWPro.step[i] = L[WoWPro.step[i]]
     end
-    if WoWPro.map[i] then
-        if (WoWPro.map[i] == "PLAYER") then
-            local x, y = WoWPro:GetPlayerZonePosition()
-            if (x  and y) then
-                WoWPro.map[i]= ("%.2f"):format(x * 100) .. ',' .. ("%.2f"):format(y * 100)
-            else
-                WoWPro.map[i]= nil
-            end
-        else
-            WoWPro:ValidateMapCoords(GID,WoWPro.action[i],WoWPro.step[i],WoWPro.map[i])
-        end
-    end
     WoWPro.zone[i] = WoWPro.zone[i] or (WoWPro.map[i] and zone)
     if WoWPro.zone[i] and WoWPro.map[i] and not WoWPro:ValidZone(WoWPro.zone[i]) then
         WoWPro:Error("Step %s [%s] has a bad ¦Z¦%s¦ tag.",WoWPro.action[i],WoWPro.step[i],WoWPro.zone[i])

--- a/WoWPro_Recorder/WoWPro_Recorder_Frames.lua
+++ b/WoWPro_Recorder/WoWPro_Recorder_Frames.lua
@@ -133,7 +133,7 @@ local function CreateInitSpecMenu(module)
 					WoWPro.Recorder.CurrentGuide["Zone"] = "Orgrimmar"
 					WoWPro.Recorder.CurrentGuide["Faction"] = "Horde"
 				else
-					WoWPro.Recorder.CurrentGuide["Zone"] = "Stormwind"
+					WoWPro.Recorder.CurrentGuide["Zone"] = "Stormwind City"
 					WoWPro.Recorder.CurrentGuide["Faction"] = "Alliance"
 				end
 				WoWPro.Recorder.CurrentGuide["Author"] = "Tester"


### PR DESCRIPTION
The issue with new alliance guides that caused an error on reload

Title will now show the guide name instead of Stormwind or Orgrimmar in recorder.

Fixed the case issue in race and class comparison logic.

Removed the _G. from native lua functions and put them up on the ignore list at the top of the file Gethe pointed out to me.