### PR TITLE
Icon Fix, Progress Width, Report

### DIFF
--- a/WoWPro/WoWPro_Broker.lua
+++ b/WoWPro/WoWPro_Broker.lua
@@ -1046,7 +1046,7 @@ function WoWPro:RowUpdate(offset)
                     WoWPro.LogBox = WoWPro.LogBox or WoWPro:CreateErrorLog("Report an Issue","Hit escape to dismiss")
 					local LogBox = WoWPro.LogBox
 					local X, Y, mapId = WoWPro:GetPlayerZonePosition()
-					local text = "Step Info:\n"
+					local text = "Step Info for " .. GID .. ":\n"
 					local Sindex = WoWPro.rows[currentRow.num].index
 					if WoWPro.rows[currentRow.num]:IsVisible() then
 						local line = WoWPro.EmitStep(Sindex)
@@ -1054,10 +1054,10 @@ function WoWPro:RowUpdate(offset)
 						text = text .. line .. "\n"
 					end
 					if (not X) or (not Y) then
-						text = "\n" .. ("Player at ?/%s@%q aka %q aka %q"):format(tostring(mapId), WoWPro.GetZoneText(), _G.GetZoneText(), _G.GetSubZoneText()) .. "\n\n" .. text
+						text = "\n" .. WoWPro.Faction .. (" Player at ?/%s@%q aka %q aka %q"):format(tostring(mapId), WoWPro.GetZoneText(), _G.GetZoneText(), _G.GetSubZoneText()) .. "\n\n" .. text
 						LogBox.Box:SetText(text)
 					else
-						text = "\n" .. ("Player at %.2f,%.2f/%s@%q aka %q aka %q"):format(X*100, Y*100, tostring(mapId), WoWPro.GetZoneText(), _G.GetZoneText(), _G.GetSubZoneText()) .. "\n\n" .. text
+						text = "\n" .. WoWPro.Faction .. (" Player at %.2f,%.2f/%s@%q aka %q aka %q"):format(X*100, Y*100, tostring(mapId), WoWPro.GetZoneText(), _G.GetZoneText(), _G.GetSubZoneText()) .. "\n\n" .. text
 						LogBox.Box:SetText(text)
 					end
 					LogBox:Show()

--- a/WoWPro/WoWPro_GuideList.lua
+++ b/WoWPro/WoWPro_GuideList.lua
@@ -4,10 +4,7 @@
 ---------------------------------
 --      WoWPro_Guide_List      --
 ---------------------------------
-
 local L = WoWPro_Locale
-
-local FALLBACK_ICON = 134400
 local tabIndexByName = {}
 local GuideListMixin = {}
 function GuideListMixin:SetDisplay()
@@ -33,19 +30,10 @@ function GuideListMixin:SelectListItem(itemIndex)
     end
 end
 do -- GuideListMixin:SetTooltip
-    local tooltipIcon = _G.GameTooltip:CreateTexture(nil, "ARTWORK")
-    tooltipIcon:SetTexCoord(.08, .92, .08, .92)
-    tooltipIcon:SetPoint("TOPRIGHT", -6, -6)
-    tooltipIcon:SetSize(22, 22)
-
     function GuideListMixin:SetTooltip(listItem)
         local guide = self.guides[listItem:GetID()].guide
         _G.GameTooltip:SetText(WoWPro:GetGuideName(guide.GID))
         _G.GameTooltip:SetPadding(20, 0)
-
-        tooltipIcon:SetTexture(guide.icon or FALLBACK_ICON)
-        tooltipIcon:Show()
-
         self.module:SetTooltip(guide)
     end
 end
@@ -166,39 +154,6 @@ function WoWPro.CreateGuideList()
     --OnShow(WoWPro.GuideList)
 end
 
-
-
-
-local TooltipButton, TooltipIcon
-function WoWPro:ShowTooltipIcon(icon, offsets)
-    if not TooltipButton then
-         TooltipButton, TooltipIcon = WoWPro:CreateLootsButton(_G.GameTooltip, 99)
-    end
-    TooltipButton:SetParent(_G.GameTooltip)
-    TooltipIcon:SetTexture(icon)
-    if offsets then
-        local x1, x2, y1, y2 = unpack(offsets)
-        TooltipIcon:SetTexCoord(x1, x2, y1, y2)
-    end
-    TooltipButton:SetPoint("TOPRIGHT", _G.GameTooltip, "TOPRIGHT", -4, -4)
-    TooltipButton:Show()
-end
-
-function WoWPro:HideTooltipIcon()
-    if TooltipButton then
-        TooltipButton:Hide()
-        TooltipButton:SetParent(nil)
-    end
-end
-
-
-
-
-
-
-
-
-
 --[[ OLD ]]--
 function WoWPro.ActivateTab(tab)
     if not WoWPro[tab.name].GuideList then
@@ -213,7 +168,6 @@ function WoWPro.ActivateTab(tab)
         WoWPro[tab.name]:Setup_TitleRow(WoWPro[tab.name].GuideList.Frame)
     end
     WoWPro.GuideList.TitleRow:Show()
-
     WoWPro[tab.name].GuideList.Frame:SetSize(WoWPro[tab.name].GuideList.Frame.frameWidth,WoWPro[tab.name].GuideList.Frame.frameHeight)
     WoWPro.GuideList.ScrollFrame:SetScrollChild(WoWPro[tab.name].GuideList.Frame)
     local vHeight = WoWPro[tab.name].GuideList.Frame.frameHeight-WoWPro.GuideList.ScrollFrame:GetHeight()
@@ -261,13 +215,9 @@ function WoWPro:UpdateGuideList()
                 row:SetScript("OnEnter", function(this)
                     WoWPro[iGuide.guide.guidetype].GuideTooltipInfo(row, _G.GameTooltip, iGuide.guide)
                     _G.GameTooltip:Show()
-                    if iGuide.guide.icon then
-                        WoWPro:ShowTooltipIcon(iGuide.guide.icon, iGuide.guide.icon_offsets)
-                    end
                 end)
                 row:SetScript("OnLeave", function(this)
                     _G.GameTooltip:Hide()
-                    WoWPro:HideTooltipIcon()
                 end)
             end
 
@@ -287,20 +237,13 @@ function WoWPro:Setup_TitleRow(frame)
         insets = { left = 0, right = 0, top = 5, bottom = -5}
     }
     local ROWHEIGHT = 17
-
     local TitleRow = WoWPro.GuideList.TitleRow
-
     TitleRow.buffer = TitleRow.buffer or _G.CreateFrame("CheckButton", self.name .. "TitleRow.buffer", TitleRow, _G.BackdropTemplateMixin and "BackdropTemplate" or nil)
     TitleRow.buffer:SetBackdrop(titlerowBG)
     TitleRow.buffer:SetBackdropColor(0.2, 0.2, 0, 1)
     TitleRow.buffer:SetPoint("TOPLEFT", 4, 0)
     TitleRow.buffer:SetWidth(4)
     TitleRow.buffer:SetHeight(ROWHEIGHT)
-    -- local function OnShow(self)
-    --     WoWPro:Print("TitleRow.buffer:OnShow()")
-    -- end
-    -- TitleRow.buffer:SetScript("OnShow", OnShow)
-
 
     -- Create a button for each field
     for i,colDesc in pairs(self.GuideList.Format) do
@@ -337,9 +280,6 @@ function WoWPro:Setup_TitleRow(frame)
         lastButton = TitleRow[colDesc[1]]
     end
 
-    -- Last button gets the extra pixels!
-    --lastButton:SetPoint("RIGHT", TitleRow, "RIGHT")
-
     -- Set the OnClick handlers for each column that has a handler
     for _,colDesc in pairs(self.GuideList.Format) do
         if colDesc[3] then
@@ -366,13 +306,10 @@ WoWPro:Export("CreateGuideTabFrame_Rows")
 function WoWPro:CreateGuideTabFrame_Rows(frame)
     self.GuideList.Rows = {}
     self.GuideList.Offset = 0
-
     local sample = frame:CreateFontString(nil, nil, "GameFontHighlightSmall")
     sample:SetText("Something")
     local ROWHEIGHT = floor(sample:GetStringHeight()*1.5) -- Half a space between rows
     local frameHeight = 0
-
-
     local prevrow
     for i,iGuide in ipairs(self.GuideList.Guides) do
         local row = _G.CreateFrame("CheckButton", ("%s_Guide_Row%d"):format(self.name, i), frame)
@@ -381,13 +318,9 @@ function WoWPro:CreateGuideTabFrame_Rows(frame)
             row:SetScript("OnEnter", function(this)
                 WoWPro[iGuide.guide.guidetype].GuideTooltipInfo(row, _G.GameTooltip, iGuide.guide)
                 _G.GameTooltip:Show()
-                if iGuide.guide.icon then
-                    WoWPro:ShowTooltipIcon(iGuide.guide.icon, iGuide.guide.icon_offsets)
-                end
             end)
             row:SetScript("OnLeave", function(this)
                 _G.GameTooltip:Hide()
-                WoWPro:HideTooltipIcon()
             end)
         end
 
@@ -446,42 +379,30 @@ function WoWPro:CreateGuideTabFrame_Rows(frame)
             prevrow = row
         end
 
-
         row:SetPoint("LEFT", 4, 0)
         row:SetPoint("RIGHT", -4, 0)
         row:SetHeight(ROWHEIGHT)
-
         frameHeight = frameHeight + ROWHEIGHT
-
         local highlight = row:CreateTexture()
         highlight:SetTexture("Interface\\HelpFrame\\HelpFrameButton-Highlight")
         highlight:SetTexCoord(0, 1, 0, 0.578125)
         highlight:SetAllPoints()
         row:SetHighlightTexture(highlight)
         row:SetCheckedTexture(highlight)
-
         row.module = self
         row:SetScript("OnClick", self.GuideTabFrame_RowOnClick)
-
         self.GuideList.Rows[i] = row
-
     end
     frame.frameHeight = frameHeight
 end
 
-
 WoWPro:Export("CreateGuideTabFrame")
 function WoWPro:CreateGuideTabFrame()
     local frame
-
     if not self.GuideList.Frame then
         frame = _G.CreateFrame("Frame", self.name .. " TabFrame", WoWPro.GuideList.ScrollFrame)
         frame.module = self
         self.GuideList.Frame = frame
-        -- local function OnShow(self)
-        --     self.module:Print("GuideList.Frame: OnShow!")
-        -- end
-        -- frame:SetScript("OnShow", OnShow)
 
         -- Title Row --
         self:Setup_TitleRow(frame)
@@ -491,4 +412,3 @@ function WoWPro:CreateGuideTabFrame()
 
     end
 end
--- WoWPro.GuideList

--- a/WoWPro/WoWPro_Widgets.lua
+++ b/WoWPro/WoWPro_Widgets.lua
@@ -284,8 +284,10 @@ function WoWPro:CreateLootsButton(parent, id)
         local name, texture, _
         if ID and ID:len() > 1 and ID:sub(1,1) == "$" then
             local result = _G.C_CurrencyInfo.GetCurrencyInfo(tonumber(ID:sub(2)))
-            name = result['name']
-            texture = result['iconFileID']
+			if result then
+				name = result['name']
+				texture = result['iconFileID']
+			end
         elseif tonumber(ID) then
             name, _, _, _, _, _, _, _, _, texture = _G.GetItemInfo(tonumber(ID))
         end

--- a/WoWPro_Leveling/Horde/WOD_Gorgrond.lua
+++ b/WoWPro_Leveling/Horde/WOD_Gorgrond.lua
@@ -134,7 +134,7 @@ $ Odd Boulder|QID|36732|M|44.17,46.65|N|Call Beatface (click on the rock) to exp
 C Fair Warning|QID|35128|M|32.12,75.66|QO|1|S|N|Go into the cave and kill them as you go down.|Z|Fissure of Fury@Gorgrond|
 C Leave Every Soldier Behind|QID|35129|M|44.96,86.18|CHAT|QO|1|N|Talk to Thukmar and then take care of him.|Z|Fissure of Fury@Gorgrond|
 C Leave Every Soldier Behind|QID|35129|M|44.96,86.18|NC|QO|2|N|The intel is on the ground beside Thukmar.|;this seems to not be on map layer 19, despite it showing on map layer 19 when you open the map...
-$ Horned Skull|QID|35056|M|42.1,66.73|QO|1|N|Loot for some Garrison Resources.|RANK|3|Z|Fissure of Fury@Gorgrond|ITEM|$934|PRE|35880|
+$ Horned Skull|QID|35056|M|42.1,66.73|QO|1|N|Loot for some Garrison Resources.|RANK|3|Z|Fissure of Fury@Gorgrond|ITEM|$824|PRE|35880|
 K Gelgor of the Blue Flame|QID|36391|M|34.0,38.6|T|Gelgor the Blue Flame|L|118230|N|Kill and loot for an ilvl 534 versatility trinket.|PRE|35880|RANK|3|ITEM|118230|;in fissure of fury
 $ Odd Boulder|QID|36723|M|60.34,44.75|Z|Fissure of Fury@Gorgrond|N|Call Beatface (click on the rock) to expose the Aged Stone Container|PRE|35880|RANK|3|;7
 C Fair Warning|QID|35128|M|30.78,75.97|US|;Z|;Fissure of Fury|
@@ -372,7 +372,7 @@ C South Gronn Canyon-Bonus Objective|QID|36476|M|48.91,53.19|N|Kill Goren, Gronn
 t South Gronn Canyon-Bonus Objective|QID|36476|M|48.91,53.19|N|Auto tuen in.|RANK|3|
 $ Harvestable Precious Crystal|QID|36651|PRE|35707|M|44.55,50.76;46.12,49.95|CS|QO|1|N|Enter Glut's Burrow and you will find the crystal in the back, feel free to kill the Glut (silver elite} while you are here.|RANK|3|ITEM|$824|
 K Glut|QID|36204|PRE|35707|M|46.2,50.8|T|Glut|L|118229|N|Kill and loot for an ilvl 534 agility trinket.|RANK|3|ITEM|118229|
-$ Horned Skull|QID|35056|PRE|35707|M|42.56,46.88|QO|1|N|Loot for some Garrison Resources. At the bottom of the cave.|RANK|3|ITEM|$934|
+$ Horned Skull|QID|35056|PRE|35707|M|42.56,46.88|QO|1|N|Loot for some Garrison Resources. At the bottom of the cave.|RANK|3|ITEM|$824|
 K Gelgor of the Blue Flame|QID|36391|PRE|35707|M|41.89,45.43|T|Gelgor the Blue Flame|L|118230|N|Kill and loot for an ilvl 534 versatility trinket.|RANK|3|ITEM|118230|Z|Fissure of Fury@Gorgrond| ;in fissure of fury
 $ Iron Supply Chest|QID|36618|M|42.77,44.42;43.7,42.5|PRE|35707|CS|QO|1|N|Down inside Brak's Excavation (a cave). Loot for some Garrison Resources.|RANK|3|ITEM|$824|
 $ Sniper's Crossbow|QID|36634|M|45.0,42.6|PRE|35707|QO|1|N|Pick up an ilvl 539 crossbow.|RANK|3|ITEM|118713|;above/across from fissure of fury

--- a/WoWPro_Leveling/WoWPro_Leveling_GuideList.lua
+++ b/WoWPro_Leveling/WoWPro_Leveling_GuideList.lua
@@ -11,14 +11,12 @@ local defaultXpac = _G.LE_EXPANSION_CLASSIC
 local introZones = {
     [1409] = true, -- Exile's Reach - New Players
     [378] = true, -- The Wandering Isle - Pandaren
-
     [427] = true, -- Coldridge Valley - Dwarf
     [468] = true, -- Ammen Vale - Draenai
     [460] = true, -- Shadowglen - Night Elf
     [425] = true, -- Northshire - Human
     [179] = true, -- Gilneas - Worgen
     [469] = true, -- New Tinkertown - Gnome
-
     [194] = true, -- Kezan - Goblin
     [461] = true, -- Valley of Trials - Orc
     [462] = true, -- Camp Narache - Tauren
@@ -105,7 +103,6 @@ local function GetGuides()
                 level = guide.level,
 				sortlevel = guide.sortlevel
             }
-
             if WoWPro.CLASSIC then
                 guideInfo.Content = rangeFormat:format(guide.startlevel, guide.endlevel)
             else
@@ -176,7 +173,6 @@ local function progressSort(a, b)
     return a.progress and true or false
 end
 
-
 function Leveling:SetTooltip(guide)
     _G.GameTooltip:AddDoubleLine("Start Level:", tostring(guide.startlevel), 1, 1, 1, unpack(WoWPro.LevelColor(guide.startlevel)))
     _G.GameTooltip:AddDoubleLine("Avg. Level:", ("%.2f"):format(guide.level or 0), 1, 1, 1, unpack(WoWPro.LevelColor(guide)))
@@ -214,7 +210,7 @@ function Leveling:GetGuideListInfo()
             headerInfo = {
                 sorts = {zoneSort, contentSort, authorSort, progressSort},
                 names = {"Zone", "Content", "Author", "Progress"},
-                size = {0.35, 0.25, 0.30, 0.10},
+                size = {0.35, 0.25, 0.28, 0.12},
             },
         }
 		WoWPro.GuidelistReset = false
@@ -222,5 +218,4 @@ function Leveling:GetGuideListInfo()
     return listInfo
 end
 Leveling.sortIndex = 2
-
 Leveling:dbp("Guide Setup complete")


### PR DESCRIPTION
Removed the tooltip Icon from the guidelist.

Adjusted the width of the progress section in the guidelist.

Updated the Report Issue information to display faction and GID

Fixed Gorgronds invalid currency ID and fixed addon to check and report an invalid currency ID and prevent it from bombing.