### PR TITLE
Fix QO 1<1 error from progress bar update

### DIFF
--- a/WoWPro/WoWPro_Broker.lua
+++ b/WoWPro/WoWPro_Broker.lua
@@ -664,7 +664,7 @@ function WoWPro.UpdateQuestTrackerRow(row)
                 for l=1,numquesttext do
                     local lquesttext = select(numquesttext-l+1, (";"):split(questtext))
                     if WoWPro.ValidObjective(lquesttext) then
-						if select(2, _G.GetQuestLogLeaderBoard(lquesttext , j)) == "progressbar" then
+						if select(2, _G.GetQuestLogLeaderBoard(lquesttext:sub(1, 1) , j)) == "progressbar" then
 							track = "\n- ".._G.GetQuestProgressBarPercent(qid).."% out of 100% Complete. "
 						else
 							local _, status = WoWPro.QuestObjectiveStatus(qid, lquesttext)


### PR DESCRIPTION
this bug was caused by GetQuestLogLeaderBoard(index) where index should be the objective index IE QO|1| 1 is the index. Error was because of a QO|1<1| and it was reading an index of 1<1, this was changed in my progress bar update last week