### PR TITLE
Venthyr Complete, Chromie time, renown

### DIFF
--- a/Notes.md
+++ b/Notes.md
@@ -6,7 +6,7 @@
 * Hearthstones - We now support all the different hearthstones for the Hearth steps, no longer need to keep the default HS if you don't want to.
 * Extra Action Button - We can now attach the Extra Action Button to the WoWPro frame. (Requires guides to be updated to use this new EAB tag).
 * SuperTrack - Take advantage of the UI's new SuperTrack Waypoint markers introduced in 9.0, it will always mirror WoWPro's active step.
-* Guide Hubs - With Chromie Time and Level squish we put control into the users hands with guide hubs to help you jump between guides at your discretion. (For Guide Authors, new JUMP tag)
+* Guide Hubs - With Chromie Time and Level squish we put control into the users hands with guide hubs to help you jump between guides at your discretion. Also specific for chromie time, if you have her UI open and make the selection in the guide, it will make your choice for her as well. (For Guide Authors, new JUMP tag)
 * Themes - Added pre-made profile themes in settings->WoW-Profiles->Existing Profiles, these profiles are locked and you will need to Copy it to make your own alterations.
 * Reporting – Now reporting a bad step is easier by simply right clicking the step and selecting _“Report Issue”_ Copy and paste the message directly into discord with your explanation of the problem. It will also give us your current location so if you report while standing in the right spot, we will have the info to fix it ASAP.
 * Improved Guide List – With level squish and scaling the list was a mess with everything being basically the same level ranges, guide list was reworked and now sorted by Expansion.
@@ -17,7 +17,13 @@
 * New Recorder Features - Recorder updated to detect CHAT, NC and kill objectives, fixed punctuation issues and added buttons to easily create R, F and P steps.
 * Devcoords - _/wp devcoords_ to give guide writers an easy way to copy and paste coords from game to guide.
 * Date tag -  For Guide Authors, ability to time gate a step from showing based on Server epoch time (for events and known time gated content).
-
+* MID tag - For mission ID detection (garrison/follower missions)
+* Expansion specifc tags
+	+ CT: Eligible for Chromie time
+	+ MS: Chose Main Story Leveling
+	+ TOF: Chose Threads of Fate Alt leveling experienced
+	+ COV: Chosen Covenant Name
+	+ REN: Renown level detection
 ### Fixes
 * Fixed issue with flight detection, BFA and WOD were broken, now detected, also with artisan riding removed adjustments had to be made to the detection code regardless.
 * Fixed bug in PLAYER coordinates that caused it to use a previous steps coordinates sometimes.

--- a/WoWPro/WoWPro_Broker.lua
+++ b/WoWPro/WoWPro_Broker.lua
@@ -1165,10 +1165,13 @@ function WoWPro:RowUpdate(offset)
 
 		--Guide Jump Button
 		if WoWPro.jump[k] then
-			local newguide = WoWPro.jump[k]
+			local newguide, ctID = (";"):split(WoWPro.jump[k])
 			currentRow.jumpbutton:Show()
 			currentRow.jumpbutton:SetScript("OnClick", function()
 				WoWPro:dbp("WoWPro.CompleteStep: jumping from %s to %s.",WoWProDB.char.currentguide, newguide)
+				if ctID then
+					C_ChromieTime.SelectChromieTimeOption(ctID)
+				end
 				WoWPro:LoadGuide(newguide)
 			end)
 			  if not jumpkb and currentRow.targetbutton:IsVisible() and not _G.InCombatLockdown() then
@@ -2415,11 +2418,40 @@ function WoWPro.NextStep(guideIndex, rowIndex)
 				end
 			end
 
+            if WoWPro.renown and WoWPro.renown[guideIndex] then
+				local renownID = WoWPro.renown[guideIndex]
+				local renownFlip
+                local renownMatch
+                local renown = _G.C_CovenantSanctumUI.GetRenownLevel()
+				if (renownID:sub(1, 1) == "-") then
+                    renownID = renownID:sub(2)
+                    renownFlip = true
+                end
+                if tonumber(renownID) >= renown then
+                    renownMatch = true
+                end
+                if renownFlip then
+                    renownMatch = not renownMatch
+                end
+                if renownMatch then
+                    if not renownFlip then
+                        WoWPro.CompleteStep(guideIndex, "NextStep(): Renown Level ["..renown.."] is less than "..renownID..".")
+                    end
+                    skip = true
+                else
+                    WoWPro.why[guideIndex] = "NextStep(): Renown Level ["..renownID.."] not met."
+                end
+            end
+
             if WoWPro.ilvl and WoWPro.ilvl[guideIndex] then
-                local ilvlID,ilvlFlip = (";"):split(WoWPro.ilvl[guideIndex])
-                local avgIlvl = _G.GetAverageItemLevel()
+				local ilvlID = WoWPro.ilvl[guideIndex]
+				local ilvlFlip
                 local ilvlMatch
-                ilvlFlip = WoWPro.toboolean(ilvlFlip)
+                local avgIlvl = _G.GetAverageItemLevel()
+				if (ilvlID:sub(1, 1) == "-") then
+                    ilvlID = ilvlID:sub(2)
+                    ilvlFlip = true
+                end
                 if tonumber(ilvlID) >= avgIlvl then
                     ilvlMatch = true
                 end

--- a/WoWPro/WoWPro_Broker.lua
+++ b/WoWPro/WoWPro_Broker.lua
@@ -1170,7 +1170,7 @@ function WoWPro:RowUpdate(offset)
 			currentRow.jumpbutton:SetScript("OnClick", function()
 				WoWPro:dbp("WoWPro.CompleteStep: jumping from %s to %s.",WoWProDB.char.currentguide, newguide)
 				if ctID then
-					C_ChromieTime.SelectChromieTimeOption(ctID)
+					_G.C_ChromieTime.SelectChromieTimeOption(ctID)
 				end
 				WoWPro:LoadGuide(newguide)
 			end)

--- a/WoWPro/WoWPro_Events.lua
+++ b/WoWPro/WoWPro_Events.lua
@@ -670,7 +670,7 @@ WoWPro.RegisterEventHandler("GROUP_ROSTER_UPDATE", function(event, ...)
 	end
 end)
 
-WoWPro.RegisterEventHandler("NEW_WMO_CHUNK", function(event, ...)
+WoWPro.RegisterEventHandler("AREA_POIS_UPDATED", function(event, ...)
 	if successfulRequest then
 		WoWPro:UpdateGuide(event)
 	end

--- a/WoWPro/WoWPro_Parser.lua
+++ b/WoWPro/WoWPro_Parser.lua
@@ -272,47 +272,51 @@ DefineTag("L","lootitem","string",nil,function(text,i)
 end)
 DefineTag("QO","questtext","string",nil,nil)
 DefineTag("SO","sobjective","string",nil,nil)
-DefineTag("U","use","number",nil,nil)
-DefineTag("ITEM","item","string",nil,nil)
+
+DefineTag("CHAT","chat","boolean",nil,nil)
 DefineTag("EAB","eab","boolean",nil,nil)
+DefineTag("ELITE", "elite","boolean",nil,nil)
+DefineTag("ITEM","item","string",nil,nil)
 DefineTag("NC","noncombat","boolean",nil,nil)
 DefineTag("NA","noauto","boolean",nil,nil)
-DefineTag("CHAT","chat","boolean",nil,nil)
-DefineTag("V","vehichle","boolean",nil,nil) -- Yeah, that is how blizzard spelled it!
-DefineTag("LVL","level","string",validate_old_list_of_ints,nil)
-DefineTag("T","target","string",nil,nil)
-DefineTag("QG","gossip","string",nil, function (value,i) WoWPro.gossip[i] = value:upper() end)
 DefineTag("NOCACHE", "nocache","boolean",nil,nil)
-DefineTag("ELITE", "elite","boolean",nil,nil)
+DefineTag("QG","gossip","string",nil, function (value,i) WoWPro.gossip[i] = value:upper() end)
+DefineTag("RARE","rare","boolean",nil,nil)
+DefineTag("T","target","string",nil,nil)
+DefineTag("U","use","number",nil,nil)
+DefineTag("V","vehichle","boolean",nil,nil) -- Yeah, that is how blizzard spelled it!
 
 -- Conditionals
-DefineTag("REP","rep","string",nil,nil)
-DefineTag("P","prof","string",nil,nil)
-DefineTag("DATE", "serverdate","string",nil,nil)
-DefineTag("SPELL","spell","string",nil,nil)
-DefineTag("ILVL","ilvl","string",nil,nil)
-DefineTag("FLY","fly","string",nil,nil)
 DefineTag("ACH","ach","string",nil,nil)
 DefineTag("BUFF","buff","string",validate_andor_list_of_ints,nil)
-DefineTag("RECIPE","recipe","number",nil,nil)
-DefineTag("PET","pet","string",nil,nil)
 DefineTag("BUILDING","building","string",nil,nil)
-DefineTag("GUIDE","guide","string",nil,nil)
-DefineTag("JUMP","jump","string",nil,nil)
-DefineTag("GROUP","group","number",nil,nil)
-DefineTag("RARE","rare","boolean",nil,nil)
+DefineTag("COV","covenant","string",nil,nil)
+DefineTag("DATE", "serverdate","string",nil,nil)
 DefineTag("EX","expansion","string",validate_old_list_of_ints,nil)
-DefineTag("TAXI","taxi","string",nil,nil)
 DefineTag("FAIL","fail","boolean",nil,nil)
+DefineTag("FLY","fly","string",nil,nil)
+DefineTag("GROUP","group","number",nil,nil)
+DefineTag("GUIDE","guide","string",nil,nil)
+DefineTag("ILVL","ilvl","string",nil,nil)
+DefineTag("JUMP","jump","string",nil,nil)
+DefineTag("LVL","level","string",validate_old_list_of_ints,nil)
+DefineTag("P","prof","string",nil,nil)
+DefineTag("PET","pet","string",nil,nil)
+DefineTag("REN","renown","string",nil,nil)
+DefineTag("REP","rep","string",nil,nil)
+DefineTag("RECIPE","recipe","number",nil,nil)
+DefineTag("SPELL","spell","string",nil,nil)
+DefineTag("TAXI","taxi","string",nil,nil)
 
 -- Pet Stuff
+DefineTag("DEAD","dead","string",nil,nil)
 DefineTag("PET1","pet1","string",nil,nil)
 DefineTag("PET2","pet2","string",nil,nil)
 DefineTag("PET3","pet3","string",nil,nil)
-DefineTag("STRATEGY","strategy","string",nil,nil)
 DefineTag("SELECT","select","number",nil,nil)
+DefineTag("STRATEGY","strategy","string",nil,nil)
 DefineTag("SWITCH","switch","number",nil,nil)
-DefineTag("DEAD","dead","string",nil,nil)
+
 
 
 -- Stuff at the end
@@ -326,16 +330,16 @@ DefineTag("S!US",nil,"boolean",nil, function (value,i)
     WoWPro.unsticky[i] = true;
     WoWPro.stickycount = WoWPro.stickycount + 1;
 end)
-DefineTag("N","note","string",nil,nil)
-DefineTag("FACTION","faction","string",nil,nil)
-DefineTag("R","playerrace","string",nil,nil)
 DefineTag("C","playerclass","string",nil,nil)
-DefineTag("GEN","playergender","string",nil,nil)
-DefineTag("RANK","rank","number",nil,nil)
-DefineTag("COV","covenant","string",nil,nil)
-DefineTag("MS",nil,"boolean",nil,function (value,i) end)  -- Swallow MS Tags
-DefineTag("TOF",nil,"boolean",nil,function (value,i) end)  -- Swallow MS Tags
 DefineTag("CT","chromie","boolean",nil,nil)
+DefineTag("FACTION","faction","string",nil,nil)
+DefineTag("GEN","playergender","string",nil,nil)
+DefineTag("MS",nil,"boolean",nil,function (value,i) end)  -- Swallow MS Tags
+DefineTag("N","note","string",nil,nil)
+DefineTag("R","playerrace","string",nil,nil)
+DefineTag("RANK","rank","number",nil,nil)
+DefineTag("TOF",nil,"boolean",nil,function (value,i) end)  -- Swallow MS Tags
+
 
 local function addTagValue(line, tag, value)
     line = line..tag.."||"

--- a/WoWPro_Leveling/Alliance/INTRO_Chromie_Time.lua
+++ b/WoWPro_Leveling/Alliance/INTRO_Chromie_Time.lua
@@ -9,16 +9,20 @@ return [[
 P Stormwind City|QID|62567|M|55.03,93.72|Z|Teldrassil|N|If you're near Teldrassil, Take the Portal to Stormwind City at the Rut'theran Village dock. Or otherwise make your way to Stormwind.|R|NightElf,Worgen,Draenai|C|-DemonHunter,-DeathKnight|CT|
 A Adventurers Wanted: Chromie's Call|QID|62567|M|62.25,29.93|N|Make your way to the nearest Hero's Call Board and accept Chromie's Call. Onward to Adventure!|CT|
 T Adventurers Wanted: Chromie's Call|QID|62567|M|56.26,17.32|N|To Chromie near the Stormwind Embassy.|CT|
-N Choose The Cataclysm|QID|99999|M|56.26,17.31|JUMP|Cataclysm: Guide Hub|S|N|If you selected to goto the Cataclysm timeline, Vanilla is rolled into this.\n\nVanilla zones are level 10-30 and Cataclysm zones are 30-50.|CT|
-N Choose Burning Crusade|QID|99999|M|56.26,17.31|JUMP|Hellfire Peninsula|S|N|If you selected to goto the Burning Crusade timeline.|CT|
-N Choose Wrath of the Lich King|QID|99999|M|56.26,17.31|JUMP|WOTLK: Intro|S|N|If you selected to goto the Wrath of the Lich King timeline.|CT|
-N Choose Mists of Pandaria|QID|99999|M|56.26,17.31|JUMP|Jade Forest|S|N|If you selected to goto the Mists of Pandaria timeline.|CT|
-N Choose Warlords of Draenor|QID|99999|M|56.26,17.31|JUMP|WOD: Dark Portal Intro|S|N|If you selected to goto the Warlords of Draenor timeline.|CT|
-N Choose Legion|QID|99999|M|56.26,17.31|JUMP|Legion: Intro|S|N|If you selected to goto the Legion timeline.|C|-DemonHunter|CT|
-N Choose Legion|QID|99999|M|56.26,17.31|JUMP|Demon Hunter: Order Hall|S|N|If you selected to goto the Legion timeline.|C|DemonHunter|CT|
-N Remain in Battle for Azeroth|QID|99999|M|56.26,17.31|JUMP|Battle for Azeroth: Intro|S|N|If you decided to stay in the current timeline.|CT|
-N Make your choice|QID|99999|M|56.26,17.31|N|Speak with Chromie to transport you back in time to level up during any expansion period.\n\nIf you want to level in BFA content, that is the current timeline and speaking with chromie is not necessary.\n\nOnce you make your choice you can click on the guide button next to the title of your chosen expansion.|CT|
+
+N Choose The Cataclysm|QID|99999|M|56.26,17.31|JUMP|Cataclysm: Guide Hub;5|S|N|If you selected to goto the Cataclysm timeline, Vanilla is rolled into this.\n\nVanilla zones are level 10-30 and Cataclysm zones are 30-50.|CT|NOCACHE|
+N Choose Burning Crusade|QID|99999|M|56.26,17.31|JUMP|Hellfire Peninsula;6|S|N|If you selected to goto the Burning Crusade timeline.|CT|NOCACHE|
+N Choose Wrath of the Lich King|QID|99999|M|56.26,17.31|JUMP|WOTLK: Intro;7|S|N|If you selected to goto the Wrath of the Lich King timeline.|CT|NOCACHE|
+N Choose Mists of Pandaria|QID|99999|M|56.26,17.31|JUMP|Jade Forest;8|S|N|If you selected to goto the Mists of Pandaria timeline.|CT|NOCACHE|
+N Choose Warlords of Draenor|QID|99999|M|56.26,17.31|JUMP|WOD: Dark Portal Intro;9|S|N|If you selected to goto the Warlords of Draenor timeline.|CT|NOCACHE|
+N Choose Legion|QID|99999|M|56.26,17.31|JUMP|Legion: Intro;10|S|N|If you selected to goto the Legion timeline.|C|-DemonHunter|CT|NOCACHE|
+N Choose Legion|QID|99999|M|56.26,17.31|JUMP|Demon Hunter: Order Hall;10|S|N|If you selected to goto the Legion timeline.|C|DemonHunter|CT|NOCACHE|
+N Remain in Battle for Azeroth|QID|99999|M|56.26,17.31|JUMP|Battle for Azeroth: Intro|S|N|If you decided to stay in the current timeline.|CT|NOCACHE|
+
+N Make your choice|QID|99999|M|56.26,17.31|N|Speak with Chromie to transport you back in time to level up during any expansion period.\n\nIf you want to level in BFA content, that is the current timeline and speaking with chromie is not necessary.\n\nOnce Chromies UI is open, clicking the expansion button above will automaticallty make your selection with chromie as well.|CT|NOCACHE|
+
 N Not Eligible|AVAILABLE|62567|M|62.25,29.93|N|You need to have leveled a character to level 50 before you are eligible to use Chromie.|
+
 ;A Onward to Adventure: Eastern Kingdoms|QID|60891|M|56.26,17.31|N|From Chromie after activating The Cataclysm timeline.|
 ;A To Outland!|QID|60120|M|56.26,17.31|N|From Chromie. Burning Crusade.|
 ;A To Northrend!|QID|60096|M|56.26,17.31|N|From Chromie. Wrath of the Lich King.|
@@ -27,9 +31,5 @@ N Not Eligible|AVAILABLE|62567|M|62.25,29.93|N|You need to have leveled a charac
 ;A The Legion Returns|QID|40519|M|56.26,17.31|N|From Chromie after activating Legion timeline.|C|-DemonHunter|
 ;A Onward to Adventure: Broken Isles|QID|60971|M|56.26,17.31|N|From Chromie after activating Legion timeline.|C|DemonHunter|
 ;A Tides of War|QID|46727|M|62.82,71.75|N|From Hero's Herald. Battle for Azeroth|
-
-;N It's Chromie Time!|QID|62567|M|62.25,29.93|Z|Stormwind City|JUMP|Chromie Time|LVL|10|S!US|N|Congratulations on hitting level 10.\n\nYou can now accept Chromies call at the Hero's Call board in Stormwind. This will allow you to choose which expansion you want to level in.\n\nYou're free to continue your current guide or you click the guide button next to this frame to direct you to Chromie!|
 ]]
 end)
-
-

--- a/WoWPro_Leveling/Horde/INTRO_Chromie_Time.lua
+++ b/WoWPro_Leveling/Horde/INTRO_Chromie_Time.lua
@@ -7,19 +7,21 @@ WoWPro:GuideName(guide,"Chromie Time")
 WoWPro:GuideSteps(guide, function()
 return [[
 
-A Adventurers Wanted: Chromie's Call|QID|62568|M|49.66,76.46|N|Make your way to the nearest  Warchief's Command Board and accept Chromie's Call. Onward to Adventure!|
-T Adventurers Wanted: Chromie's Call|QID|62568|M|40.82,80.13|N|To Chromie near the Orgrimmar Embassy.|
+A Adventurers Wanted: Chromie's Call|QID|62568|M|49.66,76.46|N|Make your way to the nearest  Warchief's Command Board and accept Chromie's Call. Onward to Adventure!|CT|
+T Adventurers Wanted: Chromie's Call|QID|62568|M|40.82,80.13|N|To Chromie near the Orgrimmar Embassy.|CT|
 
+N Choose The Cataclysm|QID|60887|M|40.82,80.13|JUMP|Cataclysm: Guide Hub;5|S|N|If you selected to goto the Cataclysm timeline, Vanilla is rolled into this.\n\nVanilla zones are level 10-30 and Cataclysm zones are 30-50.|CT|NOCACHE|
+N Choose Burning Crusade|QID|60123|M|40.82,80.13|JUMP|Hellfire Peninsula;6|S|N|If you selected to goto the Burning Crusade timeline.|CT|NOCACHE|
+N Choose Wrath of the Lich King|QID|60097|M|40.82,80.13|JUMP|WOTLK: Intro;7|S|N|If you selected to goto the Wrath of the Lich King timeline.|CT|NOCACHE|
+N Choose Mists of Pandaria|QID|60126|M|40.82,80.13|JUMP|Jade Forest;8|S|N|If you selected to goto the Mists of Pandaria timeline.|CT|NOCACHE|
+N Choose Warlords of Draenor|QID|34398|M|40.82,80.13|JUMP|WOD: Dark Portal Intro;9|S|N|If you selected to goto the Warlords of Draenor timeline.|CT|NOCACHE|
+N Choose Legion|QID|40519|M|40.82,80.13|JUMP|Legion: Intro;10|S|N|If you selected to goto the Legion timeline.|C|-DemonHunter|CT|NOCACHE|
+N Choose Legion|QID|60970|M|40.82,80.13|JUMP|Demon Hunter: Order Hall;10|S|N|If you selected to goto the Legion timeline.|C|DemonHunter|CT|NOCACHE|
+N Remain in Battle for Azeroth|QID|51443|M|40.82,80.13|JUMP|Battle for Azeroth: Intro|S|N|If you decided to stay in the current timeline.|CT|NOCACHE|
 
-N Choose The Cataclysm|QID|60887|M|40.82,80.13|JUMP|Cataclysm: Guide Hub|S|N|If you selected to goto the Cataclysm timeline, Vanilla is rolled into this.\n\nVanilla zones are level 10-30 and Cataclysm zones are 30-50.|
-N Choose Burning Crusade|QID|60123|M|40.82,80.13|JUMP|Hellfire Peninsula|S|N|If you selected to goto the Burning Crusade timeline.|
-N Choose Wrath of the Lich King|QID|60097|M|40.82,80.13|JUMP|WOTLK: Intro|S|N|If you selected to goto the Wrath of the Lich King timeline.|
-N Choose Mists of Pandaria|QID|60126|M|40.82,80.13|JUMP|Jade Forest|S|N|If you selected to goto the Mists of Pandaria timeline.|
-N Choose Warlords of Draenor|QID|34398|M|40.82,80.13|JUMP|WOD: Dark Portal Intro|S|N|If you selected to goto the Warlords of Draenor timeline.|
-N Choose Legion|QID|40519|M|40.82,80.13|JUMP|Legion: Intro|S|N|If you selected to goto the Legion timeline.|C|-DemonHunter|
-N Choose Legion|QID|60970|M|40.82,80.13|JUMP|Demon Hunter: Order Hall|S|N|If you selected to goto the Legion timeline.|C|DemonHunter|
-N Remain in Battle for Azeroth|QID|51443|M|40.82,80.13|JUMP|Battle for Azeroth: Intro|S|N|If you decided to stay in the current timeline.|
-N Make your choice|QID|99999|M|40.82,80.13|N|Speak with Chromie to transport you back in time to level up during any expansion period.\n\nIf you want to level in BFA content, that is the current timeline and speaking with chromie is not necessary.\n\nOnce you make your choice you can click on the guide button next to the title of your chosen expansion.|
+N Make your choice|QID|99999|M|40.82,80.13|N|Speak with Chromie to transport you back in time to level up during any expansion period.\n\nIf you want to level in BFA content, that is the current timeline and speaking with chromie is not necessary.\n\nOnce Chromies UI is open, clicking the expansion button above will automaticallty make your selection with chromie as well.|CT|NOCACHE|
+
+N Not Eligible|AVAILABLE|62568|M|62.25,29.93|N|You need to have leveled a character to level 50 before you are eligible to use Chromie.|
 
 ;A Onward to Adventure: Kalimdor|QID|60887|M|40.82,80.15|N|From Chromie after activating Cataclysm timeline.|
 ;A To Outland!|QID|60123|M|40.82,80.15|N|From Chromie after activating Burning Crusade timeline.|
@@ -29,12 +31,5 @@ N Make your choice|QID|99999|M|40.82,80.13|N|Speak with Chromie to transport you
 ;A The Legion Returns|QID|43926|M|40.82,80.11|Z|Orgrimmar|N|From Chromie after activating Legion timeline.|C|-DemonHunter|
 ;A Onward to Adventure: Broken Isles|QID|60970|M|40.82,80.15|N|From Chromie after activating Legion timeline.|C|DemonHunter|
 ;A Mission Statement|QID|51443|M|49.40,76.58|N|From Warchief's Herald next to the Warchief's Command Board.|
-
-
-;N It's Chromie Time!|QID|62568|M|40.82,80.13|Z|Orgrimmar|JUMP|Chromie Time|LVL|10|S!US|N|Congratulations on hitting level 10.\n\nYou can now accept Chromies call at the Warchief's Command Board in Orgrimmar. This will allow you to choose which expansion you want to level in.\n\nYou're free to continue your current guide or you click the guide button next to this frame to direct you to Chromie!|
-
-;N It's Chromie Time!|QID|62568|M|40.82,80.13|Z|Orgrimmar|JUMP|Chromie Time|LVL|10|N|You can now accept Chromies call at the Warchief's Command Board in Orgrimmar. This will allow you to choose which expansion you want to level in.\n\nClick the guide button next to this frame to direct you to Chromie!|
 ]]
 end)
-
-

--- a/WoWPro_Leveling/Neutral/SL_Revendreth.lua
+++ b/WoWPro_Leveling/Neutral/SL_Revendreth.lua
@@ -410,11 +410,11 @@ T Hunting an Inquisitor|QID|57929|M|72.98,51.98|Z|Revendreth|N|To Archivist Fane
 A Halls of Atonement: Your Absolution|QID|58092|M|72.98,51.98|Z|Revendreth|ELITE|N|[color=e6cc80]Dungeon: [/color]\nFrom Archivist Fane. This quest is optional and out of scope for this guide.|LVL|57|PRE|57929|RANK|2|
 
 ; Sidequest Storyline - Mirror Maker of the Master
-t A Master of Their Craft|QID|60051|M|26.41,49.01|Z|Revendreth|N|To Laurent.|RANK|2|
-A An Unfortunate Situation|QID|57531|M|26.41,49.01|Z|Revendreth|N|From Laurent.|LVL|58|RANK|2|
-C An Unfortunate Situation|QID|57531|M|29.48,48.67|Z|Revendreth|N|Kill the 3 named enemies in the hideout, loot them to collect Laurent's Belongings.|RANK|2|
-T An Unfortunate Situation|QID|57531|M|26.41,49.01|Z|Revendreth|N|To Laurent.|RANK|2|
-A Foraging for Fragments|QID|57532|M|26.41,49.01|Z|Revendreth|N|From Laurent.|LVL|58|PRE|57531|RANK|2|
+t A Master of Their Craft|QID|60051|M|26.43,48.95|Z|Revendreth|N|To Laurent.|RANK|2|
+A An Unfortunate Situation|QID|57531|M|26.43,48.95|Z|Revendreth|N|From Laurent.|LVL|58|RANK|2|
+C An Unfortunate Situation|QID|57531|M|29.81,48.63|Z|Revendreth|N|Kill the Costel and his 2 friends in the hideout, loot him to collect Laurent's Belongings.|RANK|2|
+T An Unfortunate Situation|QID|57531|M|26.43,48.95|Z|Revendreth|N|To Laurent.|RANK|2|
+A Foraging for Fragments|QID|57532|M|26.43,48.95|Z|Revendreth|N|From Laurent.|LVL|58|PRE|57531|RANK|2|
 C Foraging for Fragments|QID|57532|M|25.71,48.54|Z|Revendreth|QO|1|N|Follow Laurent and defend him against attackers.|RANK|2|
 C Foraging for Fragments|QID|57532|M|25.71,48.54|Z|Revendreth|QO|2|NC|N|Click on the Mirror Fragment laying on the ground.|RANK|2|
 C Foraging for Fragments|QID|57532|M|25.53,47.37|Z|Revendreth|QO|3|N|Follow Laurent and defend him against attackers.|RANK|2|
@@ -434,16 +434,16 @@ T When Only Ash Remains|QID|57534|M|24.26,49.40|Z|Revendreth|N|To Laurent.|RANK|
 T Light Punishment|QID|57533|M|24.19,49.46|Z|Revendreth|N|To Simone.|RANK|2|
 A We Need More Power|QID|59427|M|24.19,49.46|Z|Revendreth|N|From Simone.|LVL|58|PRE|57533&57534|RANK|2|
 A Escaping the Master|QID|57535|M|24.26,49.40|Z|Revendreth|N|From Laurent.|LVL|58|PRE|57533&57534|RANK|2|
-C We Need More Power|QID|59427|M|21.71,55.15|Z|Revendreth|N|Kill enemies and interact with objects to collect the Anima.|RANK|2|S|
-C Escaping the Master|QID|57535|M|25.24,52.81|Z|Revendreth|N|Mirror Fragment.|RANK|2|
-C We Need More Power|QID|59427|M|21.71,55.15|Z|Revendreth|N|Kill enemies and interact with objects to collect the Anima.|RANK|2|US|
+C We Need More Power|QID|59427|M|24.79,53.51|Z|Revendreth|N|Click on Anima canisters laying around the area.|RANK|2|S|
+C Escaping the Master|QID|57535|M|24.79,53.51|Z|Revendreth|N|Kill enemies and loot their Mirror Fragments.|RANK|2|
+C We Need More Power|QID|59427|M|24.79,53.51|Z|Revendreth|N|Click on Anima canisters laying around the area.|RANK|2|US|
 T We Need More Power|QID|59427|M|24.19,49.46|Z|Revendreth|N|To Simone.|RANK|2|
 T Escaping the Master|QID|57535|M|24.26,49.40|Z|Revendreth|N|To Laurent.|RANK|2|
 A Mirror Making, Not Breaking|QID|57536|M|24.26,49.40|Z|Revendreth|N|From Laurent.|LVL|58|PRE|59427&57535|RANK|2|
-C Mirror Making, Not Breaking|QID|57536|M|24.76,50.28|Z|Revendreth|QO|1|NC|N|Follow Laurent and Simone to the mirror.|RANK|2|
-C Mirror Making, Not Breaking|QID|57536|M|24.76,50.28|Z|Revendreth|QO|2|CHAT|N|Speak to Laurent to let him begin.|RANK|2|
-C Mirror Making, Not Breaking|QID|57536|M|24.76,50.28|Z|Revendreth|QO|3|N|Kill waves of enemies, defending Laurent and Simone.|RANK|2|
-T Mirror Making, Not Breaking|QID|57536|M|24.26,49.40|Z|Revendreth|N|To Laurent.|RANK|2|
+C Mirror Making, Not Breaking|QID|57536|M|24.80,50.27|Z|Revendreth|QO|1|NC|N|Follow Laurent and Simone to the mirror.|RANK|2|
+C Mirror Making, Not Breaking|QID|57536|M|24.80,50.27|Z|Revendreth|QO|2|CHAT|N|Speak to Laurent to let him begin.|RANK|2|
+C Mirror Making, Not Breaking|QID|57536|M|24.80,50.27|Z|Revendreth|QO|3|N|Kill waves of enemies, defending Laurent and Simone.|RANK|2|
+T Mirror Making, Not Breaking|QID|57536|M|24.80,50.27|Z|Revendreth|N|To Laurent.|RANK|2|
 
 ; Sidequest Storyline - Revelations of the Light
 A A Rousing Aroma|QID|60467|M|35.04,53.91|Z|Revendreth|N|From Sabina.|LVL|58|RANK|2|

--- a/WoWPro_Leveling/Neutral/SL_Venthyr.lua
+++ b/WoWPro_Leveling/Neutral/SL_Venthyr.lua
@@ -1,7 +1,7 @@
 local guide = WoWPro:RegisterGuide('Venthyr', 'Leveling', 'Ring of Fates@Oribos', 'Tester', 'Alliance')
 WoWPro:GuideName(guide,"Covenant: Venthyr")
 WoWPro:GuideLevels(guide,60, 60)
-WoWPro:GuideNextGuide(guide, 'Covenant')
+--WoWPro:GuideNextGuide(guide, 'Covenant')
 WoWPro:GuideSteps(guide, function()
 return [[
 ; Chapter 1
@@ -267,7 +267,7 @@ P Firstborne's Bounty|ACTIVE|58530|M|53.30,44.90|Z|Bastion|N|Unless you can Glid
 R Veiled Enclave|ACTIVE|58530|M|51.43,31.67|Z|Bastion!The Shadowlands|N|Make your way to the Veiled Enclave.|
 C Hidden Mirror|QID|58530|M|49.54,30.31|Z|Bastion!The Shadowlands|U|180356|NC|N|Run near the red pool and use Laurent's Compact Looking Glass to reveal the Hidden Mirror.|
 T Hidden Mirror|QID|58530|M|49.66,30.16|Z|Bastion!The Shadowlands|N|To General Draven.|
-A A Tense Reunion|QID|58555|PRE|58530|M|49.66,30.16|Z|Bastion!The Shadowlands|N|From General Draven.|PRE|58530|
+A A Tense Reunion|QID|58555|M|49.66,30.16|Z|Bastion!The Shadowlands|N|From General Draven.|PRE|58530|
 C A Tense Reunion|QID|58555|M|50.38,22.53|Z|Bastion!The Shadowlands|NC|N|Run toward The Eternal Forge.|
 T A Tense Reunion|QID|58555|M|50.09,20.71|Z|Bastion!The Shadowlands|N|To General Draven.|
 A Right our Wrongs|QID|58584|PRE|58555|M|50.09,20.71|Z|Bastion!The Shadowlands|N|From General Draven.|
@@ -312,7 +312,7 @@ C Lowering Their Defenses|QID|60994|M|24.78,23.20|Z|Bastion!The Shadowlands|QO|3
 T Lowering Their Defenses|QID|60994|M|24.41,29.87|Z|Bastion!The Shadowlands|N|To Mikanikos.|
 T Disloyalty|QID|60995|M|24.41,29.87|Z|Bastion!The Shadowlands|N|To Mikanikos.|
 A Face Your Fears|QID|60996|PRE|60994&60995|M|24.28,29.68|Z|Bastion!The Shadowlands|N|From General Draven.|
-C Face Your Fears|QID|60996|M|21.07,22.87|Z|Bastion!The Shadowlands|QO|1|Chat|N|Speak with Draven for a lift up to the Temple of Loyalty.|
+C Face Your Fears|QID|60996|M|21.07,22.87|Z|Bastion!The Shadowlands|QO|1|CHAT|N|Speak with Draven for a lift up to the Temple of Loyalty.|
 C Face Your Fears|QID|60996|M|20.38,22.89|Z|Bastion!The Shadowlands|QO|2|NC|N|Step into the blue pool and use the Action Button "[color=40C7EB]Blessing of Loyalty[/color]" to purify the Crown of the Harvesters.|EAB|
 C Face Your Fears|QID|60996|M|20.48,22.88|Z|Bastion!The Shadowlands|QO|3|N|Kill the Echo of Denathrius.|
 T Face Your Fears|QID|60996|M|21.11,22.86|Z|Bastion!The Shadowlands|N|To General Draven.|
@@ -324,18 +324,152 @@ T The Prince's New Crown|QID|59233|M|51.82,37.71|Z|Sinfall Reaches@Sinfall!Dunge
 
 ; Chapter 6
 A Confronting Sin|QID|61077|PRE|59233|M|51.77,37.55|Z|Sinfall Reaches@Sinfall!Dungeon|N|From Prince Renathal.|
-P Sinfall|ACTIVE|61077|M|36.71,48.01|Z|Sinfall Reaches@Sinfall!Dungeon|N|Take the portal to Sinfall.|
+P Confronting Sin|ACTIVE|61077|M|36.71,48.01|Z|Sinfall Reaches@Sinfall!Dungeon|N|Take the portal to Sinfall.|IZ|1699|
 T Confronting Sin|QID|61077|M|56.09,78.57|Z|Sinfall Depths@Sinfall!Dungeon|N|To The Accuser.|
 A Someone Worth Saving|QID|58382|PRE|61077|M|56.09,78.57|Z|Sinfall Depths@Sinfall!Dungeon|N|From The Accuser.|
 C Someone Worth Saving|QID|58382|M|48.17,24.73|Z|Sinfall Depths@Sinfall!Dungeon|CHAT|N|Speak to the Sinfal Executors on both sides of Kael'thas Sunstrider to have him released.|
 T Someone Worth Saving|QID|58382|M|46.41,32.26|Z|Sinfall Depths@Sinfall!Dungeon|N|To The Accuser.|
 A The Many Sins of Kael'thas Sunstrider|QID|58383|PRE|58382|M|46.41,32.26|Z|Sinfall Depths@Sinfall!Dungeon|N|From Sinfall Executor.|
+C The Many Sins of Kael'thas Sunstrider|QID|58383|M|46.45,32.13|Z|Sinfall Depths@Sinfall!Dungeon|QO|1|CHAT|N|Talk with the Accuser to begin the ritual of absolution.|
+C The Many Sins of Kael'thas Sunstrider|QID|58383|M|39.54,36.80|Z|Sinfall Depths@Sinfall!Dungeon|QO|2<1|NC|N|Click on Kael'thas: Arrogance.|
+C The Many Sins of Kael'thas Sunstrider|QID|58383|M|39.54,36.80|Z|Sinfall Depths@Sinfall!Dungeon|QO|2<2|NC|N|Click on Kael'thas: Burning Legion.|
+C The Many Sins of Kael'thas Sunstrider|QID|58383|M|39.54,36.80|Z|Sinfall Depths@Sinfall!Dungeon|QO|2<5|NC|N|Click on any of them, he is guilty of all 3.|
+T The Many Sins of Kael'thas Sunstrider|QID|58383|M|46.44,32.15|Z|Sinfall Depths@Sinfall!Dungeon|N|To The Accuser.|
+A In the Shadow of our Failures|QID|58426|PRE|58383|M|46.44,32.15|Z|Sinfall Depths@Sinfall!Dungeon|N|From The Accuser.|
+P In the Shadow of our Failures|ACTIVE|58426|M|70.41,38.48|Z|Sinfall Depths@Sinfall!Dungeon|N|Take the portal to Sinfall.|IZ|1700|
+F Charred Ramparts|ACTIVE|58426|M|67.30,21.45|Z|Sinfall Reaches@Sinfall!Dungeon|N|Head to the flightmaster and take a flight to Charred Ramparts.|
+T In the Shadow of our Failures|QID|58426|M|42.30,47.56|Z|Revendreth|N|To The Accuser.|
+A Dredgers Left Behind|QID|58384|PRE|58426|M|42.30,47.56|Z|Revendreth|N|From The Accuser.|
+A Learning to Sacrifice|QID|58385|PRE|58426|M|42.30,47.56|Z|Revendreth|N|From The Accuser.|
+A Use My Strengths|QID|58386|PRE|58426|M|PLAYER|Z|Revendreth|N|From Kael'thas Sunstrider.|
+C Dredgers Left Behind|QID|58384|M|42.16,53.41|Z|Revendreth|NC|N|Run near Darkwall Captives or attack their captors to give them the courage to escape.|S|
+C Learning to Sacrifice|QID|58385|M|44.85,48.75|Z|Revendreth|QO|1|NC|N|Click on one of the Legionnaires to animate them.|
+C Learning to Sacrifice|QID|58385|M|43.36,53.82|Z|Revendreth|QO|3|NC|N|Click on Vrednic to it.|
+C Learning to Sacrifice|QID|58385|M|41.69,52.39|Z|Revendreth|QO|2|NC|N|Once you enter the tower stay to the right and go up the stairs. Click on one of the Messengers animate them.|
+C Use My Strengths|QID|58386|M|41.04,54.77|Z|Revendreth|N|Go back down through the tower and out the back. Defeat Usurper Simona.|
+C Dredgers Left Behind|QID|58384|M|42.16,53.41|Z|Revendreth|NC|N|Run near Darkwall Captives or attack their captors to give them the courage to escape.|US|
+T Dredgers Left Behind|QID|58384|M|43.87,51.40|Z|Revendreth|N|To The Accuser.|
+T Learning to Sacrifice|QID|58385|M|43.87,51.40|Z|Revendreth|N|To The Accuser.|
+T Use My Strengths|QID|58386|M|43.87,51.40|Z|Revendreth|N|To The Accuser.|
+A We Each Must Carry Our Own Sins|QID|58387|PRE|58384&58385&58386|M|43.87,51.40|Z|Revendreth|N|From The Accuser.|
+C We Each Must Carry Our Own Sins|QID|58387|M|43.87,51.40|Z|Revendreth|QO|1|CHAT|N|Speak with the Accuser to begin the ritual.|
+C We Each Must Carry Our Own Sins|QID|58387|M|43.87,51.40|Z|Revendreth|QO|2|NC|N|Sit back while the Accuser completes the Ritual of extraction.|
+T We Each Must Carry Our Own Sins|QID|58387|M|43.86,51.40|Z|Revendreth|N|To The Accuser.|
+A Continued Care of Kael'thas|QID|58443|PRE|58387|M|43.86,51.40|Z|Revendreth|N|From The Accuser.|
+T Continued Care of Kael'thas|QID|58443|M|46.45,51.49|Z|Revendreth|N|To The Accuser.|
+A Blackbale Betrayers|QID|58388|PRE|58443|M|46.45,51.49|Z|Revendreth|N|From The Accuser.|
+L Suspicious Weapon|AVAILABLE|58389|M|48.37,51.70|Z|Revendreth|L|174212|N|Kill Blackbale enemies until you find the suspicious weapon.|PRE|58443|
+A Maldraxxian Weapons|QID|58389|PRE|58443|M|48.37,51.70|Z|Revendreth|U|174212|N|Click the Suspicious Weapon to get the quest
+A There's Always a Paper Trail|QID|58518|ACTIVE|58389|PRE|58443|M|PLAYER|Z|Revendreth|N|From Kael'thas Sunstrider.|
+C Maldraxxian Weapons|QID|58389|M|50.16,55.65|Z|Revendreth|N|Kill Blackbale enemies and loot their Maldraxxian Weapons.|S|
+C Blackbale Betrayers|QID|58388|M|50.16,55.65|Z|Revendreth|N|Kill Blackbale Overseers.|S|
+C There's Always a Paper Trail|QID|58518|M|51.17,55.63|Z|Revendreth|N|Kill Lord Blackbale and loot his Orders from the Tithelord.|
+C Blackbale Betrayers|QID|58388|M|50.16,55.65|Z|Revendreth|N|Kill Blackbale Overseers.|US|
+C Maldraxxian Weapons|QID|58389|M|50.16,55.65|Z|Revendreth|N|Kill Blackbale enemies and loot their Maldraxxian Weapons.|US|
+T Blackbale Betrayers|QID|58388|M|46.45,51.49|Z|Revendreth|N|To The Accuser.|
+T Maldraxxian Weapons|QID|58389|M|46.45,51.49|Z|Revendreth|N|To The Accuser.|
+T There's Always a Paper Trail|QID|58518|M|46.45,51.49|Z|Revendreth|N|To The Accuser.|
+A Reconnaissance... for my, uh, Recovery|QID|58391|PRE|58388&58389&58518|M|46.48,51.61|Z|Revendreth|N|From Kael'thas Sunstrider.|
+F Darkhaven|QID|58391|ACTIVE|58391|M|38.95,49.33|Z|Revendreth|N|Head to the flightmaster and take a flight to Darkhaven.|
+R Catacombs|ACTIVE|58391|M|61.29,59.72|Z|Revendreth|CC|N|Make your way to the Catacombs in Darkhaven.|
+C Reconnaissance... for my, uh, Recovery|QID|58391|M|61.19,60.40|Z|Revendreth|QO|1|NC|N|Run down the stairs and then click on the door.|
+C Reconnaissance... for my, uh, Recovery|QID|58391|M|61.52,60.15|Z|Revendreth|QO|2|V|N|Click on the carriage to hide and go for a ride.|
+C Reconnaissance... for my, uh, Recovery|QID|58391|M|69.94,60.20|Z|Revendreth|QO|3|NC|N|Enjoy the ride and listen for the Tithelord to disclose his plan.|
+T Reconnaissance... for my, uh, Recovery|QID|58391|M|69.89,59.96|Z|Revendreth|N|To Kael'thas Sunstrider.|
+A Death's End Destruction|QID|58392|PRE|58391|M|69.89,59.96|Z|Revendreth|N|From Kael'thas Sunstrider.|
+A Strategic Executions|QID|58393|PRE|58391|M|69.89,59.96|Z|Revendreth|N|From Kael'thas Sunstrider.|
+C Death's End Destruction|QID|58392|M|80.29,58.02|Z|Revendreth|N|Kill enemies and interact with objects to disrupt the Maldraxxus camp.|S|
+C Strategic Executions|QID|58393|M|77.25,61.11|Z|Revendreth|QO|1|N|Kill Heftor.|
+C Strategic Executions|QID|58393|M|80.80,57.63|Z|Revendreth|QO|3|N|Kill Big Shiny.|
+C Strategic Executions|QID|58393|M|80.43,64.45|Z|Revendreth|QO|2|N|Kill Stacka.|
+C Death's End Destruction|QID|58392|M|80.43,64.45|Z|Revendreth|N|Kill enemies and interact with objects to disrupt the Maldraxxus camp.|US|
+T Death's End Destruction|QID|58392|M|79.81,58.06|Z|Revendreth|N|To Kael'thas Sunstrider.|
+T Strategic Executions|QID|58393|M|79.81,58.06|Z|Revendreth|N|To Kael'thas Sunstrider.|
+A Lady Ouix'Ara|QID|58394|PRE|58392&58393|M|79.81,58.06|Z|Revendreth|N|From Kael'thas Sunstrider.|
+C Lady Ouix'Ara|QID|58394|M|78.81,62.85|Z|Revendreth|N|Kill Lady Ouix'Ara.|
+T Lady Ouix'Ara|QID|58394|M|PLAYER|Z|Revendreth|N|To Kael'thas Sunstrider.|
+A Enough Vengeance For One Day|QID|58395|PRE|58394|M|PLAYER|Z|Revendreth|N|From Kael'thas Sunstrider.|
+H Sinfall|ACTIVE|58395|M|PLAYER|Z|Revendreth|N|Hearth back or otherwise make your way to Sinfall.|
+T Enough Vengeance For One Day|QID|58395|M|51.78,37.53|Z|Sinfall Reaches@Sinfall!Dungeon|N|To Prince Renathal.|
 
+; Chapter 7
+A Stonevigil Unrest|QID|57727|PRE|58395|M|51.78,37.53|Z|Sinfall Reaches@Sinfall!Dungeon|N|From Prince Renathal.|
+F Darkhaven|ACTIVE|57727|M|67.31,21.48|Z|Sinfall Reaches@Sinfall!Dungeon|N|Head to the flightmaster and take a flight to Darkhaven.|
+T Stonevigil Unrest|QID|57727|M|56.32,66.71|Z|Revendreth|N|To Prince Renathal.|
+A Fangs and Minds|QID|57772|PRE|57727|M|56.32,66.71|Z|Revendreth|N|From Prince Renathal.|
+A An Unwelcome Incursion|QID|57771|PRE|57727|M|56.33,66.59|Z|Revendreth|N|From Baroness Draka.|
+A Third Talon Vartox|QID|60145|PRE|57727|M|56.33,66.59|Z|Revendreth|N|From Baroness Draka.|
+N Anima Collector|ACTIVE|57771|M|56.89,69.16|Z|Revendreth|BUFF|327012|NC|N|Look for an Anima Collector laying around the ground and click it to wear it.|
+L Supply Chain Memo|AVAILABLE|60265|M|56.89,69.16|Z|Revendreth|L|178557|N|Kill Stonevigil enemies until you find the Supply Chain Memo.|PRE|60145|
+A Disrupting the Chain|QID|60265|PRE|57727|M|56.89,69.16|Z|Revendreth|U|178557|N|Click on the memo to get the quest.|
+C Fangs and Minds|QID|57772|M|57.96,68.08|Z|Revendreth|NC|U|178213|N|Use Prince Renathal's Decree to inspire Stonevigil Citizens.|S|
+C An Unwelcome Incursion|QID|57771|M|57.45,68.22|Z|Revendreth|QO|1|N|Kill Stoneborn enemies and collect their anima.|S|
+C Third Talon Vartox|QID|60145|M|56.57,68.90|Z|Revendreth|N|Kill Third Talon Vartox.|
+C Disrupting the Chain|QID|60265|M|56.70,71.23|Z|Revendreth|QO|2|NC|N|Destroy the Manor Carriage.|
+C Disrupting the Chain|QID|60265|M|58.50,68.57|Z|Revendreth|QO|1|NC|N|Destroy the Darkhaven Carriage.|
+C An Unwelcome Incursion|QID|57771|M|57.45,68.22|Z|Revendreth|QO|1|N|Kill Stoneborn enemies and collect their anima.|US|
+C An Unwelcome Incursion|QID|57771|M|58.24,69.17|Z|Revendreth|QO|2|NC|N|Depleted Anima Well filled.|
+C Fangs and Minds|QID|57772|M|57.96,68.08|Z|Revendreth|NC|U|178213|N|Use Prince Renathal's Decree to inspire Stonevigil Citizens.|US|
+T Fangs and Minds|QID|57772|M|56.32,66.72|Z|Revendreth|N|To Prince Renathal.|
+T Disrupting the Chain|QID|60265|M|56.32,66.72|Z|Revendreth|N|To Prince Renathal.|
+T An Unwelcome Incursion|QID|57771|M|56.34,66.59|Z|Revendreth|N|To Baroness Draka.|
+T Third Talon Vartox|QID|60145|M|56.34,66.59|Z|Revendreth|N|To Baroness Draka.|
+A After Them!|QID|60183|PRE|57771&60145&57772&60265|M|56.35,66.58|Z|Revendreth|N|From Baroness Draka.|
+C After Them!|QID|60183|M|56.35,66.58|Z|Revendreth|QO|1|V|N|Hop onto Deathfang to chase the Carriage.|
+C After Them!|QID|60183|M|61.79,69.29|Z|Revendreth|QO|2|N|Kill Provisioner Kraus.|
+T After Them!|QID|60183|M|61.60,69.65|Z|Revendreth|N|To Prince Renathal.|
+A To the Estate|QID|57729|PRE|60183|M|61.60,69.65|Z|Revendreth|N|From Prince Renathal.|
+T To the Estate|QID|57729|M|71.93,68.86|Z|Revendreth|N|To Prince Renathal.|
+A The Tithelord|QID|57646|PRE|57729|M|71.93,68.86|Z|Revendreth|N|From Prince Renathal.|
+C The Tithelord|QID|57646|M|77.79,70.18|Z|Revendreth|QO|1|N|Fight the Tithelord, this is a 3 phase battle.\n\nRoughly every 1/3 of his health he will shield and run the toward his manor.\n\nOnce he's been killed, look the Medallion of Envy.|
+C The Tithelord|QID|57646|M|77.79,70.18|Z|Revendreth|QO|2|V|N|Hop on Clemency Enforcer Traal for a free ride back to Sinfall.|
+T The Tithelord|QID|57646|M|51.87,37.70|Z|Sinfall Reaches@Sinfall!Dungeon|N|To Prince Renathal.|
 
+; Sidequest Storyline - Mirror Maker of the Master - From Revendreth guide (this is a PRE for chapter 8 and is available to everyone regardless of covenant.)
+t A Master of Their Craft|QID|60051|M|26.43,48.95|Z|Revendreth|N|To Laurent.|
+A An Unfortunate Situation|QID|57531|M|26.43,48.95|Z|Revendreth|N|From Laurent.|LVL|58|
+C An Unfortunate Situation|QID|57531|M|29.81,48.63|Z|Revendreth|N|Kill the Costel and his 2 friends in the hideout, loot him to collect Laurent's Belongings.|
+T An Unfortunate Situation|QID|57531|M|26.43,48.95|Z|Revendreth|N|To Laurent.|
+A Foraging for Fragments|QID|57532|M|26.43,48.95|Z|Revendreth|N|From Laurent.|LVL|58|PRE|57531|
+C Foraging for Fragments|QID|57532|M|25.71,48.54|Z|Revendreth|QO|1|N|Follow Laurent and defend him against attackers.|
+C Foraging for Fragments|QID|57532|M|25.71,48.54|Z|Revendreth|QO|2|NC|N|Click on the Mirror Fragment laying on the ground.|
+C Foraging for Fragments|QID|57532|M|25.53,47.37|Z|Revendreth|QO|3|N|Follow Laurent and defend him against attackers.|
+C Foraging for Fragments|QID|57532|M|25.53,47.37|Z|Revendreth|QO|4|NC|N|Click on the Mirror Fragment laying on the ground.|
+C Foraging for Fragments|QID|57532|M|24.97,48.00|Z|Revendreth|QO|5|N|Follow Laurent and defend him against attackers.|
+C Foraging for Fragments|QID|57532|M|24.97,48.00|Z|Revendreth|QO|6|NC|N|Click on the Mirror Fragment laying on the ground.|
+T Foraging for Fragments|QID|57532|M|24.26,49.40|Z|Revendreth|N|To Laurent.|
+A Moving Mirrors|QID|57571|M|24.26,49.40|Z|Revendreth|N|From Laurent.|LVL|58|PRE|57532|
+C Moving Mirrors|QID|57571|M|24.09,49.68|Z|Revendreth|QO|1|NC|N|Click on the mirrors to free Simone.|
+T Moving Mirrors|QID|57571|M|24.19,49.46|Z|Revendreth|N|To Simone.|
+A Light Punishment|QID|57533|M|24.19,49.46|Z|Revendreth|N|From Simone.|LVL|58|PRE|57571|
+A When Only Ash Remains|QID|57534|M|24.26,49.40|Z|Revendreth|N|From Laurent.|LVL|58|PRE|57571|
+C When Only Ash Remains|QID|57534|M|22.48,52.16|Z|Revendreth|N|Kill Ashen enemies.|S|
+C Light Punishment|QID|57533|M|22.48,52.16|Z|Revendreth|NC|N|Click on the mirrors around Blistering Outcasts to free them.|
+C When Only Ash Remains|QID|57534|M|22.48,52.16|Z|Revendreth|N|Kill Ashen enemies.|US|
+T When Only Ash Remains|QID|57534|M|24.26,49.40|Z|Revendreth|N|To Laurent.|
+T Light Punishment|QID|57533|M|24.19,49.46|Z|Revendreth|N|To Simone.|
+A We Need More Power|QID|59427|M|24.19,49.46|Z|Revendreth|N|From Simone.|LVL|58|PRE|57533&57534|
+A Escaping the Master|QID|57535|M|24.26,49.40|Z|Revendreth|N|From Laurent.|LVL|58|PRE|57533&57534|
+C We Need More Power|QID|59427|M|24.79,53.51|Z|Revendreth|N|Click on Anima canisters laying around the area.|S|
+C Escaping the Master|QID|57535|M|24.79,53.51|Z|Revendreth|N|Kill enemies and loot their Mirror Fragments.|
+C We Need More Power|QID|59427|M|24.79,53.51|Z|Revendreth|N|Click on Anima canisters laying around the area.|US|
+T We Need More Power|QID|59427|M|24.19,49.46|Z|Revendreth|N|To Simone.|
+T Escaping the Master|QID|57535|M|24.26,49.40|Z|Revendreth|N|To Laurent.|
+A Mirror Making, Not Breaking|QID|57536|M|24.26,49.40|Z|Revendreth|N|From Laurent.|LVL|58|PRE|59427&57535|
+C Mirror Making, Not Breaking|QID|57536|M|24.80,50.27|Z|Revendreth|QO|1|NC|N|Follow Laurent and Simone to the mirror.|
+C Mirror Making, Not Breaking|QID|57536|M|24.80,50.27|Z|Revendreth|QO|2|CHAT|N|Speak to Laurent to let him begin.|
+C Mirror Making, Not Breaking|QID|57536|M|24.80,50.27|Z|Revendreth|QO|3|N|Kill waves of enemies, defending Laurent and Simone.|
+T Mirror Making, Not Breaking|QID|57536|M|24.80,50.27|Z|Revendreth|N|To Laurent.|
 
-
-
-
-N Safety|QID|99999|N|Safety Net.|
+; Chapter 8
+A Mirror to Maldraxxus|QID|58406|M|51.73,37.59|Z|Sinfall Reaches@Sinfall!Dungeon|N|From Prince Renathal.|PRE|57536|
+T Mirror to Maldraxxus|QID|58406|M|27.27,40.39|Z|Revendreth|N|Take the ramp and portal outside to the surface and make your way to Laurent.|
+A The Medallion of Dominion|QID|58407|PRE|58406|M|27.42,40.34|Z|Revendreth|N|From General Draven.|
+C Taking the Necropolis|ACTIVE|58407|Z|Maldraxxus|SO|1|N|Kill Necromancers until one discloses the location of Kel'Thuzad.|
+C To the Skies!|ACTIVE|58407|M|PLAYER|Z|Maldraxxus|SO|2|N|Hop onto General Draven to assist him in clearing the skies of enemies.|
+C Reanimating Your Allies|ACTIVE|58407|Z|Maldraxxus|SO|4|NC|N|Click on the giant crystals to reanimate your allies.|
+C United in Battle|ACTIVE|58407|Z|Maldraxxus|SO|5|N|Use Action Ability "[color=40C7EB]Call General Draven[/color]" to help kill Maw Infernous.|EAB|
+C The Medallion of Dominion|ACTIVE|58407|M|73.93,33.24|Z|Maldraxxus!Instance1689|SO|6|S|N|Recover the Medallion of Dominion from Kel'Thuzad.|
+T The Medallion of Dominion|QID|58407|M|51.69,37.47|Z|Sinfall Reaches@Sinfall!Dungeon|N|To Prince Renathal.|
 ]]
 end)

--- a/WoWPro_Recorder/WoWPro_Recorder.lua
+++ b/WoWPro_Recorder/WoWPro_Recorder.lua
@@ -336,7 +336,7 @@ function WoWPro.Recorder.FlightStep()
     if x and y then
         mapxy = ("%.2f,%.2f"):format(x * 100, y * 100)
     end
-	print("WoWPro Recorder: Flight is primed, take your flight.")
+	_G.print("WoWPro Recorder: Flight is primed, take your flight.")
     WoWPro.Recorder.Flights = {
         map = mapxy,
         zone = zonetag,
@@ -357,7 +357,7 @@ function WoWPro.Recorder.PortalStep()
     if x and y then
         mapxy = ("%.2f,%.2f"):format(x * 100, y * 100)
     end
-	print("WoWPro Recorder: Portal is primed, Step through the portal.")
+	_G.print("WoWPro Recorder: Portal is primed, Step through the portal.")
     WoWPro.Recorder.Portals = {
         map = mapxy,
         zone = zonetag,

--- a/WoWPro_Recorder/WoWPro_Recorder.lua
+++ b/WoWPro_Recorder/WoWPro_Recorder.lua
@@ -156,7 +156,7 @@ function WoWPro.Recorder.eventHandler(frame, event, ...)
 			WoWPro.Recorder.AddStep(stepInfo)
 			WoWPro.Recorder.Flights = nil
 		end
-	elseif event == "NEW_WMO_CHUNK" then
+	elseif event == "AREA_POIS_UPDATED" then
 		if WoWPro.Recorder.Portals  then
 			local subzone = _G.GetSubZoneText() or zonetag
 			local stepInfo = {
@@ -336,7 +336,7 @@ function WoWPro.Recorder.FlightStep()
     if x and y then
         mapxy = ("%.2f,%.2f"):format(x * 100, y * 100)
     end
-
+	print("WoWPro Recorder: Flight is primed, take your flight.")
     WoWPro.Recorder.Flights = {
         map = mapxy,
         zone = zonetag,
@@ -357,7 +357,7 @@ function WoWPro.Recorder.PortalStep()
     if x and y then
         mapxy = ("%.2f,%.2f"):format(x * 100, y * 100)
     end
-
+	print("WoWPro Recorder: Portal is primed, Step through the portal.")
     WoWPro.Recorder.Portals = {
         map = mapxy,
         zone = zonetag,
@@ -538,7 +538,7 @@ end
 
 
 function WoWPro.Recorder:RegisterEvents()
-    WoWPro.Recorder.events = {"UI_INFO_MESSAGE", "CHAT_MSG_SYSTEM", "PLAYER_LEVEL_UP", "PLAYER_CONTROL_GAINED", "NEW_WMO_CHUNK"}
+    WoWPro.Recorder.events = {"UI_INFO_MESSAGE", "CHAT_MSG_SYSTEM", "PLAYER_LEVEL_UP", "PLAYER_CONTROL_GAINED", "AREA_POIS_UPDATED"}
 
     for _, event in pairs(WoWPro.Recorder.events) do
         WoWPro.RecorderFrame:RegisterEvent(event)


### PR DESCRIPTION
Completeed Venthyr campaign

chromie time now chooses expansion for you when used with jump

renown tag with REN

fixed bug with recorder portal steps.