### PR TITLE
Update WOTLK_Grizzly_Hills.lua

### DIFF
--- a/WoWPro_Leveling/Alliance/WOTLK_Grizzly_Hills.lua
+++ b/WoWPro_Leveling/Alliance/WOTLK_Grizzly_Hills.lua
@@ -68,13 +68,13 @@ A Seared Scourge|QID|12029|PRE|12484|M|16.7,48.3|N|From Mack Fearson.\n\nThis wi
 A Shimmercap Stew|QID|12483|PRE|12484|M|15.7,46.7|N|From Prigmon.|
 C Ice Serpent Eyes|QID|12483|QO|1|N|Drop from Ice Serpent or Serpent Defender, you need five eyes.|S|
 C Shimmering Snowcaps|QID|12483|QO|2|NC|N|From the Shimmering Snowcaps, to the west, near the river.|S|
-l Frozen Mojos|QID|11991|L|35799 5|N|Drop from Krakkari Warriors and Shamans, you need 5 mojos.|M|12.9,59.2|
+l Frozen Mojos|QID|11991|L|35799 5|N|Drop from Drakkari Warriors and Shamans, you need 5 mojos.|M|12.9,59.2|
 T Subject to Interpretation|QID|11991|M|13.2,60.9|U|35797|N|Use the [Drakuru's Elixir] near the Drakuru's Brazier. Turn the quest into the Image of Drakuru.|
 A Sacrifices Must be Made|QID|12007|PRE|11991|M|13.2,60.9|N|From the Image of Drakuru.|
 C Ice Serpent Eyes|QID|12483|QO|1|N|Drop from Ice Serpent or Serpent Defender, you need five eyes.|US|
 C Shimmering Snowcaps|QID|12483|QO|2|NC|N|From the Shimmering Snowcaps, to the west, near the river.|US|
 C Shimmercap Stew|QID|12483|QO|3|NC|N|Loot Sweetroots from the ground.|M|16.1,34.8|S|
-K Warlord Zim'bo|L|35836|QID|12007|N|Kill and loot Warlord Zim'bo.|M|15,37|
+K Warlord Zim'bo|L|35836|QID|12007|N|Kill and loot Warlord Zim'bo.|M|14.54,3756|N|Inside the Hut.|
 C Sacrifices Must be Made|QID|12007|L|35806|NC|N|Get the "Eye of the Prophets" from the Seer of Zeb'Halak, up the stairs.|M|17.92,36.51|
 C Use the Elixer|QID|12007|U|35797|N|Use the Drakuru's Elixir near the Drakuru's Brazier.|NC|M|17.46,36.42|
 T Sacrifices Must be Made|QID|12007|U|35797|N|To the Image of Drakuru.|M|17.46,36.42|

--- a/WoWPro_Leveling/Alliance/WOTLK_Grizzly_Hills.lua
+++ b/WoWPro_Leveling/Alliance/WOTLK_Grizzly_Hills.lua
@@ -74,7 +74,7 @@ A Sacrifices Must be Made|QID|12007|PRE|11991|M|13.2,60.9|N|From the Image of Dr
 C Ice Serpent Eyes|QID|12483|QO|1|N|Drop from Ice Serpent or Serpent Defender, you need five eyes.|US|
 C Shimmering Snowcaps|QID|12483|QO|2|NC|N|From the Shimmering Snowcaps, to the west, near the river.|US|
 C Shimmercap Stew|QID|12483|QO|3|NC|N|Loot Sweetroots from the ground.|M|16.1,34.8|S|
-K Warlord Zim'bo|L|35836|QID|12007|N|Kill and loot Warlord Zim'bo.|M|14.54,3756|N|Inside the Hut.|
+K Warlord Zim'bo|L|35836|QID|12007|N|Kill and loot Warlord Zim'bo.|M|14.54,37.56|N|Inside the Hut.|
 C Sacrifices Must be Made|QID|12007|L|35806|NC|N|Get the "Eye of the Prophets" from the Seer of Zeb'Halak, up the stairs.|M|17.92,36.51|
 C Use the Elixer|QID|12007|U|35797|N|Use the Drakuru's Elixir near the Drakuru's Brazier.|NC|M|17.46,36.42|
 T Sacrifices Must be Made|QID|12007|U|35797|N|To the Image of Drakuru.|M|17.46,36.42|

--- a/WoWPro_Leveling/Alliance/WOTLK_Grizzly_Hills.lua
+++ b/WoWPro_Leveling/Alliance/WOTLK_Grizzly_Hills.lua
@@ -74,7 +74,7 @@ A Sacrifices Must be Made|QID|12007|PRE|11991|M|13.2,60.9|N|From the Image of Dr
 C Ice Serpent Eyes|QID|12483|QO|1|N|Drop from Ice Serpent or Serpent Defender, you need five eyes.|US|
 C Shimmering Snowcaps|QID|12483|QO|2|NC|N|From the Shimmering Snowcaps, to the west, near the river.|US|
 C Shimmercap Stew|QID|12483|QO|3|NC|N|Loot Sweetroots from the ground.|M|16.1,34.8|S|
-K Warlord Zim'bo|L|35836|QID|12007|N|Kill and loot Warlord Zim'bo.|M|14.54,37.56|N|Inside the Hut.|
+K Warlord Zim'bo|L|35836|QID|12007|N|Kill and loot Warlord Zim'bo. He is inside the Hut|M|14.54,37.56|
 C Sacrifices Must be Made|QID|12007|L|35806|NC|N|Get the "Eye of the Prophets" from the Seer of Zeb'Halak, up the stairs.|M|17.92,36.51|
 C Use the Elixer|QID|12007|U|35797|N|Use the Drakuru's Elixir near the Drakuru's Brazier.|NC|M|17.46,36.42|
 T Sacrifices Must be Made|QID|12007|U|35797|N|To the Image of Drakuru.|M|17.46,36.42|


### PR DESCRIPTION
On the Grizzly Hills alliance guide step Frozen Mojos (56), there is a typo - the mojos drop from Drakkari warriors and Shamans not Krakkari.
fureeous Today at 13:12
Also the Warlord Zimbo step's the coords are a little off - should be 14.54,37.56, and I'd suggest adding a "inside the hut" note to the step as it took me a couple of mins to figure out where he was hiding out!