### PR TITLE
(no coordinates) bug fix in WoWPro_Broker.lua

### DIFF
--- a/WoWPro/WoWPro_Broker.lua
+++ b/WoWPro/WoWPro_Broker.lua
@@ -965,9 +965,10 @@ function WoWPro:RowUpdate(offset)
             if zone then
                 note = note .. "@" ..zone
             end
-        elseif not coord and action and not WoWPro.Guides[GID].NoCoordsOK then
+        elseif WoWProDB.profile.showcoords and not coord and action then
             -- No coordinates, let them know!
-            note = note.."\n(No coordinates)"
+				note = note.." (No coordinates)"
+
         end
 
         currentRow.note:SetText(note)


### PR DESCRIPTION
fixed text for (No coordinates) showing when user has show coordinates turned off in config 
also changed formatting of (No coordinates) to not start on newline due to adding two lines when no note is present.