### PR TITLE
Autoswitch Removal

### DIFF
--- a/WoWPro_Leveling/Alliance/BFA_Endgame_Story.lua
+++ b/WoWPro_Leveling/Alliance/BFA_Endgame_Story.lua
@@ -3,7 +3,6 @@ WoWPro:GuideLevels(guide, 50, 50, 50)
 WoWPro:GuideSort(guide, 7)
 WoWPro:GuideName(guide,'Endgame Storylines')
 WoWPro:GuideNextGuide(guide, 'TBD')
-WoWPro:GuideAutoSwitch(guide)
 WoWPro:GuideSteps(guide, function()
 return [[
 N About|M|67.99,22.01|Z|Boralus|N|You must be level 50 and have the Kul Tourist achievement to start this guide. This guide is for the Jaina Proudmoore storyline in Kul'tiras. It earns the Pride of Kul'tiras achievement and unlocks the Siege of Boralus mythic-only instance.|AVAILABLE|52194|

--- a/WoWPro_Leveling/Horde/BFA_Endgame_Story.lua
+++ b/WoWPro_Leveling/Horde/BFA_Endgame_Story.lua
@@ -3,7 +3,6 @@ WoWPro:GuideLevels(guide, 50, 50, 50)
 WoWPro:GuideSort(guide, 7)
 WoWPro:GuideName(guide,'Endgame Storylines')
 WoWPro:GuideNextGuide(guide, 'TBD')
-WoWPro:GuideAutoSwitch(guide)
 WoWPro:GuideSteps(guide, function()
 return [[
 N A Bargain of Blood|AVAILABLE|47199|M|40.89,73.00|Z|Hall of Croniclers!Dazar'alor|N|The first part of the these questlines require you to have completed the zone achievement for Nazmir as well as Zandalar. Vol'dun will be required eventually you should start working on all 3. If you're trying to just go for these achievements and don't care about sidequests, try running the guide on Rank 1 with rares and treasures disabled.|ACH|11861+11868|

--- a/WoWPro_Leveling/Horde/BFA_Zuldazar.lua
+++ b/WoWPro_Leveling/Horde/BFA_Zuldazar.lua
@@ -3,7 +3,6 @@ WoWPro:GuideSort(guide, 2)
 WoWPro:GuideName(guide,'Zuldazar')
 WoWPro:GuideNickname(guide, "Zuldazar")
 WoWPro:GuideNextGuide(guide, 'Nazmir')
-WoWPro:GuideAutoSwitch(guide)
 WoWPro:GuideSteps(guide, function()
 return [[
 N Guide Hub|QID|99999|M|PLAYER|JUMP|Battle for Azeroth: Guide Hub|LVL|25|S!US|N|Jump to the Guide Hub|NOCACHE|

--- a/WoWPro_Leveling/Neutral/BFA_Mechagon.lua
+++ b/WoWPro_Leveling/Neutral/BFA_Mechagon.lua
@@ -4,7 +4,6 @@ WoWPro:GuideSort(guide, 9)
 WoWPro:GuideName(guide,'Mechagon Island')
 WoWPro:GuideNickname(guide, "Mechagon Island")
 WoWPro:GuideNextGuide(guide, 'Battle for Azeroth: Guide Hub')
-WoWPro:GuideAutoSwitch(guide)
 WoWPro:GuideSteps(guide, function()
 return [[
 N Guide Hub|QID|99999|M|PLAYER|JUMP|Battle for Azeroth: Guide Hub|LVL|25|S!US|N|Jump to the Guide Hub|NOCACHE|

--- a/WoWPro_Leveling/Neutral/SL_Maw_Intro.lua
+++ b/WoWPro_Leveling/Neutral/SL_Maw_Intro.lua
@@ -7,11 +7,11 @@ WoWPro:GuideNextGuide(guide, 'Bastion')
 WoWPro:GuideSteps(guide, function()
 return [[
 A A Chilling Summons|QID|61874|Z|Orgrimmar|N|From Highlord Darion Mograine. Auto Accepted.|FACTION|Horde|
-R Orgrimmar|QID|61874|N|If you aren't in Orgrimmar, go there to get the starting quest.|FACTION|Horde|
+R Orgrimmar|QID|61874|IZ|-Orgrimmar|N|If you aren't in Orgrimmar, go there to get the starting quest.|FACTION|Horde|
 C A Chilling Summons|QID|61874|M|50.38,76.58|Z|Orgrimmar|QO|1|CHAT|N|Speak with Nazgrim outside Grommash Hold and he will open a gate.|FACTION|Horde|
 C A Chilling Summons|QID|61874|M|49.16,78.13|Z|Orgrimmar|QO|2|NC|N|Enter the Death gate to Acherus.|FACTION|Horde|
 A Shadowlands: A Chilling Summons|QID|60545|M|76.55,42.72|Z|Stormwind City|N|From Highlord Darion Mograine. Auto Accepted.|FACTION|Alliance|
-R Stormwind|QID|60545|IZ|Stormwind City|N|If you aren't in Stormwind, go there to get the starting quest.|FACTION|Alliance|
+R Stormwind|QID|60545|IZ|-84|N|If you aren't in Stormwind, go there to get the starting quest.|FACTION|Alliance|
 C Shadowlands: A Chilling Summons|QID|60545|M|76.70,42.75|Z|Stormwind City|QO|1|CHAT|N|Speak with High Inquisitor Whitemane and she will open a gate.|FACTION|Alliance|
 C Shadowlands: A Chilling Summons|QID|60545|M|77.08,42.08|Z|Stormwind City|QO|2|NC|N|Enter the Death gate to Acherus.|FACTION|Alliance|
 C Shadowlands: A Chilling Summons|QID|60545^61874|M|59.78,19.86|Z|Lower Acherus@Icecrown Citadel!Dungeon1681|QO|3|NC|N|Run toward Icecrown Citadel and stand on the teleporter to the Frozen Throne.|


### PR DESCRIPTION
Removed more Autoswitch

Fixed som IZ tags. Stormwind using -84 because the zone is littered with inconsistancies and it doesn't work right in all places.