### PR TITLE
Update CLASSIC_BC_Blood_Elf.lua

### DIFF
--- a/WoWPro_Leveling/Classic_BC/Horde/CLASSIC_BC_Blood_Elf.lua
+++ b/WoWPro_Leveling/Classic_BC/Horde/CLASSIC_BC_Blood_Elf.lua
@@ -1,6 +1,5 @@
 local guide = WoWPro:RegisterGuide('BC-BloodElf', 'Leveling', 'Eversong Woods', 'Kraevac', 'Horde', 2)
 WoWPro:GuideLevels(guide, 1, 10)
-WoWPro:GuideRaceSpecific(guide, BloodElf)
 WoWPro:GuideSort(guide, 2)
 WoWPro:GuideNickname(guide, "Blood Elf: Intro")
 WoWPro:GuideName(guide,"Blood Elf: Intro")
@@ -8,275 +7,273 @@ WoWPro:GuideNextGuide(guide, 'CLASSIC_BC_Silverpine_Forest')
 WoWPro:GuideSteps(guide, function()
 return [[
 ; Sunstrider Isle starting zone is for BloodElf's only.
-A Reclaiming Sunstrider Isle|QID|8325|M|38.21,20.83|N|From Magistrix Erona.|
-K Mana Wyrm|ACTIVE|8325|M|34.84,19.97|QO|1|N|Behind you then down the big stairs, you should see plenty of Mana Wyrms.|
-L Level 2|QID|8326|N|You'll want to be within 5 bubbles of level 2 before you return.\nContinue killing Mana Wyrms until you are.|LVL|1;-100|
-T Reclaiming Sunstrider Isle|QID|8325|M|38.21,20.83|N|To Magistrix Erona.|
-A Unfortunate Measures|QID|8326|M|38.21,20.83|N|From Magistrix Erona.|
+A Reclaiming Sunstrider Isle|QID|8325|M|38.21,20.83|N|From Magistrix Erona.|R|BloodElf|
+K Mana Wyrm|ACTIVE|8325|M|34.84,19.97|QO|1|N|Behind you then down the big stairs, you should see plenty of Mana Wyrms.|R|BloodElf|
+L Level 2|AVAILABLE|8326|N|You'll want to be within 5 bubbles of level 2 before you return.\nContinue killing Mana Wyrms until you are.|LVL|1;-100|R|BloodElf|
+T Reclaiming Sunstrider Isle|QID|8325|M|38.21,20.83|N|To Magistrix Erona.|R|BloodElf|
+A Unfortunate Measures|QID|8326|M|38.21,20.83|N|From Magistrix Erona.|R|BloodElf|
 ; -- Class quests
-A Mage Training|QID|8328|M|38.21,20.83|N|From Magistrix Erona.|PRE|8325|C|Mage|
-A Warrior Training|QID|8329|M|38.21,20.83|N|From Magistrix Erona.|PRE|8325|C|Warrior|
-A Warlock Training|QID|8563|M|38.21,20.83|N|From Magistrix Erona.|PRE|8325|C|Warlock|
-A Priest Training|QID|8564|M|38.21,20.83|N|From Magistrix Erona.|PRE|8325|C|Priest|
-A Rogue Training|QID|9392|M|38.21,20.83|N|From Magistrix Erona.|PRE|8325|C|Rogue|
-A Hunter Training|QID|9393|M|38.21,20.83|N|From Magistrix Erona.|PRE|8325|C|Hunter|
-A Paladin Training|QID|9676|M|38.21,20.83|N|From Magistrix Erona.|PRE|8325|C|Paladin|
-T Mage Training|QID|8328|M|39.23,21.45|N|To Julia Sunstriker, inside the building.|C|Mage|
-T Warrior Training|QID|8329|M|39.29,20.10|N|To Delios Silverblade, inside the building.|C|Warrior|
-T Warlock Training|QID|8563|M|38.93,21.44|N|Summoner Teli'Larien, inside the building.|C|Warlock|
-T Priest Training|QID|8564|M|39.42,20.38|N|To Matron Arena, inside the building.|C|Priest|
-T Rogue Training|QID|9392|M|38.93,20.02|N|To Pathstalker Kariel, inside the building.|C|Rogue|
-T Hunter Training|QID|9393|M|39.05,20.01|N|To Ranger Sallina, inside the building.|C|Hunter|
-T Paladin Training|QID|9676|M|39.48,20.56|N|To Jesthenis Sunstriker, inside the building.|C|Paladin|
+A Mage Training|QID|8328|M|38.21,20.83|N|From Magistrix Erona.|PRE|8325|R|BloodElf|C|Mage|
+A Warrior Training|QID|8329|M|38.21,20.83|N|From Magistrix Erona.|PRE|8325|R|BloodElf|C|Warrior|
+A Warlock Training|QID|8563|M|38.21,20.83|N|From Magistrix Erona.|PRE|8325|R|BloodElf|C|Warlock|
+A Priest Training|QID|8564|M|38.21,20.83|N|From Magistrix Erona.|PRE|8325|R|BloodElf|C|Priest|
+A Rogue Training|QID|9392|M|38.21,20.83|N|From Magistrix Erona.|PRE|8325|R|BloodElf|C|Rogue|
+A Hunter Training|QID|9393|M|38.21,20.83|N|From Magistrix Erona.|PRE|8325|R|BloodElf|C|Hunter|
+A Paladin Training|QID|9676|M|38.21,20.83|N|From Magistrix Erona.|PRE|8325|R|BloodElf|C|Paladin|
+T Mage Training|QID|8328|M|39.23,21.45|N|To Julia Sunstriker, inside the building.|R|BloodElf|C|Mage|
+T Warrior Training|QID|8329|M|39.29,20.10|N|To Delios Silverblade, inside the building.|R|BloodElf|C|Warrior|
+T Warlock Training|QID|8563|M|38.93,21.44|N|Summoner Teli'Larien, inside the building.|R|BloodElf|C|Warlock|
+T Priest Training|QID|8564|M|39.42,20.38|N|To Matron Arena, inside the building.|R|BloodElf|C|Priest|
+T Rogue Training|QID|9392|M|38.93,20.02|N|To Pathstalker Kariel, inside the building.|R|BloodElf|C|Rogue|
+T Hunter Training|QID|9393|M|39.05,20.01|N|To Ranger Sallina, inside the building.|R|BloodElf|C|Hunter|
+T Paladin Training|QID|9676|M|39.48,20.56|N|To Jesthenis Sunstriker, inside the building.|R|BloodElf|C|Paladin|
 ; --
-A Well Watcher Solanian|QID|10068^10069^10070^10071^10072|N|From your Class Trainer.|LEAD|8330|PRE|8328^8329^8563^8564^9392^9393^9676|
-T Well Watcher Solanian|QID|10068^10069^10070^10071^10072|M|38.76,19.36|N|To Well Watcher Solanian, outside on the balcony at the top of the ramp.|
-A Solanian's Belongings|QID|8330|M|38.76,19.36|N|From Well Watcher Solanian.|
-A The Shrine of Dath'Remar|QID|8345|M|38.76,19.36|N|From Well Watcher Solanian.|
-A A Fistful of Slivers|QID|8336|M|38.28,19.13|N|From Arcanist Ithanas, on the patio below you. You can jump down from the balcony.|
-A Thirst Unending|QID|8346|M|37.18,18.95|N|From Arcanist Helion. You can see him on the patio directly opposite from your current position.|
-R Empty your bags|ACTIVE|8346|M|37.14,19.03|N|Empty your bags and repair before venturing further.\n[color=FF0000]NOTE: [/color]Jainthess Thelryn, standing beside you, can help you with that.|
+A Well Watcher Solanian|QID|10068^10069^10070^10071^10072|N|From your Class Trainer.|LEAD|8330|PRE|8328^8329^8563^8564^9392^9393^9676|R|BloodElf|
+T Well Watcher Solanian|QID|10068^10069^10070^10071^10072|M|38.76,19.36|N|To Well Watcher Solanian, outside on the balcony at the top of the ramp.|R|BloodElf|
+A Solanian's Belongings|QID|8330|M|38.76,19.36|N|From Well Watcher Solanian.|R|BloodElf|
+A The Shrine of Dath'Remar|QID|8345|M|38.76,19.36|N|From Well Watcher Solanian.|R|BloodElf|
+A A Fistful of Slivers|QID|8336|M|38.28,19.13|N|From Arcanist Ithanas, on the patio below you. You can jump down from the balcony.|R|BloodElf|
+A Thirst Unending|QID|8346|M|37.18,18.95|N|From Arcanist Helion. You can see him on the patio directly opposite from your current position.|R|BloodElf|
+R Empty your bags|ACTIVE|8346|M|37.14,19.03|N|Empty your bags and repair before venturing further.\n[color=FF0000]NOTE: [/color]Jainthess Thelryn, standing beside you, can help you with that.|R|BloodElf|
 
-C Unfortunate Measures|QID|8326|M|54.82,54.34|L|20797 8|N|Kill Springpaw Lynxes and Cubs to collect the Lynx Collars.\n[color=FF0000]NOTE: [/color]Lynxes drop multiples and Cubs only drop one at a time.|S|
-C A Fistful of Slivers|QID|8336|M|35.39,20.24|L|20482 6|N|Kill Mana Wyrms to collect the Arcane Slivers.\n[color=FF0000]NOTE: [/color]Any creature that uses mana can drop them; Mana Wyrms are easier and more convenient.|S|
-C Thirst Unending|QID|8346|M|35.39,20.24|N|Use Arcane Torrent when you are within 8 yards of a Mana Wyrm.\n[color=FF0000]NOTE: [/color]Arcane Torrent has a 2 minute cooldown.\nThis works on ANY creature that uses mana.|
-C Solanian's Belongings|QID|8330|M|60.06,57.11|QO|3|N|Pick up Solanian's Journal, near the big green crystal.|
-C Unfortunate Measures|QID|8326|M|54.82,54.34|N|Finish collecting the Lynx collars.|US|
-T Thirst Unending|QID|8346|N|To Arcanist Helion.|M|37.20,18.95|
-R Empty your bags|QID|8326|N|Don't forget to repair and empty your bags.|
-T Unfortunate Measures|QID|8326|M|38.21,20.83|N|To Magistrix Erona.|
+C Unfortunate Measures|QID|8326|M|54.82,54.34|L|20797 8|N|Kill Springpaw Lynxes and Cubs to collect the Lynx Collars.\n[color=FF0000]NOTE: [/color]Lynxes drop multiples and Cubs only drop one at a time.|R|BloodElf|S|
+C A Fistful of Slivers|QID|8336|M|35.39,20.24|L|20482 6|N|Kill Mana Wyrms to collect the Arcane Slivers.\n[color=FF0000]NOTE: [/color]Any creature that uses mana can drop them; Mana Wyrms are easier and more convenient.|R|BloodElf|S|
+C Thirst Unending|QID|8346|M|35.39,20.24|N|Use Arcane Torrent when you are within 8 yards of a Mana Wyrm.\n[color=FF0000]NOTE: [/color]Arcane Torrent has a 2 minute cooldown.\nThis works on ANY creature that uses mana.|R|BloodElf|
+l Solanian's Belongings|QID|8330|M|60.06,57.11|L|20472|N|Pick up Solanian's Journal, near the big green crystal.|R|BloodElf|
+C Unfortunate Measures|QID|8326|M|54.82,54.34|N|Finish collecting the Lynx collars.|R|BloodElf|US|
 
-L Level 3|LVL|3|N|You need to be Level 3 to continue this guide.|QID|8327|
+L Level 3|AVAILABLE|8327|N|You need to be Level 3 to continue this guide.|LVL|3|R|BloodElf|
+T Thirst Unending|QID|8346|M|37.20,18.95|N|To Arcanist Helion.|R|BloodElf|
+R Empty your bags|ACTIVE|8326|N|Don't forget to repair and empty your bags.|R|BloodElf|
+T Unfortunate Measures|QID|8326|M|38.21,20.83|N|To Magistrix Erona.|R|BloodElf|
+A Report to Lanthan Perilon|QID|8327|M|61.59,44.49|N|From Magistrix Erona.|R|BloodElf|
+A Charge!|QID|27091|M|64.98,42.34|N|From Delios Silverblade.|R|BloodElf|C|Warrior|
+C Charge!|QID|27091|M|62.00,44.00|N|Learn charge from your trainer and Charge the target dummy.|R|BloodElf|C|Warrior|
+T Charge!|QID|27091|M|64.98,42.34|N|To Delios Silverblade.|R|BloodElf|C|Warrior|
+A Steady Shot|QID|10070|M|64.06,42.03|N|From Ranger Sallina.|R|BloodElf|C|Hunter|
+C Steady Shot|QID|10070|M|62.00,44.00|N|Learn Steady Shot from Ranger Sallina. Locate a Training Dummy outside the Sunspire and practice using Steady Shot 5 times.|R|BloodElf|C|Hunter|
+T Steady Shot|QID|10070|M|64.06,42.03|N|To Ranger Sallina.|R|BloodElf|C|Hunter|
+A Arcane Missiles|QID|10068|M|64.67,46.65|N|From Julia Sunstriker.|R|BloodElf|C|Mage|
+C Arcane Missiles|QID|10068|M|62.00,44.00|N|Learn Arcane Missiles from Julia Sunstriker. Locate a Training Dummy outside the Sunspire and practice using Arcane Missiles 2 times.|R|BloodElf|C|Mage|
+T Arcane Missiles|QID|10068|M|64.67,46.65|N|To Julia Sunstriker.|R|BloodElf|C|Mage|
+A Ways of the Light|QID|10069|M|65.60,43.88|N|From Jesthenis Sunstriker.|R|BloodElf|C|Paladin|
+C Ways of the Light|QID|10069|M|62.00,44.00|N|Learn Judgement and Seal of Righteousness from Jesthenis Sunstriker. Cast Seal of Righteousness on yourself, then locate a Training Dummy outside the Sunspire and use Judgement.|R|BloodElf|C|Paladin|
+T Ways of the Light|QID|10069|M|65.60,43.88|N|To Jesthenis Sunstriker.|R|BloodElf|C|Paladin|
+A Evisceration|QID|10071|M|63.75,42.03|N|From Pathstalker Kariel.|R|BloodElf|C|Rogue|
+C Evisceration|QID|10071|M|62.00,44.00|N|Learn Eviscerate from Pathstalker Kariel. Locate a Training Dummy outside the Sunspire and practice using Eviscerate 3 times.|R|BloodElf|C|Rogue|
+T Evisceration|QID|10071|M|63.75,42.03|N|To Pathstalker Kariel.|R|BloodElf|C|Rogue|
+A Learning the Word|QID|10072|M|65.29,43.26|N|From Matron Arena.|R|BloodElf|C|Priest|
+C Learning the Word|QID|10072|M|134.64,115.87|N|Locate a Training Dummy outside the Sunspire and practice using Shadow Word: Pain 5 times.|R|BloodElf|C|Priest|
+T Learning the Word|QID|10072|M|65.29,43.26|N|To Matron Arena|R|BloodElf|C|Priest|
+A Immolation|QID|10073|M|63.75,46.34|N|From Summoner Teli'Larien|R|BloodElf|C|Warlock|
+C Immolation|QID|10073|M|62.00,44.00|N|Learn Immolate from Summoner Teli'Larien. Locate a Training Dummy outside the Sunspire and practice casting Immolate 5 times.|R|BloodElf|C|Warlock|
+T Immolation|QID|10073|M|63.75,46.34|N|To Summoner Teli'Larien|R|BloodElf|C|Warlock|
+T Report to Lanthan Perilon|QID|8327|M|35.4,22.5|N|To Lanthan Perilon.|R|BloodElf|
 
-A Report to Lanthan Perilon|QID|8327|M|61.59,44.49|N|From Magistrix Erona.|
-A Charge!|QID|27091|M|64.98,42.34|C|Warrior|N|From Delios Silverblade.|
-C Charge!|QID|27091|M|62.00,44.00||C|Warrior|N|Learn charge from your trainer and Charge the target dummy.|
-T Charge!|QID|27091|M|64.98,42.34|C|Warrior|N|To Delios Silverblade.|
-A Steady Shot|QID|10070|M|64.06,42.03|C|Hunter|N|From Ranger Sallina.|
-C Steady Shot|QID|10070|M|62.00,44.00|C|Hunter|N|Learn Steady Shot from Ranger Sallina. Locate a Training Dummy outside the Sunspire and practice using Steady Shot 5 times.|
-T Steady Shot|QID|10070|M|64.06,42.03|C|Hunter|N|To Ranger Sallina.|
-A Arcane Missiles|QID|10068|M|64.67,46.65|C|Mage|N|From Julia Sunstriker.|
-C Arcane Missiles|QID|10068|M|62.00,44.00|C|Mage|N|Learn Arcane Missiles from Julia Sunstriker. Locate a Training Dummy outside the Sunspire and practice using Arcane Missiles 2 times.|
-T Arcane Missiles|QID|10068|M|64.67,46.65|C|Mage|N|To Julia Sunstriker.|
-A Ways of the Light|QID|10069|M|65.60,43.88|C|Paladin|N|From Jesthenis Sunstriker.|
-C Ways of the Light|QID|10069|M|62.00,44.00|C|Paladin|N|Learn Judgement and Seal of Righteousness from Jesthenis Sunstriker. Cast Seal of Righteousness on yourself, then locate a Training Dummy outside the Sunspire and use Judgement.|
-T Ways of the Light|QID|10069|M|65.60,43.88|C|Paladin|N|To Jesthenis Sunstriker.|
-A Evisceration|QID|10071|M|63.75,42.03|C|Rogue|N|From Pathstalker Kariel.|
-C Evisceration|QID|10071|M|62.00,44.00|C|Rogue|N|Learn Eviscerate from Pathstalker Kariel. Locate a Training Dummy outside the Sunspire and practice using Eviscerate 3 times.|
-T Evisceration|QID|10071|M|63.75,42.03|C|Rogue|N|To Pathstalker Kariel.|
-A Learning the Word|QID|10072|M|65.29,43.26|C|Priest|N|From Matron Arena.|
-C Learning the Word|QID|10072|M|134.64,115.87|C|Priest|N|Locate a Training Dummy outside the Sunspire and practice using Shadow Word: Pain 5 times.|
-T Learning the Word|QID|10072|M|65.29,43.26|C|Priest|N|To Matron Arena|
-A Immolation|QID|10073|M|63.75,46.34|C|Warlock|N|From Summoner Teli'Larien|
-C Immolation|QID|10073|M|62.00,44.00|C|Warlock|N|Learn Immolate from Summoner Teli'Larien. Locate a Training Dummy outside the Sunspire and practice casting Immolate 5 times.|
-T Immolation|QID|10073|M|63.75,46.34|C|Warlock|N|To Summoner Teli'Larien|
-T Report to Lanthan Perilon|QID|8327|N|To Lanthan Perilon.|M|35.4,22.5|
+A Aggression|QID|8334|M|35.4,22.5|N|From Lanthan Perilon.|R|BloodElf|
+C Aggression|QID|8334|N|Kill any Tender and Feral Tender you see.|R|BloodElf|S|
+l Solanian's Scrying Orb|ACTIVE|8330|M|52.15,69.46|L|20470|N|Pick up Solanian's Scrying Orb from the lake's platform, to the south of Sunstrider Isle.|R|BloodElf|
+l Solanian's Belongings|ACTIVE|8330|M|40.48,50.50|L|20471|N|Pick up the Scroll of Scourge Magic, which is northwest.|R|BloodElf|
+C The Shrine of Dath'Remar|QID|8345|M|35.43,40.49|N|Go to the far north-west of the island until you reach the Shrine of Dath'Remar. Click on it to read the plaque.|R|BloodElf|NC|
+C Aggression|QID|8334|N|Finish killing the Feral Tenders and Tenders you need.|R|BloodElf|US|
+C A Fistful of Slivers|QID|8336|M|59.44,54.04|N|As you head back to the Sunspire, finish collecting the Slivers from the Mana Wyrms and Feral Tenders|R|BloodElf|US|
+T The Shrine of Dath'Remar|QID|8345|M|38.96,20.27|N|To Well Watcher Solanian, inside The Sunspire, up the ramp.|R|BloodElf|
+T Solanian's Belongings|QID|8330|M|38.96,20.27|N|To Well Watcher Solanian.|R|BloodElf|
+T A Fistful of Slivers|QID|8336|M|38.3,19.1|N|To Arcanist Ithanas.|R|BloodElf|
+T Aggression|QID|8334|M|52.98,49.73|N|To Lanthan Perilon.|R|BloodElf|
 
-A Aggression|QID|8334|N|From Lanthan Perilon.|M|35.4,22.5|
-C Aggression|QID|8334|S|N|Kill any Tender and Feral Tender you see.|
-C Solanian's Scrying Orb|QID|8330|N|Get Solanian's Scrying Orb from the lake's platform, to the south of Sunstrider Isle.|M|52.15,69.46|QO|Solanian's Scrying Orb: 1/1|NC|
-C Solanian's Belongings|QID|8330|N|Get the Scroll of Scourge Magic, which is northwest.|M|40.48,50.50|NC|QO|Scroll of Scourge Magic: 1/1|
-C The Shrine of Dath'Remar|QID|8345|N|Go to the far north-west of the island until you reach the Shrine of Dath'Remar. Click on it to read the plaque.|M|35.43,40.49|NC|
-C Aggression|QID|8334|US|N|Finish killing the Feral Tenders and Tenders you need.|
-C A Fistful of Slivers|QID|8336|N|As you head back to the Sunspire, finish collecting the Slivers from the Mana Wyrms and Feral Tenders|M|59.44,54.04|US|
-T The Shrine of Dath'Remar|QID|8345|N|To Well Watcher Solanian, inside The Sunspire, up the ramp.|M|38.96,20.27|
-T Solanian's Belongings|QID|8330|N|To Well Watcher Solanian.|M|38.96,20.27|
-T A Fistful of Slivers|QID|8336|N|To Arcanist Ithanas.|M|38.3,19.1|
-T Aggression|QID|8334|M|52.98,49.73|N|To Lanthan Perilon.|
+A Felendren the Banished|QID|8335|M|35.4,22.5|N|From Lanthan Perilon.|R|BloodElf|
+K Felendren the Banished|ACTIVE|8335|M|39.03,63.98|QO|1|N|Kill Arcane Wraiths|R|BloodElf|S|
+C Tainted Arcane Sliver|QID|8338|L|20483|N|Kill and loot a Tainted Arcane Wraith, it will drop a Tainted Arcane Sliver.|R|BloodElf|S|
+K Felendren the Banished|QID|8335|M|41.56,61.85;38.05,66.35|CC|L|20799|N|Go up the ramp and to the top of Falthrien Academy. At the first waypoint, there will be two paths to choose, both will merge further on, so either can be taken. At the top, kill Felendren and loot his head.|R|BloodElf|
+C Tainted Arcane Sliver|QID|8338|L|20483|N|Kill and loot the Tainted Arcane Wraiths until they drop the Tainted Arcane Sliver.|R|BloodElf|US|
+A Tainted Arcane Sliver|QID|8338|N|Click on the Tainted Arcane Sliver to start the quest.|U|20483|R|BloodElf|
+C Felendren the Banished|QID|8335|M|39.03,63.98|N|Kill another Tainted Arcane Wraith|R|BloodElf|
+C Felendren the Banished|QID|8335|M|39.03,63.98|N|Finish killing the Arcane Wraiths|R|BloodElf|US|
+L Level 4|QID|8347|LVL|4|N|You need to be Level 4 to continue this guide.|R|BloodElf|
+H Sunstrider Isle|ACTIVE|8338|M|37.75,21.10|N|Run back if your Hearth is on cooldown.|R|BloodElf|
+T Tainted Arcane Sliver|QID|8338|M|37.2,18.9|N|To Arcanist Helion.|R|BloodElf|
+r Repair/Sell|ACTIVE|8335|M|58.46,38.95|N|Repair and sell unwanted loot to Jainthess Thelryn.\nClose this step to continue.|RANK|3|R|BloodElf|
+T Felendren the Banished|QID|8335|M|35.4,22.5|N|To Lanthan Perilon.|R|BloodElf|
 
-A Felendren the Banished|QID|8335|N|From Lanthan Perilon.|M|35.4,22.5|
-C Felendren the Banished|QID|8335|N|Kill Arcane Wraiths|M|39.03,63.98|S|QO|Arcane Wraith slain: 8/8|
-l Tainted Arcane Sliver|S|QID|8338|L|20483|N|Kill and loot a Tainted Arcane Wraith, it will drop a Tainted Arcane Sliver.|
-K Felendren the Banished|QID|8335|N|Go up the ramp and to the top of Falthrien Academy. At the first waypoint there will be two paths to choose, both will merge further on, so either can be taken. At the top, kill Felendren and loot his head.|M|41.56,61.85;38.05,66.35|L|20799|CC|
-l Tainted Arcane Sliver|US|QID|8338|L|20483|N|Kill and loot the Tainted Arcane Wraiths until they drop the Tainted Arcane Sliver.|
-A Tainted Arcane Sliver|QID|8338|U|20483|N|The Tainted Arcane Sliver starts a quest - click it and accept the quest.|
-C Felendren the Banished|QID|8335|N|Kill another Tainted Arcane Wraith|M|39.03,63.98|QO|Tainted Arcane Wraith slain: 2/2|
-C Felendren the Banished|QID|8335|N|Finish killing the Arcane Wraiths|M|39.03,63.98|US|QO|Arcane Wraith slain: 8/8|
-H Sunstrider Isle|QID|8338|U|6948|N|Hearthstone back to the starting point, or run back.|M|37.75,21.10|
-T Tainted Arcane Sliver|QID|8338|N|To Arcanist Helion.|M|37.2,18.9|
-r Repair/Sell|QID|8335|M|58.46,38.95|N|Good opportunity to sell unwanted loot with Jainthess Thelryn.\nClose this step to continue.|RANK|3|
-T Felendren the Banished|QID|8335|N|To Lanthan Perilon.|M|35.4,22.5|
-
-L Level 4|QID|8347|LVL|4|N|You need to be Level 4 to continue this guide.|
-
-A Aiding the Outrunners|QID|8347|N|From Lanthan Perilon.|M|35.4,22.5|
-T Aiding the Outrunners|QID|8347|N|To Outrunner Alarion.|M|40.4,32.2|
-A Slain by the Wretched|QID|9704|N|From Outrunner Alarion.|M|68.37,79.58|
+A Aiding the Outrunners|QID|8347|M|35.4,22.5|N|From Lanthan Perilon.|R|BloodElf|
+T Aiding the Outrunners|QID|8347|M|40.4,32.2|N|To Outrunner Alarion.|R|BloodElf|
+A Slain by the Wretched|QID|9704|M|68.37,79.58|N|From Outrunner Alarion.|R|BloodElf|
 ;The guide continues at this point for all races
-R Eversong Woods|QID|9704|N|Head to to the Ruins of Silvermoon in Eversong Woods. From Thunderbluff, fly to Orgrimmar. From Orgrimmar, use the Zeppelin at the Eastern Tower to get to Tirisfal Glades. From Tirisfal Glades/Undercity, use the Orb of Translocation at the Ruins of Lordaeron (54.84,11.22 a room to the west as you enter Undercity from Tirisfal Glades). From Silvermoon City, head out of the city (head south-east/south, the exit is at the south end of the Walk of Elders)|M|56.95,49.60|Z|Eversong Woods|
-F Falconwing Square|QID|9704|Z|Eversong Woods|M|54.37,50.73|N|Head west to Skymistress Gloaming, then take a ride to Falconwing Square.|R|Goblin;Tauren;Orc;Troll;Forsaken;Pandaren|
-T Slain by the Wretched|QID|9704|N|To Slain Outrunner.|Z|Eversong Woods|M|42.0,35.7|
-A Package Recovery|QID|9705|PRE|9704|N|From Slain Outrunner.|Z|Eversong Woods|M|42.0,35.7|
-T Package Recovery|QID|9705|N|To Outrunner Alarion.|Z|Eversong Woods|M|40.4,32.2|
-A Completing the Delivery|QID|8350|PRE|9705|N|From Outrunner Alarion.|Z|Eversong Woods|M|40.4,32.2|
-f Falconwing Square|QID|8350|Z|Eversong Woods|M|46.24,46.80|N|Get the flightpoint from Skymaster Skyles.|
-T Completing the Delivery|QID|8350|N|To Innkeeper Delaniel.|Z|Eversong Woods|M|48.1,47.7|
-h Falconwing Inn|QID|8472|N|Set your hearthstone to Falconwing Square with Innkeeper Delaniel.|Z|Eversong Woods|M|48.1,47.7|
-N Professions|QID|8472|N|If you plan on learning any professions, now's the time. Saren will teach all Primary and Secondary professions, he can be found upstairs. You can also learn Cooking from Quarelestra nearby.  \n\nClick this step to continue.|Z|Eversong Woods|M|48.93,46.86|
-A Unstable Mana Crystals|QID|8463|N|From Aeldon Sunbrand, back outside of the inn.|Z|Eversong Woods|M|48.2,46.0|
-A WANTED: Thaelis the Hungerer|QID|8468|N|From 'Wanted: Thaelis the Hungerer' signpost.|Z|Eversong Woods|M|48.2,46.3|
-A Major Malfunction|QID|8472|N|From Magister Jaronis.|Z|Eversong Woods|M|47.3,46.3|
-C Major Malfunction|QID|8472|N|Kill and loot Arcane Patrollers for the Arcane Cores.|Z|Eversong Woods|M|45.,40.5|S|
-C Unstable Mana Crystals|QID|8463|S|N|Look for light beams that come out of the boxes.|Z|Eversong Woods|M|45.386,42|NC|
-C Thaelis the Hungerer|QID|8468|T|Thaelis the Hungerer|N|Kill and loot Thaelis the Hungerer.\n\nBe careful to pull all the Wretched Urchins around him first before attacking.|Z|Eversong Woods|M|45.00,38.40|
-C Unstable Mana Crystals|QID|8463|Z|Eversong Woods|M|45.38,40.85|US|N|Look for light beams that come out of the boxes.|NC|
-C Major Malfunction|QID|8472|N|Finish killing and looting Arcane Patrollers for the Arcane Cores.|Z|Eversong Woods|M|45,40.5|US|
-T Major Malfunction|QID|8472|N|To Magister Jaronis.|Z|Eversong Woods|M|47.3,46.3|
-A Delivery to the North Sanctum|QID|8895|PRE|8472|N|From Magister Jaronis.|Z|Eversong Woods|M|47.3,46.3|
-T WANTED: Thaelis the Hungerer|QID|8468|N|To Sergeant Kan'ren.|Z|Eversong Woods|M|47.8,46.6|
-T Unstable Mana Crystals|QID|8463|N|To Aeldon Sunbrand.|Z|Eversong Woods|M|48.2,46.0|
-A Darnassian Intrusions|QID|9352|PRE|8463|N|From Aeldon Sunbrand.|Z|Eversong Woods|M|48.2,46.0|
-T Delivery to the North Sanctum|QID|8895|N|To Ley-Keeper Caidanis.|Z|Eversong Woods|M|44.6,53.1|
-A Malfunction at the West Sanctum|QID|9119|PRE|8895|N|From Ley-Keeper Caidanis.|Z|Eversong Woods|M|44.6,53.1|
-T Malfunction at the West Sanctum|QID|9119|N|To Ley-Keeper Velania.|Z|Eversong Woods|M|36.7,57.4|
-A Arcane Instability|QID|8486|PRE|9119|N|From Ley-Keeper Velania|Z|Eversong Woods|M|36.7,57.4|
-C Arcane Instability|QID|8486|N|Kill the Manawraith and Mana Stalker located around the West Sanctum.|Z|Eversong Woods|M|36,58|S|
-K Darnassian Scout|QID|9352|L|20765|N|Kill a Darnassian Scout and loot Incriminating Documents.|Z|Eversong Woods|M|34.50,60.00|
-A Incriminating Documents|QID|8482|U|20765|N|Quest starts from the Incriminating Documents. Click the envelope.|Z|Eversong Woods|M|33.9,58.4|
-C Arcane Instability|QID|8486|N|Finish killing the Manawraith and Mana Stalker located around the West Sanctum.|Z|Eversong Woods|M|36,58|US|
-T Darnassian Intrusions|QID|9352|N|To Ley-Keeper Velania.|Z|Eversong Woods|M|36.7,57.4|
-T Arcane Instability|QID|8486|N|To Ley-Keeper Velania.|Z|Eversong Woods|M|36.7,57.4|
-A Fish Heads, Fish Heads...|QID|8884|N|From Hathvelion Sungaze. Go around the northside of the mountain.|Z|Eversong Woods|M|31.49,53.78;30.20,58.37|CC|
-C Fish Heads, Fish Heads...|QID|8884|N|Kill murlocs for the 8 fish heads.|Z|Eversong Woods|M|27,59.5|
-l Captain Kelisendra's Lost Rutters|QID|8887|L|21776|N|Keep killing murlocs until one of them drops Captain Kelisendra's Lost Rutters.|Z|Eversong Woods|M|27,59.5|
-A Captain Kelisendra's Lost Rutters|QID|8887|U|21776|N|From Captain Kelisendra's Lost Rutters.|
-T Fish Heads, Fish Heads...|QID|8884|N|To Hathvelion Sungaze.|Z|Eversong Woods|M|29.89,58.52|
-A The Ring of Mmmrrrggglll|QID|8885|PRE|8884|N|From Hathvelion Sungaze.|Z|Eversong Woods|M|29.89,58.52|
-H Falconwing Square|QID|8482|U|6948|N|Hearth to Falconwing Square.|
-T Incriminating Documents|QID|8482|N|To Aeldon Sunbrand.|Z|Eversong Woods|M|48.2,46.0|
-A The Dwarven Spy|QID|8483|PRE|8482|N|From Aeldon Sunbrand.|Z|Eversong Woods|M|48.2,46.0|
-C The Dwarven Spy|QID|8483|L|20764|CHAT|N|Speak to Prospector Anvilward. He will walk into the North Sanctum, when he is at the top, he will attack you. Be sure to be full health and buffed before you talk to him. Once you kill him, loot his head.|Z|Eversong Woods|M|44.60,53.30|
-A Roadside Ambush|QID|9035|LEAD|9062|N|From Apprentice Ralen.|Z|Eversong Woods|M|45.2,56.4|
-T Roadside Ambush|QID|9035|N|To Apprentice Meledor.|Z|Eversong Woods|M|44.9,61.0|
-A Soaked Pages|QID|9062|N|From Apprentice Meledor.|Z|Eversong Woods|M|44.9,61.0|
-C Soaked Pages|QID|9062|L|22414|N|Dive under the bridge just in front of you, the Soaked Pages are in the river.|Z|Eversong Woods|M|44.40,61.90|NC|
-T Soaked Pages|QID|9062|N|To Apprentice Meledor.|Z|Eversong Woods|M|44.9,61.0|
-A Taking the Fall|QID|9064|PRE|9062|N|From Apprentice Meledor.|Z|Eversong Woods|M|44.9,61.0|
-T Taking the Fall|QID|9064|N|To Instructor Antheol.|Z|Eversong Woods|M|55.7,54.5|
-A Swift Discipline|QID|9066|PRE|9064|N|From Instructor Antheol.|Z|Eversong Woods|M|55.7,54.5|
-A Fetch!|QID|9402|N|From Instructor Antheol.|C|Mage|Z|Eversong Woods|M|55.7,54.5|
-C Fetch!|QID|9402|N|Dive into the middle of the lake. The phial is on the bottom.|C|Mage|Z|Eversong Woods|M|54.87,56.38|
-T Fetch!|QID|9402|N|To Instructor Antheol.|C|Mage|Z|Eversong Woods|M|55.7,54.5|
-A The Dead Scar|QID|8475|N|From Ranger Jaela.|Z|Eversong Woods|M|50.3,50.8|
-C Swift Discipline - Apprentice Ralen|QID|9066|U|22473|NC|N|Target Apprentice Ralen and use the rod that Anetheol gave you.|Z|Eversong Woods|M|45.20,56.40|QO|2|T|Apprentice Ralen|
-C Swift Discipline - Apprentice Meledor|QID|9066|U|22473|NC|N|Target Apprentice Meledor and use the rod that Anetheol gave you.|Z|Eversong Woods|M|44.9,61.0|QO|1|T|Apprentice Meledor|
-C The Dead Scar|QID|8475|N|Go through the Dead Scar and kill 8 Plaguebone Pillagers.\n\nBe careful of the pack of Rotlimb Cannibals and also avoid the center of the Dead Scar as both can be difficult for an in-level player to survive.|Z|Eversong Woods|M|51.2,56.3|
-T The Dead Scar|QID|8475|N|To Ranger Jaela.|Z|Eversong Woods|M|50.3,50.8|
-T Swift Discipline|QID|9066|N|To Instructor Antheol.|Z|Eversong Woods|M|55.7,54.5|
-F Falconwing Square|QID|8483|Z|Eversong Woods|M|54.37,50.73|N|Fly to Falconwing Square.|
-T The Dwarven Spy|QID|8483|N|To Aeldon Sunbrand.|Z|Eversong Woods|M|48.2,46.0|
-A Fairbreeze Village|QID|9256|LEAD|8892|PRE|8483|N|From Aeldon Sunbrand.|
-f Fairbreeze Village|QID|9256|Z|Eversong Woods|M|43.94,69.98|N|Run to Fairbreeze Village and get the flight point from Skymaster Brightdawn.|
-A Pelt Collection|QID|8491|N|From Velan Brightoak.|Z|Eversong Woods|M|44.7,69.6|
-A Saltheril's Haven|QID|9395|LEAD|9067|N|From Magistrix Landra Dawnstrider.|Z|Eversong Woods|M|44.0,70.8|
-A The Wayward Apprentice|QID|9254|LEAD|8487|N|From Magistrix Landra Dawnstrider.|Z|Eversong Woods|M|44.0,70.8|
-T Fairbreeze Village|QID|9256|N|To Ranger Degolien. Up the ramp.|Z|Eversong Woods|M|43.4,70.8|
-A Situation at Sunsail Anchorage|QID|8892|N|From Ranger Degolien|Z|Eversong Woods|M|43.3,70.8|
-A Ranger Sareyn|QID|9358|LEAD|9252|N|From Marniel Amberlight. If you've already done Defending Fairbreeze Village this quest won't be available so just skip it.|Z|Eversong Woods|M|43.7,71.2|
+R Eversong Woods|QID|9704|M|56.95,49.60|N|Head to to the Ruins of Silvermoon in Eversong Woods. From Thunderbluff, fly to Orgrimmar. From Orgrimmar, use the Zeppelin at the Eastern Tower to get to Tirisfal Glades. From Tirisfal Glades/Undercity, use the Orb of Translocation at the Ruins of Lordaeron (54.84,11.22 a room to the west as you enter Undercity from Tirisfal Glades). From Silvermoon City, head out of the city (head south-east/south, the exit is at the south end of the Walk of Elders)|
+F Falconwing Square|QID|9704|M|54.37,50.73|N|Head west to Skymistress Gloaming, then take a ride to Falconwing Square.|R|Goblin;Tauren;Orc;Troll;Forsaken;Pandaren|
+T Slain by the Wretched|QID|9704|M|42.0,35.7|N|To Slain Outrunner.|
+A Package Recovery|QID|9705|M|42.0,35.7|N|From Slain Outrunner.|PRE|9704|
+T Package Recovery|QID|9705|M|40.4,32.2|N|To Outrunner Alarion.|
+A Completing the Delivery|QID|8350|M|40.4,32.2|N|From Outrunner Alarion.|PRE|9705|
+f Falconwing Square|QID|8350|M|46.24,46.80|N|Get the flightpoint from Skymaster Skyles.|
+T Completing the Delivery|QID|8350|M|48.1,47.7|N|To Innkeeper Delaniel.|
+h Falconwing Inn|QID|8472|M|48.1,47.7|N|Set your hearthstone to Falconwing Square with Innkeeper Delaniel.|
+N Professions|QID|8472|N|If you plan on learning any professions, now's the time. Saren will teach all Primary and Secondary professions, he can be found upstairs. You can also learn Cooking from Quarelestra nearby.  \n\nClick this step to continue.|M|48.93,46.86|
+A Unstable Mana Crystals|QID|8463|M|48.2,46.0|N|From Aeldon Sunbrand, back outside of the inn.|
+A WANTED: Thaelis the Hungerer|QID|8468|M|48.2,46.3|N|From 'Wanted: Thaelis the Hungerer' signpost.|
+A Major Malfunction|QID|8472|M|47.3,46.3|N|From Magister Jaronis.|
+C Major Malfunction|QID|8472|M|45.,40.5|N|Kill and loot Arcane Patrollers for the Arcane Cores.|S|
+C Unstable Mana Crystals|QID|8463|M|45.386,42|N|Look for light beams that come out of the boxes.|S|NC|
+C Thaelis the Hungerer|QID|8468|M|45.00,38.40|N|Kill and loot Thaelis the Hungerer.\n\nBe careful to pull all the Wretched Urchins around him first before attacking.|T|Thaelis the Hungerer|
+C Unstable Mana Crystals|QID|8463|M|45.38,40.85|N|Look for light beams that come out of the boxes.|US|NC|
+C Major Malfunction|QID|8472|M|45,40.5|N|Finish killing and looting Arcane Patrollers for the Arcane Cores.|US|
+T Major Malfunction|QID|8472|M|47.3,46.3|N|To Magister Jaronis.|
+A Delivery to the North Sanctum|QID|8895|M|47.3,46.3|N|From Magister Jaronis.|PRE|8472|
+T WANTED: Thaelis the Hungerer|QID|8468|M|47.8,46.6|N|To Sergeant Kan'ren.|
+T Unstable Mana Crystals|QID|8463|M|48.2,46.0|N|To Aeldon Sunbrand.|
+A Darnassian Intrusions|QID|9352|M|48.2,46.0|N|From Aeldon Sunbrand.|PRE|8463|
+T Delivery to the North Sanctum|QID|8895|M|44.6,53.1|N|To Ley-Keeper Caidanis.|
+A Malfunction at the West Sanctum|QID|9119|M|44.6,53.1|N|From Ley-Keeper Caidanis.|PRE|8895|
+T Malfunction at the West Sanctum|QID|9119|M|36.7,57.4|N|To Ley-Keeper Velania.|
+A Arcane Instability|QID|8486|M|36.7,57.4|N|From Ley-Keeper Velania|PRE|9119|
+C Arcane Instability|QID|8486|M|36,58|N|Kill the Manawraith and Mana Stalker located around the West Sanctum.|S|
+K Darnassian Scout|QID|9352|M|34.50,60.00|L|20765|N|Kill a Darnassian Scout and loot Incriminating Documents.|
+A Incriminating Documents|QID|8482|M|33.9,58.4|N|Quest starts from the Incriminating Documents. Click the envelope.|U|20765|
+C Arcane Instability|QID|8486|M|36,58|N|Finish killing the Manawraith and Mana Stalker located around the West Sanctum.|US|
+T Darnassian Intrusions|QID|9352|M|36.7,57.4|N|To Ley-Keeper Velania.|
+T Arcane Instability|QID|8486|M|36.7,57.4|N|To Ley-Keeper Velania.|
+A Fish Heads, Fish Heads...|QID|8884|M|31.49,53.78;30.20,58.37|CC|N|From Hathvelion Sungaze. Go around the northside of the mountain.|
+C Fish Heads, Fish Heads...|QID|8884|M|27,59.5|N|Kill murlocs for the 8 fish heads.|
+l Captain Kelisendra's Lost Rutters|AVAILABLE|8887|M|27,59.5|L|21776|N|Keep killing murlocs until one of them drops Captain Kelisendra's Lost Rutters.|
+A Captain Kelisendra's Lost Rutters|QID|8887|N|From Captain Kelisendra's Lost Rutters.|U|21776|O|
+T Fish Heads, Fish Heads...|QID|8884|M|29.89,58.52|N|To Hathvelion Sungaze.|
+A The Ring of Mmmrrrggglll|QID|8885|M|29.89,58.52|N|From Hathvelion Sungaze.|PRE|8884|
+H Falconwing Square|QID|8482|N|Hearth to Falconwing Square.|
+T Incriminating Documents|QID|8482|M|48.2,46.0|N|To Aeldon Sunbrand.|
+A The Dwarven Spy|QID|8483|M|48.2,46.0|N|From Aeldon Sunbrand.|PRE|8482|
+C The Dwarven Spy|QID|8483|M|44.60,53.30|L|20764|N|Speak to Prospector Anvilward. He will walk into the North Sanctum, when he is at the top, he will attack you. Be sure to be full health and buffed before you talk to him. Once you kill him, loot his head.|CHAT|
+A Roadside Ambush|QID|9035|M|45.2,56.4|N|From Apprentice Ralen.|LEAD|9062|
+T Roadside Ambush|QID|9035|M|44.9,61.0|N|To Apprentice Meledor.|
+A Soaked Pages|QID|9062|M|44.9,61.0|N|From Apprentice Meledor.|
+C Soaked Pages|QID|9062|M|44.40,61.90|L|22414|N|Dive under the bridge just in front of you, the Soaked Pages are in the river.|NC|
+T Soaked Pages|QID|9062|M|44.9,61.0|N|To Apprentice Meledor.|
+A Taking the Fall|QID|9064|M|44.9,61.0|N|From Apprentice Meledor.|PRE|9062|
+T Taking the Fall|QID|9064|M|55.7,54.5|N|To Instructor Antheol.|
+A Swift Discipline|QID|9066|M|55.7,54.5|N|From Instructor Antheol.|PRE|9064|
+A Fetch!|QID|9402|M|55.7,54.5|N|From Instructor Antheol.|R|BloodElf|C|Mage|
+C Fetch!|QID|9402|M|54.87,56.38|N|Dive into the middle of the lake. The phial is on the bottom.|R|BloodElf|C|Mage|
+T Fetch!|QID|9402|M|55.7,54.5|N|To Instructor Antheol.|R|BloodElf|C|Mage|
+A The Dead Scar|QID|8475|M|50.3,50.8|N|From Ranger Jaela.|
+C Swift Discipline - Apprentice Ralen|QID|9066|M|45.20,56.40|QO|2|N|Target Apprentice Ralen and use the rod that Anetheol gave you.|T|Apprentice Ralen|U|22473|NC|
+C Swift Discipline - Apprentice Meledor|QID|9066|M|44.9,61.0|QO|1|N|Target Apprentice Meledor and use the rod that Anetheol gave you.|T|Apprentice Meledor|U|22473|NC|
+C The Dead Scar|QID|8475|M|51.2,56.3|N|Go through the Dead Scar and kill 8 Plaguebone Pillagers.\n\nBe careful of the pack of Rotlimb Cannibals and also avoid the center of the Dead Scar as both can be difficult for an in-level player to survive.|
+T The Dead Scar|QID|8475|M|50.3,50.8|N|To Ranger Jaela.|
+T Swift Discipline|QID|9066|M|55.7,54.5|N|To Instructor Antheol.|
+F Falconwing Square|QID|8483|M|54.37,50.73|N|Fly to Falconwing Square.|
+T The Dwarven Spy|QID|8483|M|48.2,46.0|N|To Aeldon Sunbrand.|
+A Fairbreeze Village|QID|9256|N|From Aeldon Sunbrand.|LEAD|8892|PRE|8483|
+f Fairbreeze Village|QID|9256|M|43.94,69.98|N|Run to Fairbreeze Village and get the flight point from Skymaster Brightdawn.|
+A Pelt Collection|QID|8491|M|44.7,69.6|N|From Velan Brightoak.|
+A Saltheril's Haven|QID|9395|M|44.0,70.8|N|From Magistrix Landra Dawnstrider.|LEAD|9067|
+A The Wayward Apprentice|QID|9254|M|44.0,70.8|N|From Magistrix Landra Dawnstrider.|LEAD|8487|
+T Fairbreeze Village|QID|9256|M|43.4,70.8|N|To Ranger Degolien. Up the ramp.|
+A Situation at Sunsail Anchorage|QID|8892|M|43.3,70.8|N|From Ranger Degolien|
+A Ranger Sareyn|QID|9358|M|43.7,71.2|N|From Marniel Amberlight.|LEAD|9252|
 h Fairbreeze Village|QID|9395|N|With Marniel Amberlight.|
-A Goods from Silvermoon City|QID|9130|Z|Eversong Woods|M|43.7,71.54|N|From Sathiel.|
-r Repair/Sell Junk|QID|9395|Z|Eversong Woods|M|43.7,71.54|N|At Sathiel.\n\nRight click this step to continue.|
-C Pelt Collection|QID|8491|N|Kill springpaws.|Z|Eversong Woods|M|46.00,67.00|S|
-T Saltheril's Haven|QID|9395|N|To Lord Saltheril.|Z|Eversong Woods|M|38.1,73.6|
-A The Party Never Ends|QID|9067|N|From Lord Saltheril.|Z|Eversong Woods|M|38.1,73.6|
-B Bundle of Fireworks|QID|9067|QO|3|N|Buy a Bundle of fireworks from Halis Dawnstrider at Fairbreeze Village.|Z|Eversong Woods|M|44.10,70.40|
-T Goods from Silvermoon City|QID|9130|N|To Skymaster Brightdawn.|Z|Eversong Woods|M|44,70|
-A Fly to Silvermoon City|QID|9133|PRE|9130|Z|Eversong Woods|M|44,70|N|From Skymaster Brightdawn.|
-F Silvermoon City|QID|9133|Z|Eversong Woods|M|44,70|N|Ask Skymaster Brightdawn to fly you to Silvermoon City.|
-R Silvermoon City|QID|9133|N|Run east to Silvermoon City.|M|72.37,90.93|Z|Silvermoon City|
-T Fly to Silvermoon City|QID|9133|Z|Silvermoon City|N|To Sathren Azuredawn.|M|69.26,77.04;68.28,74.08;66.50,73.43;54,71|CS|
-A Skymistress Gloaming|QID|9134|PRE|9133|M|54,71|Z|Silvermoon City|N|From Sathren Azuredawn.|
-B Suntouched Special Reserve|QID|9067|QO|1|Z|Silvermoon City|N|Buy a bottle of Suntouched Special Reserve from Vinemaster Suntouched. Also, visit your trainer if you need to.|M|79.70,58.40|
-T Skymistress Gloaming|QID|9134|Z|Eversong Woods|M|54.38,50.79|N|To Skymistress Gloaming.|
-A Return to Sathiel|QID|9135|PRE|9134|Z|Eversong Woods|M|54.38,50.79|N|From Skymistress Gloaming.|
-F Fairbreeze Village|QID|9135|Z|Eversong Woods|M|54.38,50.79|N|Fly to Fairbreeze Village, or just hearth.|
-T Return to Sathiel|QID|9135|Z|Eversong Woods|M|43.69,71.51|N|To Sathiel.|
-T Captain Kelisendra's Lost Rutters|QID|8887|N|To Captain Kelisendra. Follow the road west until you reach Sunsail Anchorage.|Z|Eversong Woods|M|36.4,66.7|
-A Grimscale Pirates!|QID|8886|N|From Captain Kelisendra.|Z|Eversong Woods|M|36.4,66.7|
-A Lost Armaments|QID|8480|N|From Velendris Whitemorn.|Z|Eversong Woods|M|36.4,66.7|
-C Grimscale Pirates!|QID|8886|N|Either pick these up from the floor, or kill and loot the murlocs.|Z|Eversong Woods|M|24.9,66.8|S|
-K Kill Mmmrrrggglll|QID|8885|QO|1|N|He roams the beach.|Z|Eversong Woods|M|25,69|T|Mmmrrrggglll|
-C Grimscale Pirates!|QID|8886|N|Either pick these up from the floor, or kill and loot the murlocs.|Z|Eversong Woods|M|24.9,66.8|US|
-T The Ring of Mmmrrrggglll|QID|8885|N|To Hathvelion Sungaze|Z|Eversong Woods|M|30.2,58.5|
-C Situation at Sunsail Anchorage|QID|8892|S|N|Kill Wretched Thugs and Hooligans.|
-C Lost Armaments|QID|8480|N|Run around the big white gazeebo looting the Weapon Containers.|Z|Eversong Woods|M|31.0,69.0|NC|
-T Grimscale Pirates!|QID|8886|N|To Captain Kelisendra. At Sunsail Anchorage.|Z|Eversong Woods|M|36.4,66.7|
-T Lost Armaments|QID|8480|N|To Velendris Whitemorn.|Z|Eversong Woods|M|36.4,66.7|
-A Wretched Ringleader|QID|9076|PRE|8480|N|From Velendris Whitemorn.|Z|Eversong Woods|M|36.4,66.7|
-K Aldaron|QID|9076|QO|1|N|Go back to the big white tower-like building and fight your way up. At the top you'll find Aldaron the Reckless with two guards. If you are careful you can probably pull the guards solo before you kill Aldras.|Z|Eversong Woods|M|32.70,68.4|
-C Situation at Sunsail Anchorage|QID|8892|S|N|Finish killing the Wretched Thugs and Hooligans.|
-T Wretched Ringleader|QID|9076|N|To Velendris Whitemorn.|Z|Eversong Woods|M|36.4,66.7|
-C Pelt Collection|QID|8491|N|Kill springpaws. They're all around Fairbreeze.|Z|Eversong Woods|M|46.00,67.00|US|
-T Pelt Collection|QID|8491|N|To Velan Brightoak.|Z|Eversong Woods|M|44.7,69.6|
-T Situation at Sunsail Anchorage|QID|8892|N|To Ranger Degolien.|Z|Eversong Woods|M|43.3,70.8|
-A Farstrider Retreat|QID|9359|LEAD|8476|PRE|8892|N|From Ranger Degolien.|Z|Eversong Woods|M|43.3,70.8|
-r Repair/Sell Junk|QID|9358|Z|Eversong Woods|M|43.7,71.54|N|At Sathiel.\n\nRight click this step to continue.|
-T Ranger Sareyn|QID|9358|N|To Ranger Sareyn.|Z|Eversong Woods|M|46.9,71.8|
-A Defending Fairbreeze Village|QID|9252|N|From Ranger Sareyn.|Z|Eversong Woods|M|46.9,71.8|
-C Defending Fairbreeze Village|QID|9252|N|4 of each: Rotlimb marauder, Darkwraith. Follow the road southeast until you hit the Dead Scar. Then head south.|Z|Eversong Woods|M|50.00,75.00|
-T The Wayward Apprentice|QID|9254|N|To Apprentice Mirveda. Go north along the Dead Scar until you reach Mivenda.|Z|Eversong Woods|M|54.3,71.0|
-A Corrupted Soil|QID|8487|N|From Apprentice Mirveda.|Z|Eversong Woods|M|54.3,71.0|
-C Corrupted Soil|QID|8487|N|Loot 8 Tainted Soil Samples, they are green looking.|Z|Eversong Woods|M|52.60,68.40|
-T Corrupted Soil|QID|8487|N|To Apprentice Mirveda.|Z|Eversong Woods|M|54.3,71.0|
-A Unexpected Results|QID|8488|PRE|8487|N|From Apprentice Mirveda. Get to full HP/Mana and take the follow up. Protect Mivenda from the Scourge Attack. Three level 7/8 mobs wills spawn and attack her. Kill them one by one as fast as possible.|Z|Eversong Woods|M|54.3,71.0|
+A Goods from Silvermoon City|QID|9130|M|43.7,71.54|N|From Sathiel.|
+r Repair/Sell Junk|QID|9395|M|43.7,71.54|N|At Sathiel.\n\nRight click this step to continue.|
+C Pelt Collection|QID|8491|M|46.00,67.00|N|Kill springpaws.|S|
+T Saltheril's Haven|QID|9395|M|38.1,73.6|N|To Lord Saltheril.|
+A The Party Never Ends|QID|9067|M|38.1,73.6|N|From Lord Saltheril.|
+B Bundle of Fireworks|QID|9067|M|44.10,70.40|QO|3|N|Buy a Bundle of fireworks from Halis Dawnstrider at Fairbreeze Village.|
+T Goods from Silvermoon City|QID|9130|M|44,70|N|To Skymaster Brightdawn.|
+A Fly to Silvermoon City|QID|9133|M|44,70|N|From Skymaster Brightdawn.|PRE|9130|
+F Silvermoon City|QID|9133|M|44,70|N|Ask Skymaster Brightdawn to fly you to Silvermoon City.|
+R Silvermoon City|QID|9133|M|72.37,90.93|Z|Silvermoon City|N|Run east to Silvermoon City.|
+T Fly to Silvermoon City|QID|9133|M|69.26,77.04;68.28,74.08;66.50,73.43;54,71|CS|Z|Silvermoon City|N|To Sathren Azuredawn.|
+A Skymistress Gloaming|QID|9134|M|54,71|Z|Silvermoon City|N|From Sathren Azuredawn.|PRE|9133|
+B Suntouched Special Reserve|QID|9067|M|79.70,58.40|Z|Silvermoon City|QO|1|N|Buy a bottle of Suntouched Special Reserve from Vinemaster Suntouched. Also, visit your trainer if you need to.|
+T Skymistress Gloaming|QID|9134|M|54.38,50.79|N|To Skymistress Gloaming.|
+A Return to Sathiel|QID|9135|M|54.38,50.79|N|From Skymistress Gloaming.|PRE|9134|
+F Fairbreeze Village|QID|9135|M|54.38,50.79|N|Fly to Fairbreeze Village, or just hearth.|
+T Return to Sathiel|QID|9135|M|43.69,71.51|N|To Sathiel.|
+T Captain Kelisendra's Lost Rutters|QID|8887|M|36.4,66.7|N|To Captain Kelisendra. Follow the road west until you reach Sunsail Anchorage.|
+A Grimscale Pirates!|QID|8886|M|36.4,66.7|N|From Captain Kelisendra.|
+A Lost Armaments|QID|8480|M|36.4,66.7|N|From Velendris Whitemorn.|
+C Grimscale Pirates!|QID|8886|M|24.9,66.8|N|Either pick these up from the floor, or kill and loot the murlocs.|S|
+K Kill Mmmrrrggglll|QID|8885|M|25,69|QO|1|N|He roams the beach.|T|Mmmrrrggglll|
+C Grimscale Pirates!|QID|8886|M|24.9,66.8|N|Either pick these up from the floor, or kill and loot the murlocs.|US|
+T The Ring of Mmmrrrggglll|QID|8885|M|30.2,58.5|N|To Hathvelion Sungaze|
+C Situation at Sunsail Anchorage|QID|8892|N|Kill Wretched Thugs and Hooligans.|S|
+C Lost Armaments|QID|8480|M|31.0,69.0|N|Run around the big white gazeebo looting the Weapon Containers.|NC|
+T Grimscale Pirates!|QID|8886|M|36.4,66.7|N|To Captain Kelisendra. At Sunsail Anchorage.|
+T Lost Armaments|QID|8480|M|36.4,66.7|N|To Velendris Whitemorn.|
+A Wretched Ringleader|QID|9076|M|36.4,66.7|N|From Velendris Whitemorn.|PRE|8480|
+K Aldaron|QID|9076|M|32.70,68.4|QO|1|N|Go back to the big white tower-like building and fight your way up. At the top you'll find Aldaron the Reckless with two guards. If you are careful you can probably pull the guards solo before you kill Aldras.|
+C Situation at Sunsail Anchorage|QID|8892|N|Finish killing the Wretched Thugs and Hooligans.|S|
+T Wretched Ringleader|QID|9076|M|36.4,66.7|N|To Velendris Whitemorn.|
+C Pelt Collection|QID|8491|M|46.00,67.00|N|Kill springpaws. They're all around Fairbreeze.|US|
+T Pelt Collection|QID|8491|M|44.7,69.6|N|To Velan Brightoak.|
+T Situation at Sunsail Anchorage|QID|8892|M|43.3,70.8|N|To Ranger Degolien.|
+A Farstrider Retreat|QID|9359|M|43.3,70.8|N|From Ranger Degolien.|LEAD|8476|PRE|8892|
+r Repair/Sell Junk|QID|9358|M|43.7,71.54|N|At Sathiel.\n\nRight click this step to continue.|
+T Ranger Sareyn|QID|9358|M|46.9,71.8|N|To Ranger Sareyn.|
+A Defending Fairbreeze Village|QID|9252|M|46.9,71.8|N|From Ranger Sareyn.|
+C Defending Fairbreeze Village|QID|9252|M|50.00,75.00|N|4 of each: Rotlimb marauder, Darkwraith. Follow the road southeast until you hit the Dead Scar. Then head south.|
+T The Wayward Apprentice|QID|9254|M|54.3,71.0|N|To Apprentice Mirveda. Go north along the Dead Scar until you reach Mivenda.|
+A Corrupted Soil|QID|8487|M|54.3,71.0|N|From Apprentice Mirveda.|
+C Corrupted Soil|QID|8487|M|52.60,68.40|N|Loot 8 Tainted Soil Samples, they are green looking.|
+T Corrupted Soil|QID|8487|M|54.3,71.0|N|To Apprentice Mirveda.|
+A Unexpected Results|QID|8488|M|54.3,71.0|N|From Apprentice Mirveda. Get to full HP/Mana and take the follow up. Protect Mivenda from the Scourge Attack. Three level 7/8 mobs wills spawn and attack her. Kill them one by one as fast as possible.|PRE|8487|
 C Unexpected Results|QID|8488|N|Protect Mirveda.|
-T Unexpected Results|QID|8488|N|To Apprentice Mirveda. You should now be level 10!|Z|Eversong Woods|M|54.3,71.0|
-A Research Notes|QID|9255|PRE|8488|N|From Apprentice Mirveda.|Z|Eversong Woods|M|54.3,71.0|
-T Farstrider Retreat|QID|9359|N|To Lieutenant Dawnrunner.|Z|Eversong Woods|M|60.3,62.8|
-A Amani Encroachment|QID|8476|N|From Lieutenant Dawnrunner.|Z|Eversong Woods|M|60.3,62.8|
-B Buy Springpaw Appetizers|QID|9067|QO|2|N|Buy Springpaw Appetizers from Zalene Firstlight at Farstrider Retreat.|Z|Eversong Woods|M|60.40,62.46|
-A The Spearcrafter's Hammer|QID|8477|N|From Arathel Sunforge.|Z|Eversong Woods|M|59.5,62.6|
-A The Magister's Apprentice|QID|8888|LEAD|8889|N|From Magister Duskwither. Up the right ramp.|Z|Eversong Woods|M|60.3,61.4|
-A The Purest Water|QID|9403|PRE|9402|N|From Instructor Antheol.|C|Mage|Z|Eversong Woods|M|55.7,54.5|
-R Thuron's Livery|QID|8888|N|If you want the explorer achievement, head to Thuron's Livery.\n\nIf you don't, just click this step.|Z|Eversong Woods|M|62.00,53.00|
-T The Magister's Apprentice|QID|8888|N|To Apprentice Loralthalis. Head out of the city and follow the road east.|Z|Eversong Woods|M|67.8,56.5|
-A Deactivating the Spire|QID|8889|N|From Apprentice Loralthalis.|Z|Eversong Woods|M|67.8,56.5|
-A Where's Wyllithen?|QID|9394|LEAD|8894|N|From Apprentice Loralthalis.|Z|Eversong Woods|M|67.8,56.5|
-T Where's Wyllithen?|QID|9394|N|To Groundskeeper Wyllithen.|Z|Eversong Woods|M|68.7,46.9|
-A Cleaning up the Grounds|QID|8894|N|From Groundskeeper Wyllithen.|Z|Eversong Woods|M|68.7,46.9|
+T Unexpected Results|QID|8488|M|54.3,71.0|N|To Apprentice Mirveda. You should now be level 10!|
+A Research Notes|QID|9255|M|54.3,71.0|N|From Apprentice Mirveda.|PRE|8488|
+T Farstrider Retreat|QID|9359|M|60.3,62.8|N|To Lieutenant Dawnrunner.|
+A Amani Encroachment|QID|8476|M|60.3,62.8|N|From Lieutenant Dawnrunner.|
+B Buy Springpaw Appetizers|QID|9067|M|60.40,62.46|QO|2|N|Buy Springpaw Appetizers from Zalene Firstlight at Farstrider Retreat.|
+A The Spearcrafter's Hammer|QID|8477|M|59.5,62.6|N|From Arathel Sunforge.|
+A The Magister's Apprentice|QID|8888|M|60.3,61.4|N|From Magister Duskwither. Up the right ramp.|LEAD|8889|
+A The Purest Water|QID|9403|M|55.7,54.5|N|From Instructor Antheol.|PRE|9402|R|BloodElf|C|Mage|
+R Thuron's Livery|QID|8888|M|62.00,53.00|N|If you want the explorer achievement, head to Thuron's Livery.\n\nIf you don't, just click this step.|RANK|3|
+T The Magister's Apprentice|QID|8888|M|67.8,56.5|N|To Apprentice Loralthalis. Head out of the city and follow the road east.|
+A Deactivating the Spire|QID|8889|M|67.8,56.5|N|From Apprentice Loralthalis.|
+A Where's Wyllithen?|QID|9394|M|67.8,56.5|N|From Apprentice Loralthalis.|LEAD|8894|
+T Where's Wyllithen?|QID|9394|M|68.7,46.9|N|To Groundskeeper Wyllithen.|
+A Cleaning up the Grounds|QID|8894|M|68.7,46.9|N|From Groundskeeper Wyllithen.|
 C Cleaning up the Grounds|QID|8894|N|Kill the Mana Serpent and Ether Fiends from around Duskwither Grounds.|S|
-R Azurebreeze Coast|QID|8894|N|If you want the explorer achievement, head to Azurebreeze Coast.\n\nIf you don't, just click this step.|Z|Eversong Woods|M|72.00,43.00|
+R Azurebreeze Coast|QID|8894|M|72.00,43.00|N|If you want the explorer achievement, head to Azurebreeze Coast.\n\nIf you don't, just click this step.|RANK|3|
 C Cleaning up the Grounds|QID|8894|N|Kill the Mana Serpent and Ether Fiends from around Duskwither Grounds.|US|
-T Cleaning up the Grounds|QID|8894|N|To Groundskeeper Wyllithen.|Z|Eversong Woods|M|68.7,46.9|
-N Deactivating the Spire - First Power Source|QID|8889|N|Click on the Orb of Translocation, then deactivate the First Power Source.|Z|Eversong Woods|M|69.20,52.10|QO|1|NC|
-N Deactivating the Spire - Second Power Source|QID|8889|N|Head up the stairs, then deactivate the Second Power Source.|Z|Eversong Woods|M|69.20,52.10|QO|2|NC|
-A Abandoned Investigations|QID|8891|N|From Magister Duskwither's Journal on the table near the door.|Z|Eversong Woods|M|69.2,52.1|
-C Deactivating the Spire|QID|8889|N|Head up the stairs again, then deactivate the Third Power Source.|Z|Eversong Woods|M|69.20,52.10|QO|3|NC|
-T Deactivating the Spire|QID|8889|N|Click the Orb of Translocation to head back to ground level, then head to Apprentice Loralthalis.|Z|Eversong Woods|M|67.8,56.5|
-A Word from the Spire|QID|8890|PRE|8889|N|From Apprentice Loralthalis.|Z|Eversong Woods|M|67.8,56.5|
+T Cleaning up the Grounds|QID|8894|M|68.7,46.9|N|To Groundskeeper Wyllithen.|
+C Deactivating the Spire - First Power Source|QID|8889|M|69.20,52.10|QO|1|N|Click on the Orb of Translocation, then deactivate the First Power Source.|NC|
+C Deactivating the Spire - Second Power Source|QID|8889|M|69.20,52.10|QO|2|N|Head up the stairs, then deactivate the Second Power Source.|NC|
+A Abandoned Investigations|QID|8891|M|69.2,52.1|N|From Magister Duskwither's Journal on the table near the door.|
+C Deactivating the Spire|QID|8889|M|69.20,52.10|QO|3|N|Head up the stairs again, then deactivate the Third Power Source.|NC|
+T Deactivating the Spire|QID|8889|M|67.8,56.5|N|Click the Orb of Translocation to head back to ground level, then head to Apprentice Loralthalis.|
+A Word from the Spire|QID|8890|M|67.8,56.5|N|From Apprentice Loralthalis.|PRE|8889|
 ;N Visit your trainer if you want|QID|8890|N|since we are by Silvermoon City. Right-click the box to continue.|
-T Word from the Spire|QID|8890|N|To Magister Duskwither. Back at farstrider retreat, up the right ramp.|Z|Eversong Woods|M|60.3,61.4|
-T Abandoned Investigations|QID|8891|N|To Magister Duskwither.|Z|Eversong Woods|M|60.3,61.4|
+T Word from the Spire|QID|8890|M|60.3,61.4|N|To Magister Duskwither. Back at farstrider retreat, up the right ramp.|
+T Abandoned Investigations|QID|8891|M|60.3,61.4|N|To Magister Duskwither.|
 C Amani Encroachment|QID|8476|N|Kill trolls that you need for Amani Encroachment while doing the next quests.|S|
-K Spearcrafter Otembe|QID|8477|QO|1|N|Head to southeast to the trolls, toward Spearcrafter Otembe. Kill trolls that you need for Amani Encroachment while you go.|Z|Eversong Woods|M|70,72|
-A Zul'Marosh|QID|8479|N|From Ven'jashi.|Z|Eversong Woods|M|70.5,72.3|
-K Chieftain Zul'Marosh|QID|8479|L|23249|N|Head west across the water to the next troll camp. Zul'Marosh is in the big building on the top floor. Pull guards first.|Z|Eversong Woods|M|61.60,79.60|
-A Amani Invasion|QID|9360|N|From the Amani Invasion Plans.|Z|Eversong Woods|M|62.6,79.7|U|23249|
-T Zul'Marosh|QID|8479|N|To Ven'jashi.|Z|Eversong Woods|M|70.5,72.3|
-C Amani Encroachment|QID|8476|US|Z|Eversong Woods|M|69.00,72.00|N|Finish killing Trolls needed.|
-R Elrendar Falls|QID|9360|N|If you want the explorer achievement, head to Elrendar Falls.\n\nIf you don't, just click this step.|Z|Eversong Woods|M|64.00,73.00|
-T Amani Encroachment|QID|8476|N|To Lieutenant Dawnrunner at the Farstrider Retreat.|Z|Eversong Woods|M|60.3,62.8|
-T Amani Invasion|QID|9360|N|To Lieutenant Dawnrunner.|Z|Eversong Woods|M|60.3,62.8|
-A Warning Fairbreeze Village|QID|9363|PRE|9360|Z|Eversong Woods|M|60.32,62.76|N|From Lieutenant Dawnrunner.|
-T The Spearcrafter's Hammer|QID|8477|N|To Arathel Sunforge.|Z|Eversong Woods|M|59.5,62.6|
-C The Purest Water|QID|9403|C|Mage|Z|Eversong Woods|M|64.21,72.66|U|23566|N|Go to the base of the waterfall, in the water, and fill the Azure Phial.|
-T The Purest Water|QID|9403|C|Mage|N|To Instructor Antheol.|Z|Eversong Woods|M|55.7,54.5|
-H Fairbreeze Village|QID|9255|U|6948|N|Hearth to Fairbreeze Village.|
-T Research Notes|QID|9255|N|To Magistrix Landra Dawnstrider.|Z|Eversong Woods|M|44.03,70.76|
-T Warning Fairbreeze Village|QID|9363|N|To Ranger Degolien.|Z|Eversong Woods|M|43.3,70.8|
-T Defending Fairbreeze Village|QID|9252|N|To Ranger Sareyn.|Z|Eversong Woods|M|46.93,71.79|
-A The Scorched Grove|QID|9258|LEAD|8473|N|From Ardeyn Riverwind.|Z|Eversong Woods|M|43.6,71.2|
-T The Party Never Ends|QID|9067|N|To Lord Saltheril.|Z|Eversong Woods|M|38.1,73.6|
-T The Scorched Grove|QID|9258|Z|Eversong Woods|M|34,80|N|To Larianna Riverwind. Find Larianna Riverwind near the Scorched Grove in the southwest of Eversong Woods.|
-A A Somber Task|QID|8473|N|From Larianna Riverwind.|Z|Eversong Woods|M|34,80|
-C A Somber Task|QID|8473|Z|Eversong Woods|M|35.7,85.2|N|Kill 10 Withered Green Keepers.|S|
-K Old Whitebark|QID|8474|Z|Eversong Woods|M|35.7,85.2|N|Look for Old Whitebark, kill him to loot his amulet.|L|23228|T|Old Whitebark|
-A Old Whitebark's Pendant|QID|8474|U|23228|N|From Old Whitebark's Pendant. Use the pendant, and accept the quest.|
-T Old Whitebark's Pendant|QID|8474|Z|Eversong Woods|M|34,80|N|To Larianna Riverwind.|
-A Whitebark's Memory|QID|10166|PRE|8474|Z|Eversong Woods|M|34,80|N|From Larianna Riverwind.|
-T Whitebark's Memory|QID|10166|Z|Eversong Woods|M|37.58,86.14|N|To Whitebark's Spirit. Use the pendant, Whitebark will attack you. Get him down in health, then turn the quest in.|U|28209|
-C A Somber Task|QID|8473|Z|Eversong Woods|M|35.7,85.2|N|Kill 10 Withered Green Keepers.|US|
-T A Somber Task|QID|8473|Z|Eversong Woods|M|34,80|N|To Larianna Riverwind.|
-N End of Eversong Woods Guide|QID|9144|N|That's it from Eversong Woods. Don't worry about not yet having the Explore Eversong Woods Acheivement if you're missing just two (Runestone Falithas and Runestone Shan'dor) as you'll discover those places in the Ghostlands guide.  If you're not doing Ghostlands guide, then run to the two waypoints.  \n\nYou may also want to update your skills from Silvermoon City.\n\nClick here to continue to the Ghostlands Guide.|Z|Eversong Woods|M|43,86;55,84|CC|
+K Spearcrafter Otembe|QID|8477|M|70,72|QO|1|N|Head to southeast to the trolls, toward Spearcrafter Otembe. Kill trolls that you need for Amani Encroachment while you go.|
+A Zul'Marosh|QID|8479|M|70.5,72.3|N|From Ven'jashi.|
+K Chieftain Zul'Marosh|QID|8479|M|61.60,79.60|L|23249|N|Head west across the water to the next troll camp. Zul'Marosh is in the big building on the top floor. Pull guards first.|
+A Amani Invasion|QID|9360|M|62.6,79.7|N|From the Amani Invasion Plans.|U|23249|
+T Zul'Marosh|QID|8479|M|70.5,72.3|N|To Ven'jashi.|
+C Amani Encroachment|QID|8476|M|69.00,72.00|N|Finish killing Trolls needed.|US|
+R Elrendar Falls|QID|9360|M|64.00,73.00|N|If you want the explorer achievement, head to Elrendar Falls.\n\nIf you don't, just click this step.|RANK|3|
+T Amani Encroachment|QID|8476|M|60.3,62.8|N|To Lieutenant Dawnrunner at the Farstrider Retreat.|
+T Amani Invasion|QID|9360|M|60.3,62.8|N|To Lieutenant Dawnrunner.|
+A Warning Fairbreeze Village|QID|9363|M|60.32,62.76|N|From Lieutenant Dawnrunner.|PRE|9360|
+T The Spearcrafter's Hammer|QID|8477|N|To Arathel Sunforge.|M|59.5,62.6|
+C The Purest Water|QID|9403|M|64.21,72.66|N|Go to the base of the waterfall, in the water, and fill the Azure Phial.|U|23566|R|BloodElf|C|Mage|
+T The Purest Water|QID|9403|M|55.7,54.5|N|To Instructor Antheol.|R|BloodElf|C|Mage|
+H Fairbreeze Village|QID|9255|N|Hearth to Fairbreeze Village.|
+T Research Notes|QID|9255|M|44.03,70.76|N|To Magistrix Landra Dawnstrider.|
+T Warning Fairbreeze Village|QID|9363|M|43.3,70.8|N|To Ranger Degolien.|
+T Defending Fairbreeze Village|QID|9252|M|46.93,71.79|N|To Ranger Sareyn.|
+A The Scorched Grove|QID|9258|M|43.6,71.2|N|From Ardeyn Riverwind.|LEAD|8473|
+T The Party Never Ends|QID|9067|M|38.1,73.6|N|To Lord Saltheril.|
+T The Scorched Grove|QID|9258|M|34,80|N|To Larianna Riverwind. Find Larianna Riverwind near the Scorched Grove in the southwest of Eversong Woods.|
+A A Somber Task|QID|8473|M|34,80|N|From Larianna Riverwind.|
+C A Somber Task|QID|8473|M|35.7,85.2|N|Kill 10 Withered Green Keepers.|S|
+K Old Whitebark|AVAILABLE|8474|M|35.7,85.2|L|23228|N|Look for Old Whitebark, kill him to loot his amulet.|T|Old Whitebark|
+A Old Whitebark's Pendant|QID|8474|N|From Old Whitebark's Pendant. Use the pendant, and accept the quest.|U|23228|O|
+T Old Whitebark's Pendant|QID|8474|M|34,80|N|To Larianna Riverwind.|
+A Whitebark's Memory|QID|10166|M|34,80|N|From Larianna Riverwind.|PRE|8474|
+T Whitebark's Memory|QID|10166|M|37.58,86.14|N|To Whitebark's Spirit. Use the pendant, Whitebark will attack you. Get him down in health, then turn the quest in.|U|28209|
+C A Somber Task|QID|8473|M|35.7,85.2|N|Kill 10 Withered Green Keepers.|US|
+T A Somber Task|QID|8473|M|34,80|N|To Larianna Riverwind.|
+N End of Eversong Woods Guide|QID|9144|M|43,86;55,84|N|That's it from Eversong Woods. Don't worry about not yet having the Explore Eversong Woods Acheivement if you're missing just two (Runestone Falithas and Runestone Shan'dor) as you'll discover those places in the Ghostlands guide.  If you're not doing Ghostlands guide, then run to the two waypoints.  \n\nYou may also want to update your skills from Silvermoon City.\n\nClick here to continue to the Ghostlands Guide.|CC|
 ]]
 end)

--- a/WoWPro_Leveling/Classic_BC/Horde/CLASSIC_BC_Blood_Elf.lua
+++ b/WoWPro_Leveling/Classic_BC/Horde/CLASSIC_BC_Blood_Elf.lua
@@ -1,5 +1,6 @@
 local guide = WoWPro:RegisterGuide('BC-BloodElf', 'Leveling', 'Eversong Woods', 'Kraevac', 'Horde', 2)
 WoWPro:GuideLevels(guide, 1, 10)
+WoWPro:GuideRaceSpecific(guide, BloodElf)
 WoWPro:GuideSort(guide, 2)
 WoWPro:GuideNickname(guide, "Blood Elf: Intro")
 WoWPro:GuideName(guide,"Blood Elf: Intro")
@@ -7,117 +8,117 @@ WoWPro:GuideNextGuide(guide, 'CLASSIC_BC_Silverpine_Forest')
 WoWPro:GuideSteps(guide, function()
 return [[
 ; Sunstrider Isle starting zone is for BloodElf's only.
-A Reclaiming Sunstrider Isle|QID|8325|M|38.21,20.83|N|From Magistrix Erona.|R|BloodElf|
-K Mana Wyrm |ACTIVE|8325|M|34.84,19.97|N|Behind you then down the big stairs, you should see plenty of Mana Wyrms.|R|BloodElf|
-L Level 2|QID|8326|N|You'll want to be within 5 bubbles of level 2 before you return.\nContinue killing Mana Wyrms until you are.|LVL|2;-100|
-T Reclaiming Sunstrider Isle|QID|8325|M|38.21,20.83|N|To Magistrix Erona.|R|BloodElf|
-A Unfortunate Measures|QID|8326|M|38.21,20.83|N|From Magistrix Erona.|R|BloodElf|
+A Reclaiming Sunstrider Isle|QID|8325|M|38.21,20.83|N|From Magistrix Erona.|
+K Mana Wyrm|ACTIVE|8325|M|34.84,19.97|QO|1|N|Behind you then down the big stairs, you should see plenty of Mana Wyrms.|
+L Level 2|QID|8326|N|You'll want to be within 5 bubbles of level 2 before you return.\nContinue killing Mana Wyrms until you are.|LVL|1;-100|
+T Reclaiming Sunstrider Isle|QID|8325|M|38.21,20.83|N|To Magistrix Erona.|
+A Unfortunate Measures|QID|8326|M|38.21,20.83|N|From Magistrix Erona.|
 ; -- Class quests
-A Warrior Training |QID|8329|M|38.21,20.83|N|From Magistrix Erona.|R|BloodElf|C|Warrior|
-A Hunter Training |QID|9393|M|38.21,20.83|N|From Fagistrix Erona.|R|BloodElf|C|Hunter|
-A Mage Training |QID|8328|M|38.21,20.83|N|From Magistrix Erona.|R|BloodElf|C|Mage|
-A Paladin Training |QID|9676|M|38.21,20.83|N|From Magistrix Erona.|R|BloodElf|C|Paladin|
-A Priest Training |QID|8564|M|38.21,20.83|N|From Magistrix Eron.a|R|BloodElf|C|Priest|
-A Rogue Training |QID|9392|M|38.21,20.83|N|From Magistrix Erona.|R|BloodElf|C|Rogue|
-A Warlock Training |QID|8563|M|38.21,20.83|N|From Magistrix Erona.|R|BloodElf|C|Warlock|
-T Warrior Training |QID|8329|M|39.29,20.10|N|To Delios Silverblade, inside the building.|R|BloodElf|C|Warrior|
-T Hunter Training |QID|9393|M|39.0,20.0|N|To Ranger Sallina, inside the building.|R|BloodElf|C|Hunter|
-T Mage Training |QID|8328|M|39.2,21.5|N|To Julia Sunstriker, inside the building.|R|BloodElf|C|Mage|
-T Paladin Training |QID|9676|M|39.5,20.6|N|To Jesthenis Sunstriker, inside the building.|R|BloodElf|C|Paladin|
-T Priest Training |QID|8564|M|39.4,20.4|N|To Matron Arena, inside the building.|R|BloodElf|C|Priest|
-T Rogue Training |QID|9392|M|38.9,20.0|N|To Pathstalker Kariel, inside the building.|R|BloodElf|C|Rogue|
-T Warlock Training |QID|8563|M|38.9,21.4|N|Summoner Teli'Larien, inside the building.|R|BloodElf|C|Warlock|
+A Mage Training|QID|8328|M|38.21,20.83|N|From Magistrix Erona.|PRE|8325|C|Mage|
+A Warrior Training|QID|8329|M|38.21,20.83|N|From Magistrix Erona.|PRE|8325|C|Warrior|
+A Warlock Training|QID|8563|M|38.21,20.83|N|From Magistrix Erona.|PRE|8325|C|Warlock|
+A Priest Training|QID|8564|M|38.21,20.83|N|From Magistrix Erona.|PRE|8325|C|Priest|
+A Rogue Training|QID|9392|M|38.21,20.83|N|From Magistrix Erona.|PRE|8325|C|Rogue|
+A Hunter Training|QID|9393|M|38.21,20.83|N|From Magistrix Erona.|PRE|8325|C|Hunter|
+A Paladin Training|QID|9676|M|38.21,20.83|N|From Magistrix Erona.|PRE|8325|C|Paladin|
+T Mage Training|QID|8328|M|39.23,21.45|N|To Julia Sunstriker, inside the building.|C|Mage|
+T Warrior Training|QID|8329|M|39.29,20.10|N|To Delios Silverblade, inside the building.|C|Warrior|
+T Warlock Training|QID|8563|M|38.93,21.44|N|Summoner Teli'Larien, inside the building.|C|Warlock|
+T Priest Training|QID|8564|M|39.42,20.38|N|To Matron Arena, inside the building.|C|Priest|
+T Rogue Training|QID|9392|M|38.93,20.02|N|To Pathstalker Kariel, inside the building.|C|Rogue|
+T Hunter Training|QID|9393|M|39.05,20.01|N|To Ranger Sallina, inside the building.|C|Hunter|
+T Paladin Training|QID|9676|M|39.48,20.56|N|To Jesthenis Sunstriker, inside the building.|C|Paladin|
+; --
+A Well Watcher Solanian|QID|10068^10069^10070^10071^10072|N|From your Class Trainer.|LEAD|8330|PRE|8328^8329^8563^8564^9392^9393^9676|
+T Well Watcher Solanian|QID|10068^10069^10070^10071^10072|M|38.76,19.36|N|To Well Watcher Solanian, outside on the balcony at the top of the ramp.|
+A Solanian's Belongings|QID|8330|M|38.76,19.36|N|From Well Watcher Solanian.|
+A The Shrine of Dath'Remar|QID|8345|M|38.76,19.36|N|From Well Watcher Solanian.|
+A A Fistful of Slivers|QID|8336|M|38.28,19.13|N|From Arcanist Ithanas, on the patio below you. You can jump down from the balcony.|
+A Thirst Unending|QID|8346|M|37.18,18.95|N|From Arcanist Helion. You can see him on the patio directly opposite from your current position.|
+R Empty your bags|ACTIVE|8346|M|37.14,19.03|N|Empty your bags and repair before venturing further.\n[color=FF0000]NOTE: [/color]Jainthess Thelryn, standing beside you, can help you with that.|
 
-A The Shrine of Dath'Remar|QID|8345|M|38.76,19.36|N|From Well Watcher Solanian, on the balcony at the top of the ramp.|R|BloodElf|
-A Solanian's Belongings|QID|8330|M|38.76,19.36|N|From Well Watcher Solanian.|R|BloodElf|
-A A Fistful of Slivers |QID|8336|M|38.3,19.1|N|From Arcanist Ithanas, on the patio below you. You can jump down from the balcony.|R|BloodElf|
-A Thirst Unending|QID|8346|R|BloodElf|N|From Arcanist Helion. Go through the gazebo in front of you.|M|37.2,18.9|
+C Unfortunate Measures|QID|8326|M|54.82,54.34|L|20797 8|N|Kill Springpaw Lynxes and Cubs to collect the Lynx Collars.\n[color=FF0000]NOTE: [/color]Lynxes drop multiples and Cubs only drop one at a time.|S|
+C A Fistful of Slivers|QID|8336|M|35.39,20.24|L|20482 6|N|Kill Mana Wyrms to collect the Arcane Slivers.\n[color=FF0000]NOTE: [/color]Any creature that uses mana can drop them; Mana Wyrms are easier and more convenient.|S|
+C Thirst Unending|QID|8346|M|35.39,20.24|N|Use Arcane Torrent when you are within 8 yards of a Mana Wyrm.\n[color=FF0000]NOTE: [/color]Arcane Torrent has a 2 minute cooldown.\nThis works on ANY creature that uses mana.|
+C Solanian's Belongings|QID|8330|M|60.06,57.11|QO|3|N|Pick up Solanian's Journal, near the big green crystal.|
+C Unfortunate Measures|QID|8326|M|54.82,54.34|N|Finish collecting the Lynx collars.|US|
+T Thirst Unending|QID|8346|N|To Arcanist Helion.|M|37.20,18.95|
+R Empty your bags|QID|8326|N|Don't forget to repair and empty your bags.|
+T Unfortunate Measures|QID|8326|M|38.21,20.83|N|To Magistrix Erona.|
 
-R Empty your bags|QID|8346|N|You may want to empty your bags before venturing further. \nSell unwanted items to Jainthess Thelryn beside you.|R|BloodElf|
+L Level 3|LVL|3|N|You need to be Level 3 to continue this guide.|QID|8327|
 
-C Unfortunate Measures |QID|8326|R|BloodElf|N|Kill and loot Springpaw Lynxs and Cubs for the Lynx collars.|M|54.82,54.34|S|
-C Thirst Unending |QID|8346|R|BloodElf|N|Use your racial talent, Arcane Torrent, when you are within 8 yards of a Mana Wyrm. |M|59.44,54.04|S|
-C Solonaian's Journal |QID|8330|R|BloodElf|N|Get Solonaian's Journal, near the big green crystal. |M|60.06,57.11|NC|QO|Solanian's Journal: 1/1|
-C Thirst Unending |QID|8346|R|BloodElf|N|Use your racial talent, Arcane Torrent, on a Mana Wyrm. |M|59.44,54.04|US|
-C Unfortunate Measures |QID|8326|R|BloodElf|N|Finish killing and looting Springpaw Lynxs and Cubs for the Lynx collars. |M|54.82,54.34|US|
-T Thirst Unending |QID|8346|R|BloodElf|N|To Arcanist Helion.|M|37.20,18.95|
-R Empty your bags|QID|8326|R|BloodElf|N|You may want to empty your bags before venturing further. \nSell unwanted items to Jainthess Thelryn beside you.|
-T Unfortunate Measures |QID|8326|R|BloodElf|M|38.21,20.83|N|To Magistrix Erona.|
+A Report to Lanthan Perilon|QID|8327|M|61.59,44.49|N|From Magistrix Erona.|
+A Charge!|QID|27091|M|64.98,42.34|C|Warrior|N|From Delios Silverblade.|
+C Charge!|QID|27091|M|62.00,44.00||C|Warrior|N|Learn charge from your trainer and Charge the target dummy.|
+T Charge!|QID|27091|M|64.98,42.34|C|Warrior|N|To Delios Silverblade.|
+A Steady Shot|QID|10070|M|64.06,42.03|C|Hunter|N|From Ranger Sallina.|
+C Steady Shot|QID|10070|M|62.00,44.00|C|Hunter|N|Learn Steady Shot from Ranger Sallina. Locate a Training Dummy outside the Sunspire and practice using Steady Shot 5 times.|
+T Steady Shot|QID|10070|M|64.06,42.03|C|Hunter|N|To Ranger Sallina.|
+A Arcane Missiles|QID|10068|M|64.67,46.65|C|Mage|N|From Julia Sunstriker.|
+C Arcane Missiles|QID|10068|M|62.00,44.00|C|Mage|N|Learn Arcane Missiles from Julia Sunstriker. Locate a Training Dummy outside the Sunspire and practice using Arcane Missiles 2 times.|
+T Arcane Missiles|QID|10068|M|64.67,46.65|C|Mage|N|To Julia Sunstriker.|
+A Ways of the Light|QID|10069|M|65.60,43.88|C|Paladin|N|From Jesthenis Sunstriker.|
+C Ways of the Light|QID|10069|M|62.00,44.00|C|Paladin|N|Learn Judgement and Seal of Righteousness from Jesthenis Sunstriker. Cast Seal of Righteousness on yourself, then locate a Training Dummy outside the Sunspire and use Judgement.|
+T Ways of the Light|QID|10069|M|65.60,43.88|C|Paladin|N|To Jesthenis Sunstriker.|
+A Evisceration|QID|10071|M|63.75,42.03|C|Rogue|N|From Pathstalker Kariel.|
+C Evisceration|QID|10071|M|62.00,44.00|C|Rogue|N|Learn Eviscerate from Pathstalker Kariel. Locate a Training Dummy outside the Sunspire and practice using Eviscerate 3 times.|
+T Evisceration|QID|10071|M|63.75,42.03|C|Rogue|N|To Pathstalker Kariel.|
+A Learning the Word|QID|10072|M|65.29,43.26|C|Priest|N|From Matron Arena.|
+C Learning the Word|QID|10072|M|134.64,115.87|C|Priest|N|Locate a Training Dummy outside the Sunspire and practice using Shadow Word: Pain 5 times.|
+T Learning the Word|QID|10072|M|65.29,43.26|C|Priest|N|To Matron Arena|
+A Immolation|QID|10073|M|63.75,46.34|C|Warlock|N|From Summoner Teli'Larien|
+C Immolation|QID|10073|M|62.00,44.00|C|Warlock|N|Learn Immolate from Summoner Teli'Larien. Locate a Training Dummy outside the Sunspire and practice casting Immolate 5 times.|
+T Immolation|QID|10073|M|63.75,46.34|C|Warlock|N|To Summoner Teli'Larien|
+T Report to Lanthan Perilon|QID|8327|N|To Lanthan Perilon.|M|35.4,22.5|
 
-L Level 3|LVL|3|N|You need to be Level 3 to continue this guide.|QID|8327|R|BloodElf|
+A Aggression|QID|8334|N|From Lanthan Perilon.|M|35.4,22.5|
+C Aggression|QID|8334|S|N|Kill any Tender and Feral Tender you see.|
+C Solanian's Scrying Orb|QID|8330|N|Get Solanian's Scrying Orb from the lake's platform, to the south of Sunstrider Isle.|M|52.15,69.46|QO|Solanian's Scrying Orb: 1/1|NC|
+C Solanian's Belongings|QID|8330|N|Get the Scroll of Scourge Magic, which is northwest.|M|40.48,50.50|NC|QO|Scroll of Scourge Magic: 1/1|
+C The Shrine of Dath'Remar|QID|8345|N|Go to the far north-west of the island until you reach the Shrine of Dath'Remar. Click on it to read the plaque.|M|35.43,40.49|NC|
+C Aggression|QID|8334|US|N|Finish killing the Feral Tenders and Tenders you need.|
+C A Fistful of Slivers|QID|8336|N|As you head back to the Sunspire, finish collecting the Slivers from the Mana Wyrms and Feral Tenders|M|59.44,54.04|US|
+T The Shrine of Dath'Remar|QID|8345|N|To Well Watcher Solanian, inside The Sunspire, up the ramp.|M|38.96,20.27|
+T Solanian's Belongings|QID|8330|N|To Well Watcher Solanian.|M|38.96,20.27|
+T A Fistful of Slivers|QID|8336|N|To Arcanist Ithanas.|M|38.3,19.1|
+T Aggression|QID|8334|M|52.98,49.73|N|To Lanthan Perilon.|
 
-A Report to Lanthan Perilon |QID|8327|R|BloodElf|M|61.59,44.49|N|From Magistrix Erona.|
-A Charge!|QID|27091|M|64.98,42.34|R|BloodElf|C|Warrior|N|From Delios Silverblade.|
-C Charge!|QID|27091|M|62.00,44.00||R|BloodElf|C|Warrior|N|Learn charge from your trainer and Charge the target dummy.|
-T Charge!|QID|27091|M|64.98,42.34|R|BloodElf|C|Warrior|N|To Delios Silverblade.|
-A Steady Shot|QID|10070|R|BloodElf|M|64.06,42.03|C|Hunter|N|From Ranger Sallina.|
-C Steady Shot|QID|10070|R|BloodElf|M|62.00,44.00|C|Hunter|N|Learn Steady Shot from Ranger Sallina. Locate a Training Dummy outside the Sunspire and practice using Steady Shot 5 times.|
-T Steady Shot|QID|10070|R|BloodElf|M|64.06,42.03|C|Hunter|N|To Ranger Sallina.|
-A Arcane Missiles|QID|10068|R|BloodElf|M|64.67,46.65|C|Mage|N|From Julia Sunstriker.|
-C Arcane Missiles|QID|10068|R|BloodElf|M|62.00,44.00|C|Mage|N|Learn Arcane Missiles from Julia Sunstriker. Locate a Training Dummy outside the Sunspire and practice using Arcane Missiles 2 times.|
-T Arcane Missiles|QID|10068|R|BloodElf|M|64.67,46.65|C|Mage|N|To Julia Sunstriker.|
-A Ways of the Light|QID|10069|R|BloodElf|M|65.60,43.88|C|Paladin|N|From Jesthenis Sunstriker.|
-C Ways of the Light|QID|10069|R|BloodElf|M|62.00,44.00|C|Paladin|N|Learn Judgement and Seal of Righteousness from Jesthenis Sunstriker. Cast Seal of Righteousness on yourself, then locate a Training Dummy outside the Sunspire and use Judgement.|
-T Ways of the Light|QID|10069|R|BloodElf|M|65.60,43.88|C|Paladin|N|To Jesthenis Sunstriker.|
-A Evisceration|QID|10071|R|BloodElf|M|63.75,42.03|C|Rogue|N|From Pathstalker Kariel.|
-C Evisceration|QID|10071|R|BloodElf|M|62.00,44.00|C|Rogue|N|Learn Eviscerate from Pathstalker Kariel. Locate a Training Dummy outside the Sunspire and practice using Eviscerate 3 times. |
-T Evisceration|QID|10071|R|BloodElf|M|63.75,42.03|C|Rogue|N|To Pathstalker Kariel.|
-A Learning the Word|QID|10072|R|BloodElf|M|65.29,43.26|C|Priest|N|From Matron Arena.|
-C Learning the Word|QID|10072|R|BloodElf|M|134.64,115.87|Z|Sunstrider Isle|C|Priest|N|Locate a Training Dummy outside the Sunspire and practice using Shadow Word: Pain 5 times.|
-T Learning the Word|QID|10072|R|BloodElf|M|65.29,43.26|C|Priest|N|To Matron Arena|
-A Immolation|QID|10073|R|BloodElf|M|63.75,46.34|C|Warlock|N|From Summoner Teli'Larien|
-C Immolation|QID|10073|R|BloodElf|M|62.00,44.00|C|Warlock|N|Learn Immolate from Summoner Teli'Larien. Locate a Training Dummy outside the Sunspire and practice casting Immolate 5 times. |
-T Immolation|QID|10073|R|BloodElf|M|63.75,46.34|C|Warlock|N|To Summoner Teli'Larien|
-T Report to Lanthan Perilon |QID|8327|R|BloodElf|N|To Lanthan Perilon.|M|35.4,22.5|
+A Felendren the Banished|QID|8335|N|From Lanthan Perilon.|M|35.4,22.5|
+C Felendren the Banished|QID|8335|N|Kill Arcane Wraiths|M|39.03,63.98|S|QO|Arcane Wraith slain: 8/8|
+l Tainted Arcane Sliver|S|QID|8338|L|20483|N|Kill and loot a Tainted Arcane Wraith, it will drop a Tainted Arcane Sliver.|
+K Felendren the Banished|QID|8335|N|Go up the ramp and to the top of Falthrien Academy. At the first waypoint there will be two paths to choose, both will merge further on, so either can be taken. At the top, kill Felendren and loot his head.|M|41.56,61.85;38.05,66.35|L|20799|CC|
+l Tainted Arcane Sliver|US|QID|8338|L|20483|N|Kill and loot the Tainted Arcane Wraiths until they drop the Tainted Arcane Sliver.|
+A Tainted Arcane Sliver|QID|8338|U|20483|N|The Tainted Arcane Sliver starts a quest - click it and accept the quest.|
+C Felendren the Banished|QID|8335|N|Kill another Tainted Arcane Wraith|M|39.03,63.98|QO|Tainted Arcane Wraith slain: 2/2|
+C Felendren the Banished|QID|8335|N|Finish killing the Arcane Wraiths|M|39.03,63.98|US|QO|Arcane Wraith slain: 8/8|
+H Sunstrider Isle|QID|8338|U|6948|N|Hearthstone back to the starting point, or run back.|M|37.75,21.10|
+T Tainted Arcane Sliver|QID|8338|N|To Arcanist Helion.|M|37.2,18.9|
+r Repair/Sell|QID|8335|M|58.46,38.95|N|Good opportunity to sell unwanted loot with Jainthess Thelryn.\nClose this step to continue.|RANK|3|
+T Felendren the Banished|QID|8335|N|To Lanthan Perilon.|M|35.4,22.5|
 
-A Aggression |QID|8334|R|BloodElf|N|From Lanthan Perilon.|M|35.4,22.5|
-C A Fistful of Slivers |QID|8336|R|BloodElf|N|As you kill the Feral Tenders, loot the Arcane Slivers from them.|M|59.44,54.04|S|
-C Aggression |QID|8334|R|BloodElf|S|N|Kill any Tender and Feral Tender you see.|
-C Solanian's Scrying Orb |QID|8330|R|BloodElf|N|Get Solonaian's Scrying Orb from the lake's platform, to the south of Sunstrider Isle. |M|52.15,69.46|QO|Solanian's Scrying Orb: 1/1|NC|
-C Solanian's Belongings|QID|8330|R|BloodElf|N|Get the Scroll of Scourge Magic, which is northwest.|M|40.48,50.50|NC|QO|Scroll of Scourge Magic: 1/1|
-C The Shrine of Dath'Remar |QID|8345|R|BloodElf|N|Go to the far north-west of the island until you reach the Shrine of Dath'Remar. Click on it to read the plaque.|M|35.43,40.49|NC|
-C Aggression |QID|8334|R|BloodElf|US|N|Finish killing the Feral Tenders and Tenders you need.|
-C A Fistful of Slivers |QID|8336|R|BloodElf|N|As you head back to the Sunspire, finish collecting the Slivers from the Mana Wyrms and Feral Tenders|M|59.44,54.04|US|
-T The Shrine of Dath'Remar |QID|8345|R|BloodElf|N|To Well Watcher Solanian, inside The Sunspire, up the ramp.|M|38.96,20.27|
-T Solanian's Belongings |QID|8330|R|BloodElf|N|To Well Watcher Solanian.|M|38.96,20.27|
-T A Fistful of Slivers |QID|8336|R|BloodElf|N|To Arcanist Ithanas.|M|38.3,19.1|
-T Aggression |QID|8334|R|BloodElf|M|52.98,49.73|N|To Lanthan Perilon.|
+L Level 4|QID|8347|LVL|4|N|You need to be Level 4 to continue this guide.|
 
-A Felendren the Banished |QID|8335|R|BloodElf|N|From Lanthan Perilon.|M|35.4,22.5|
-C Felendren the Banished |QID|8335|R|BloodElf|N|Kill Arcane Wraiths|M|39.03,63.98|S|QO|Arcane Wraith slain: 8/8|
-l Tainted Arcane Sliver|S|QID|8338|L|20483|R|BloodElf|N|Kill and loot a Tainted Arcane Wraith, it will drop a Tainted Arcane Sliver.|
-K Felendren the Banished |QID|8335|R|BloodElf|N|Go up the ramp and to the top of Falthrien Academy. At the first waypoint there will be two paths to choose, both will merge further on, so either can be taken. At the top, kill Felendren and loot his head.|M|41.56,61.85;38.05,66.35|L|20799|CC|
-l Tainted Arcane Sliver|US|QID|8338|L|20483|R|BloodElf|N|Kill and loot the Tainted Arcane Wraiths until they drop the Tainted Arcane Sliver.|
-A Tainted Arcane Sliver |QID|8338|R|BloodElf|U|20483|N|The Tainted Arcane Sliver starts a quest - click it and accept the quest.|
-C Felendren the Banished |QID|8335|R|BloodElf|N|Kill another Tainted Arcane Wraith|M|39.03,63.98|QO|Tainted Arcane Wraith slain: 2/2|
-C Felendren the Banished |QID|8335|R|BloodElf|N|Finish killing the Arcane Wraiths|M|39.03,63.98|US|QO|Arcane Wraith slain: 8/8|
-H Sunstrider Isle|QID|8338|U|6948|R|BloodElf|N|Hearthstone back to the starting point, or run back.|M|37.75,21.10|
-T Tainted Arcane Sliver |QID|8338|R|BloodElf|N|To Arcanist Helion.|M|37.2,18.9|
-r Repair/Sell|QID|8335|R|BloodElf|M|58.46,38.95|N|Good opportunity to sell unwanted loot with Jainthess Thelryn.\nClose this step to continue.|RANK|3|
-T Felendren the Banished |QID|8335|R|BloodElf|N|To Lanthan Perilon.|M|35.4,22.5|
-
-L Level 4|QID|8347|LVL|4|N|You need to be Level 4 to continue this guide.|R|BloodElf|
-
-A Aiding the Outrunners |QID|8347|R|BloodElf|N|From Lanthan Perilon.|M|35.4,22.5|
-T Aiding the Outrunners |QID|8347|R|BloodElf|N|To Outrunner Alarion.|M|40.4,32.2|
-A Slain by the Wretched |QID|9704|N|From Outrunner Alarion.|M|68.37,79.58|R|BloodElf|
+A Aiding the Outrunners|QID|8347|N|From Lanthan Perilon.|M|35.4,22.5|
+T Aiding the Outrunners|QID|8347|N|To Outrunner Alarion.|M|40.4,32.2|
+A Slain by the Wretched|QID|9704|N|From Outrunner Alarion.|M|68.37,79.58|
 ;The guide continues at this point for all races
 R Eversong Woods|QID|9704|N|Head to to the Ruins of Silvermoon in Eversong Woods. From Thunderbluff, fly to Orgrimmar. From Orgrimmar, use the Zeppelin at the Eastern Tower to get to Tirisfal Glades. From Tirisfal Glades/Undercity, use the Orb of Translocation at the Ruins of Lordaeron (54.84,11.22 a room to the west as you enter Undercity from Tirisfal Glades). From Silvermoon City, head out of the city (head south-east/south, the exit is at the south end of the Walk of Elders)|M|56.95,49.60|Z|Eversong Woods|
 F Falconwing Square|QID|9704|Z|Eversong Woods|M|54.37,50.73|N|Head west to Skymistress Gloaming, then take a ride to Falconwing Square.|R|Goblin;Tauren;Orc;Troll;Forsaken;Pandaren|
-T Slain by the Wretched|QID|9704|N|To Slain Outrunner.|Z|Eversong Woods|M|42.0,35.7|R|BloodElf|
-A Package Recovery |QID|9705|PRE|9704|N|From Slain Outrunner.|Z|Eversong Woods|M|42.0,35.7|
-T Package Recovery |QID|9705|N|To Outrunner Alarion.|Z|Eversong Woods|M|40.4,32.2|
+T Slain by the Wretched|QID|9704|N|To Slain Outrunner.|Z|Eversong Woods|M|42.0,35.7|
+A Package Recovery|QID|9705|PRE|9704|N|From Slain Outrunner.|Z|Eversong Woods|M|42.0,35.7|
+T Package Recovery|QID|9705|N|To Outrunner Alarion.|Z|Eversong Woods|M|40.4,32.2|
 A Completing the Delivery|QID|8350|PRE|9705|N|From Outrunner Alarion.|Z|Eversong Woods|M|40.4,32.2|
 f Falconwing Square|QID|8350|Z|Eversong Woods|M|46.24,46.80|N|Get the flightpoint from Skymaster Skyles.|
 T Completing the Delivery|QID|8350|N|To Innkeeper Delaniel.|Z|Eversong Woods|M|48.1,47.7|
-h Falconwing Inn |QID|8472|N|Set your hearthstone to Falconwing Square with Innkeeper Delaniel.|Z|Eversong Woods|M|48.1,47.7|
-N Professions |QID|8472|N|If you plan on learning any professions, now's the time. Saren will teach all Primary and Secondary professions, he can be found upstairs. You can also learn Cooking from Quarelestra nearby.  \n\nClick this step to continue.|Z|Eversong Woods|M|48.93,46.86|
+h Falconwing Inn|QID|8472|N|Set your hearthstone to Falconwing Square with Innkeeper Delaniel.|Z|Eversong Woods|M|48.1,47.7|
+N Professions|QID|8472|N|If you plan on learning any professions, now's the time. Saren will teach all Primary and Secondary professions, he can be found upstairs. You can also learn Cooking from Quarelestra nearby.  \n\nClick this step to continue.|Z|Eversong Woods|M|48.93,46.86|
 A Unstable Mana Crystals|QID|8463|N|From Aeldon Sunbrand, back outside of the inn.|Z|Eversong Woods|M|48.2,46.0|
-A WANTED: Thaelis the Hungerer |QID|8468|N|From 'Wanted: Thaelis the Hungerer' signpost.|Z|Eversong Woods|M|48.2,46.3|
+A WANTED: Thaelis the Hungerer|QID|8468|N|From 'Wanted: Thaelis the Hungerer' signpost.|Z|Eversong Woods|M|48.2,46.3|
 A Major Malfunction|QID|8472|N|From Magister Jaronis.|Z|Eversong Woods|M|47.3,46.3|
 C Major Malfunction|QID|8472|N|Kill and loot Arcane Patrollers for the Arcane Cores.|Z|Eversong Woods|M|45.,40.5|S|
 C Unstable Mana Crystals|QID|8463|S|N|Look for light beams that come out of the boxes.|Z|Eversong Woods|M|45.386,42|NC|
-C Thaelis the Hungerer|QID|8468|T|Thaelis the Hungerer|N|Kill and loot Thaelis the Hungerer.\n\nBe careful to pull all the Wretched Urchins around him first before attacking. |Z|Eversong Woods|M|45.00,38.40|
+C Thaelis the Hungerer|QID|8468|T|Thaelis the Hungerer|N|Kill and loot Thaelis the Hungerer.\n\nBe careful to pull all the Wretched Urchins around him first before attacking.|Z|Eversong Woods|M|45.00,38.40|
 C Unstable Mana Crystals|QID|8463|Z|Eversong Woods|M|45.38,40.85|US|N|Look for light beams that come out of the boxes.|NC|
 C Major Malfunction|QID|8472|N|Finish killing and looting Arcane Patrollers for the Arcane Cores.|Z|Eversong Woods|M|45,40.5|US|
 T Major Malfunction|QID|8472|N|To Magister Jaronis.|Z|Eversong Woods|M|47.3,46.3|
@@ -130,13 +131,13 @@ A Malfunction at the West Sanctum|QID|9119|PRE|8895|N|From Ley-Keeper Caidanis.|
 T Malfunction at the West Sanctum|QID|9119|N|To Ley-Keeper Velania.|Z|Eversong Woods|M|36.7,57.4|
 A Arcane Instability|QID|8486|PRE|9119|N|From Ley-Keeper Velania|Z|Eversong Woods|M|36.7,57.4|
 C Arcane Instability|QID|8486|N|Kill the Manawraith and Mana Stalker located around the West Sanctum.|Z|Eversong Woods|M|36,58|S|
-K Darnassian Scout|QID|9352|L|20765|N|Kill a Darnassian Scout and loot Incriminating Documents. |Z|Eversong Woods|M|34.50,60.00|
+K Darnassian Scout|QID|9352|L|20765|N|Kill a Darnassian Scout and loot Incriminating Documents.|Z|Eversong Woods|M|34.50,60.00|
 A Incriminating Documents|QID|8482|U|20765|N|Quest starts from the Incriminating Documents. Click the envelope.|Z|Eversong Woods|M|33.9,58.4|
 C Arcane Instability|QID|8486|N|Finish killing the Manawraith and Mana Stalker located around the West Sanctum.|Z|Eversong Woods|M|36,58|US|
 T Darnassian Intrusions|QID|9352|N|To Ley-Keeper Velania.|Z|Eversong Woods|M|36.7,57.4|
-T Arcane Instability |QID|8486|N|To Ley-Keeper Velania.|Z|Eversong Woods|M|36.7,57.4|
+T Arcane Instability|QID|8486|N|To Ley-Keeper Velania.|Z|Eversong Woods|M|36.7,57.4|
 A Fish Heads, Fish Heads...|QID|8884|N|From Hathvelion Sungaze. Go around the northside of the mountain.|Z|Eversong Woods|M|31.49,53.78;30.20,58.37|CC|
-C Fish Heads, Fish Heads...|QID|8884|N|Kill murlocs for the 8 fish heads. |Z|Eversong Woods|M|27,59.5|
+C Fish Heads, Fish Heads...|QID|8884|N|Kill murlocs for the 8 fish heads.|Z|Eversong Woods|M|27,59.5|
 l Captain Kelisendra's Lost Rutters|QID|8887|L|21776|N|Keep killing murlocs until one of them drops Captain Kelisendra's Lost Rutters.|Z|Eversong Woods|M|27,59.5|
 A Captain Kelisendra's Lost Rutters|QID|8887|U|21776|N|From Captain Kelisendra's Lost Rutters.|
 T Fish Heads, Fish Heads...|QID|8884|N|To Hathvelion Sungaze.|Z|Eversong Woods|M|29.89,58.52|
@@ -148,18 +149,18 @@ C The Dwarven Spy|QID|8483|L|20764|CHAT|N|Speak to Prospector Anvilward. He will
 A Roadside Ambush|QID|9035|LEAD|9062|N|From Apprentice Ralen.|Z|Eversong Woods|M|45.2,56.4|
 T Roadside Ambush|QID|9035|N|To Apprentice Meledor.|Z|Eversong Woods|M|44.9,61.0|
 A Soaked Pages|QID|9062|N|From Apprentice Meledor.|Z|Eversong Woods|M|44.9,61.0|
-C Soaked Pages|QID|9062|L|22414|N|Dive under the bridge just in front of you, the Soaked Pages are in the river. |Z|Eversong Woods|M|44.40,61.90|NC|
+C Soaked Pages|QID|9062|L|22414|N|Dive under the bridge just in front of you, the Soaked Pages are in the river.|Z|Eversong Woods|M|44.40,61.90|NC|
 T Soaked Pages|QID|9062|N|To Apprentice Meledor.|Z|Eversong Woods|M|44.9,61.0|
 A Taking the Fall|QID|9064|PRE|9062|N|From Apprentice Meledor.|Z|Eversong Woods|M|44.9,61.0|
 T Taking the Fall|QID|9064|N|To Instructor Antheol.|Z|Eversong Woods|M|55.7,54.5|
 A Swift Discipline|QID|9066|PRE|9064|N|From Instructor Antheol.|Z|Eversong Woods|M|55.7,54.5|
-A Fetch!|QID|9402|N|From Instructor Antheol.|R|BloodElf|C|Mage|Z|Eversong Woods|M|55.7,54.5|
-C Fetch!|QID|9402|N|Dive into the middle of the lake. The phial is on the bottom.|R|BloodElf|C|Mage|Z|Eversong Woods|M|54.87,56.38|
-T Fetch!|QID|9402|N|To Instructor Antheol.|R|BloodElf|C|Mage|Z|Eversong Woods|M|55.7,54.5|
+A Fetch!|QID|9402|N|From Instructor Antheol.|C|Mage|Z|Eversong Woods|M|55.7,54.5|
+C Fetch!|QID|9402|N|Dive into the middle of the lake. The phial is on the bottom.|C|Mage|Z|Eversong Woods|M|54.87,56.38|
+T Fetch!|QID|9402|N|To Instructor Antheol.|C|Mage|Z|Eversong Woods|M|55.7,54.5|
 A The Dead Scar|QID|8475|N|From Ranger Jaela.|Z|Eversong Woods|M|50.3,50.8|
 C Swift Discipline - Apprentice Ralen|QID|9066|U|22473|NC|N|Target Apprentice Ralen and use the rod that Anetheol gave you.|Z|Eversong Woods|M|45.20,56.40|QO|2|T|Apprentice Ralen|
 C Swift Discipline - Apprentice Meledor|QID|9066|U|22473|NC|N|Target Apprentice Meledor and use the rod that Anetheol gave you.|Z|Eversong Woods|M|44.9,61.0|QO|1|T|Apprentice Meledor|
-C The Dead Scar|QID|8475|N|Go through the Dead Scar and kill 8 Plaguebone Pillagers. \n\nBe careful of the pack of Rotlimb Cannibals and also avoid the center of the Dead Scar as both can be difficult for an in-level player to survive. |Z|Eversong Woods|M|51.2,56.3|
+C The Dead Scar|QID|8475|N|Go through the Dead Scar and kill 8 Plaguebone Pillagers.\n\nBe careful of the pack of Rotlimb Cannibals and also avoid the center of the Dead Scar as both can be difficult for an in-level player to survive.|Z|Eversong Woods|M|51.2,56.3|
 T The Dead Scar|QID|8475|N|To Ranger Jaela.|Z|Eversong Woods|M|50.3,50.8|
 T Swift Discipline|QID|9066|N|To Instructor Antheol.|Z|Eversong Woods|M|55.7,54.5|
 F Falconwing Square|QID|8483|Z|Eversong Woods|M|54.37,50.73|N|Fly to Falconwing Square.|
@@ -173,46 +174,46 @@ T Fairbreeze Village|QID|9256|N|To Ranger Degolien. Up the ramp.|Z|Eversong Wood
 A Situation at Sunsail Anchorage|QID|8892|N|From Ranger Degolien|Z|Eversong Woods|M|43.3,70.8|
 A Ranger Sareyn|QID|9358|LEAD|9252|N|From Marniel Amberlight. If you've already done Defending Fairbreeze Village this quest won't be available so just skip it.|Z|Eversong Woods|M|43.7,71.2|
 h Fairbreeze Village|QID|9395|N|With Marniel Amberlight.|
-A Goods from Silvermoon City|QID|9130|R|BloodElf|Z|Eversong Woods|M|43.7,71.54|N|From Sathiel.|
+A Goods from Silvermoon City|QID|9130|Z|Eversong Woods|M|43.7,71.54|N|From Sathiel.|
 r Repair/Sell Junk|QID|9395|Z|Eversong Woods|M|43.7,71.54|N|At Sathiel.\n\nRight click this step to continue.|
 C Pelt Collection|QID|8491|N|Kill springpaws.|Z|Eversong Woods|M|46.00,67.00|S|
 T Saltheril's Haven|QID|9395|N|To Lord Saltheril.|Z|Eversong Woods|M|38.1,73.6|
 A The Party Never Ends|QID|9067|N|From Lord Saltheril.|Z|Eversong Woods|M|38.1,73.6|
 B Bundle of Fireworks|QID|9067|QO|3|N|Buy a Bundle of fireworks from Halis Dawnstrider at Fairbreeze Village.|Z|Eversong Woods|M|44.10,70.40|
-T Goods from Silvermoon City|QID|9130|R|BloodElf|N|To Skymaster Brightdawn.|Z|Eversong Woods|M|44,70|
-A Fly to Silvermoon City|QID|9133|PRE|9130|R|BloodElf|Z|Eversong Woods|M|44,70|N|From Skymaster Brightdawn.|
+T Goods from Silvermoon City|QID|9130|N|To Skymaster Brightdawn.|Z|Eversong Woods|M|44,70|
+A Fly to Silvermoon City|QID|9133|PRE|9130|Z|Eversong Woods|M|44,70|N|From Skymaster Brightdawn.|
 F Silvermoon City|QID|9133|Z|Eversong Woods|M|44,70|N|Ask Skymaster Brightdawn to fly you to Silvermoon City.|
 R Silvermoon City|QID|9133|N|Run east to Silvermoon City.|M|72.37,90.93|Z|Silvermoon City|
-T Fly to Silvermoon City|QID|9133|R|BloodElf|Z|Silvermoon City|N|To Sathren Azuredawn.|M|69.26,77.04;68.28,74.08;66.50,73.43;54,71|CS|
-A Skymistress Gloaming|QID|9134|PRE|9133|R|BloodElf|M|54,71|Z|Silvermoon City|N|From Sathren Azuredawn.|
+T Fly to Silvermoon City|QID|9133|Z|Silvermoon City|N|To Sathren Azuredawn.|M|69.26,77.04;68.28,74.08;66.50,73.43;54,71|CS|
+A Skymistress Gloaming|QID|9134|PRE|9133|M|54,71|Z|Silvermoon City|N|From Sathren Azuredawn.|
 B Suntouched Special Reserve|QID|9067|QO|1|Z|Silvermoon City|N|Buy a bottle of Suntouched Special Reserve from Vinemaster Suntouched. Also, visit your trainer if you need to.|M|79.70,58.40|
-T Skymistress Gloaming|QID|9134|R|BloodElf|Z|Eversong Woods|M|54.38,50.79|N|To Skymistress Gloaming.|
-A Return to Sathiel|QID|9135|PRE|9134|R|BloodElf|Z|Eversong Woods|M|54.38,50.79|N|From Skymistress Gloaming.|
+T Skymistress Gloaming|QID|9134|Z|Eversong Woods|M|54.38,50.79|N|To Skymistress Gloaming.|
+A Return to Sathiel|QID|9135|PRE|9134|Z|Eversong Woods|M|54.38,50.79|N|From Skymistress Gloaming.|
 F Fairbreeze Village|QID|9135|Z|Eversong Woods|M|54.38,50.79|N|Fly to Fairbreeze Village, or just hearth.|
-T Return to Sathiel|QID|9135|R|BloodElf|Z|Eversong Woods|M|43.69,71.51|N|To Sathiel.|
+T Return to Sathiel|QID|9135|Z|Eversong Woods|M|43.69,71.51|N|To Sathiel.|
 T Captain Kelisendra's Lost Rutters|QID|8887|N|To Captain Kelisendra. Follow the road west until you reach Sunsail Anchorage.|Z|Eversong Woods|M|36.4,66.7|
 A Grimscale Pirates!|QID|8886|N|From Captain Kelisendra.|Z|Eversong Woods|M|36.4,66.7|
 A Lost Armaments|QID|8480|N|From Velendris Whitemorn.|Z|Eversong Woods|M|36.4,66.7|
-C Grimscale Pirates!|QID|8886|N|Either pick these up from the floor, or kill and loot the murlocs. |Z|Eversong Woods|M|24.9,66.8|S|
-K Kill Mmmrrrggglll|QID|8885|QO|1|N|He roams the beach. |Z|Eversong Woods|M|25,69|T|Mmmrrrggglll|
-C Grimscale Pirates!|QID|8886|N|Either pick these up from the floor, or kill and loot the murlocs. |Z|Eversong Woods|M|24.9,66.8|US|
+C Grimscale Pirates!|QID|8886|N|Either pick these up from the floor, or kill and loot the murlocs.|Z|Eversong Woods|M|24.9,66.8|S|
+K Kill Mmmrrrggglll|QID|8885|QO|1|N|He roams the beach.|Z|Eversong Woods|M|25,69|T|Mmmrrrggglll|
+C Grimscale Pirates!|QID|8886|N|Either pick these up from the floor, or kill and loot the murlocs.|Z|Eversong Woods|M|24.9,66.8|US|
 T The Ring of Mmmrrrggglll|QID|8885|N|To Hathvelion Sungaze|Z|Eversong Woods|M|30.2,58.5|
 C Situation at Sunsail Anchorage|QID|8892|S|N|Kill Wretched Thugs and Hooligans.|
 C Lost Armaments|QID|8480|N|Run around the big white gazeebo looting the Weapon Containers.|Z|Eversong Woods|M|31.0,69.0|NC|
 T Grimscale Pirates!|QID|8886|N|To Captain Kelisendra. At Sunsail Anchorage.|Z|Eversong Woods|M|36.4,66.7|
-T Lost Armaments |QID|8480|N|To Velendris Whitemorn.|Z|Eversong Woods|M|36.4,66.7|
+T Lost Armaments|QID|8480|N|To Velendris Whitemorn.|Z|Eversong Woods|M|36.4,66.7|
 A Wretched Ringleader|QID|9076|PRE|8480|N|From Velendris Whitemorn.|Z|Eversong Woods|M|36.4,66.7|
-K Aldaron|QID|9076|QO|1|N|Go back to the big white tower-like building and fight your way up. At the top you'll find Aldaron the Reckless with two guards. If you are careful you can probably pull the guards solo before you kill Aldras. |Z|Eversong Woods|M|32.70,68.4|
+K Aldaron|QID|9076|QO|1|N|Go back to the big white tower-like building and fight your way up. At the top you'll find Aldaron the Reckless with two guards. If you are careful you can probably pull the guards solo before you kill Aldras.|Z|Eversong Woods|M|32.70,68.4|
 C Situation at Sunsail Anchorage|QID|8892|S|N|Finish killing the Wretched Thugs and Hooligans.|
 T Wretched Ringleader|QID|9076|N|To Velendris Whitemorn.|Z|Eversong Woods|M|36.4,66.7|
-C Pelt Collection|QID|8491|N|Kill springpaws. They're all around Fairbreeze. |Z|Eversong Woods|M|46.00,67.00|US|
+C Pelt Collection|QID|8491|N|Kill springpaws. They're all around Fairbreeze.|Z|Eversong Woods|M|46.00,67.00|US|
 T Pelt Collection|QID|8491|N|To Velan Brightoak.|Z|Eversong Woods|M|44.7,69.6|
 T Situation at Sunsail Anchorage|QID|8892|N|To Ranger Degolien.|Z|Eversong Woods|M|43.3,70.8|
 A Farstrider Retreat|QID|9359|LEAD|8476|PRE|8892|N|From Ranger Degolien.|Z|Eversong Woods|M|43.3,70.8|
 r Repair/Sell Junk|QID|9358|Z|Eversong Woods|M|43.7,71.54|N|At Sathiel.\n\nRight click this step to continue.|
 T Ranger Sareyn|QID|9358|N|To Ranger Sareyn.|Z|Eversong Woods|M|46.9,71.8|
 A Defending Fairbreeze Village|QID|9252|N|From Ranger Sareyn.|Z|Eversong Woods|M|46.9,71.8|
-C Defending Fairbreeze Village|QID|9252|N|4 of each: Rotlimb marauder, Darkwraith. Follow the road southeast until you hit the Dead Scar. Then head south. |Z|Eversong Woods|M|50.00,75.00|
+C Defending Fairbreeze Village|QID|9252|N|4 of each: Rotlimb marauder, Darkwraith. Follow the road southeast until you hit the Dead Scar. Then head south.|Z|Eversong Woods|M|50.00,75.00|
 T The Wayward Apprentice|QID|9254|N|To Apprentice Mirveda. Go north along the Dead Scar until you reach Mivenda.|Z|Eversong Woods|M|54.3,71.0|
 A Corrupted Soil|QID|8487|N|From Apprentice Mirveda.|Z|Eversong Woods|M|54.3,71.0|
 C Corrupted Soil|QID|8487|N|Loot 8 Tainted Soil Samples, they are green looking.|Z|Eversong Woods|M|52.60,68.40|
@@ -226,7 +227,7 @@ A Amani Encroachment|QID|8476|N|From Lieutenant Dawnrunner.|Z|Eversong Woods|M|6
 B Buy Springpaw Appetizers|QID|9067|QO|2|N|Buy Springpaw Appetizers from Zalene Firstlight at Farstrider Retreat.|Z|Eversong Woods|M|60.40,62.46|
 A The Spearcrafter's Hammer|QID|8477|N|From Arathel Sunforge.|Z|Eversong Woods|M|59.5,62.6|
 A The Magister's Apprentice|QID|8888|LEAD|8889|N|From Magister Duskwither. Up the right ramp.|Z|Eversong Woods|M|60.3,61.4|
-A The Purest Water|QID|9403|PRE|9402|N|From Instructor Antheol.|R|BloodElf|C|Mage|Z|Eversong Woods|M|55.7,54.5|
+A The Purest Water|QID|9403|PRE|9402|N|From Instructor Antheol.|C|Mage|Z|Eversong Woods|M|55.7,54.5|
 R Thuron's Livery|QID|8888|N|If you want the explorer achievement, head to Thuron's Livery.\n\nIf you don't, just click this step.|Z|Eversong Woods|M|62.00,53.00|
 T The Magister's Apprentice|QID|8888|N|To Apprentice Loralthalis. Head out of the city and follow the road east.|Z|Eversong Woods|M|67.8,56.5|
 A Deactivating the Spire|QID|8889|N|From Apprentice Loralthalis.|Z|Eversong Woods|M|67.8,56.5|
@@ -244,12 +245,12 @@ C Deactivating the Spire|QID|8889|N|Head up the stairs again, then deactivate th
 T Deactivating the Spire|QID|8889|N|Click the Orb of Translocation to head back to ground level, then head to Apprentice Loralthalis.|Z|Eversong Woods|M|67.8,56.5|
 A Word from the Spire|QID|8890|PRE|8889|N|From Apprentice Loralthalis.|Z|Eversong Woods|M|67.8,56.5|
 ;N Visit your trainer if you want|QID|8890|N|since we are by Silvermoon City. Right-click the box to continue.|
-T Word from the Spire|QID|8890|N|To Magister Duskwither. Back at farstrider retreat, up the right ramp. |Z|Eversong Woods|M|60.3,61.4|
+T Word from the Spire|QID|8890|N|To Magister Duskwither. Back at farstrider retreat, up the right ramp.|Z|Eversong Woods|M|60.3,61.4|
 T Abandoned Investigations|QID|8891|N|To Magister Duskwither.|Z|Eversong Woods|M|60.3,61.4|
 C Amani Encroachment|QID|8476|N|Kill trolls that you need for Amani Encroachment while doing the next quests.|S|
 K Spearcrafter Otembe|QID|8477|QO|1|N|Head to southeast to the trolls, toward Spearcrafter Otembe. Kill trolls that you need for Amani Encroachment while you go.|Z|Eversong Woods|M|70,72|
 A Zul'Marosh|QID|8479|N|From Ven'jashi.|Z|Eversong Woods|M|70.5,72.3|
-K Chieftain Zul'Marosh|QID|8479|L|23249|N|Head west across the water to the next troll camp. Zul'Marosh is in the big building on the top floor. Pull guards first. |Z|Eversong Woods|M|61.60,79.60|
+K Chieftain Zul'Marosh|QID|8479|L|23249|N|Head west across the water to the next troll camp. Zul'Marosh is in the big building on the top floor. Pull guards first.|Z|Eversong Woods|M|61.60,79.60|
 A Amani Invasion|QID|9360|N|From the Amani Invasion Plans.|Z|Eversong Woods|M|62.6,79.7|U|23249|
 T Zul'Marosh|QID|8479|N|To Ven'jashi.|Z|Eversong Woods|M|70.5,72.3|
 C Amani Encroachment|QID|8476|US|Z|Eversong Woods|M|69.00,72.00|N|Finish killing Trolls needed.|
@@ -258,10 +259,10 @@ T Amani Encroachment|QID|8476|N|To Lieutenant Dawnrunner at the Farstrider Retre
 T Amani Invasion|QID|9360|N|To Lieutenant Dawnrunner.|Z|Eversong Woods|M|60.3,62.8|
 A Warning Fairbreeze Village|QID|9363|PRE|9360|Z|Eversong Woods|M|60.32,62.76|N|From Lieutenant Dawnrunner.|
 T The Spearcrafter's Hammer|QID|8477|N|To Arathel Sunforge.|Z|Eversong Woods|M|59.5,62.6|
-C The Purest Water|QID|9403|R|BloodElf|C|Mage|Z|Eversong Woods|M|64.21,72.66|U|23566|N|Go to the base of the waterfall, in the water, and fill the Azure Phial.|
-T The Purest Water|QID|9403|R|BloodElf|C|Mage|N|To Instructor Antheol.|Z|Eversong Woods|M|55.7,54.5|
+C The Purest Water|QID|9403|C|Mage|Z|Eversong Woods|M|64.21,72.66|U|23566|N|Go to the base of the waterfall, in the water, and fill the Azure Phial.|
+T The Purest Water|QID|9403|C|Mage|N|To Instructor Antheol.|Z|Eversong Woods|M|55.7,54.5|
 H Fairbreeze Village|QID|9255|U|6948|N|Hearth to Fairbreeze Village.|
-T Research Notes |QID|9255|N|To Magistrix Landra Dawnstrider.|Z|Eversong Woods|M|44.03,70.76|
+T Research Notes|QID|9255|N|To Magistrix Landra Dawnstrider.|Z|Eversong Woods|M|44.03,70.76|
 T Warning Fairbreeze Village|QID|9363|N|To Ranger Degolien.|Z|Eversong Woods|M|43.3,70.8|
 T Defending Fairbreeze Village|QID|9252|N|To Ranger Sareyn.|Z|Eversong Woods|M|46.93,71.79|
 A The Scorched Grove|QID|9258|LEAD|8473|N|From Ardeyn Riverwind.|Z|Eversong Woods|M|43.6,71.2|
@@ -276,6 +277,6 @@ A Whitebark's Memory|QID|10166|PRE|8474|Z|Eversong Woods|M|34,80|N|From Larianna
 T Whitebark's Memory|QID|10166|Z|Eversong Woods|M|37.58,86.14|N|To Whitebark's Spirit. Use the pendant, Whitebark will attack you. Get him down in health, then turn the quest in.|U|28209|
 C A Somber Task|QID|8473|Z|Eversong Woods|M|35.7,85.2|N|Kill 10 Withered Green Keepers.|US|
 T A Somber Task|QID|8473|Z|Eversong Woods|M|34,80|N|To Larianna Riverwind.|
-N End of Eversong Woods Guide |QID|9144|N|That's it from Eversong Woods. Don't worry about not yet having the Explore Eversong Woods Acheivement if you're missing just two (Runestone Falithas and Runestone Shan'dor) as you'll discover those places in the Ghostlands guide.  If you're not doing Ghostlands guide, then run to the two waypoints.  \n\nYou may also want to update your skills from Silvermoon City.\n\nClick here to continue to the Ghostlands Guide.|Z|Eversong Woods|M|43,86;55,84|CC|
+N End of Eversong Woods Guide|QID|9144|N|That's it from Eversong Woods. Don't worry about not yet having the Explore Eversong Woods Acheivement if you're missing just two (Runestone Falithas and Runestone Shan'dor) as you'll discover those places in the Ghostlands guide.  If you're not doing Ghostlands guide, then run to the two waypoints.  \n\nYou may also want to update your skills from Silvermoon City.\n\nClick here to continue to the Ghostlands Guide.|Z|Eversong Woods|M|43,86;55,84|CC|
 ]]
 end)

--- a/WoWPro_Leveling/Classic_BC/Horde/CLASSIC_BC_Blood_Elf.lua
+++ b/WoWPro_Leveling/Classic_BC/Horde/CLASSIC_BC_Blood_Elf.lua
@@ -36,11 +36,13 @@ A A Fistful of Slivers|QID|8336|M|38.28,19.13|N|From Arcanist Ithanas, on the pa
 A Thirst Unending|QID|8346|M|37.18,18.95|N|From Arcanist Helion. You can see him on the patio directly opposite from your current position.|R|BloodElf|
 R Empty your bags|ACTIVE|8346|M|37.14,19.03|N|Empty your bags and repair before venturing further.\n[color=FF0000]NOTE: [/color]Jainthess Thelryn, standing beside you, can help you with that.|R|BloodElf|
 
-C Unfortunate Measures|QID|8326|M|54.82,54.34|L|20797 8|N|Kill Springpaw Lynxes and Cubs to collect the Lynx Collars.\n[color=FF0000]NOTE: [/color]Lynxes drop multiples and Cubs only drop one at a time.|R|BloodElf|S|
+C Unfortunate Measures|QID|8326|M|36.22,22.64|L|20797 8|N|Kill Springpaw Lynxes and Cubs to collect the Lynx Collars.|R|BloodElf|S|
 C A Fistful of Slivers|QID|8336|M|35.39,20.24|L|20482 6|N|Kill Mana Wyrms to collect the Arcane Slivers.\n[color=FF0000]NOTE: [/color]Any creature that uses mana can drop them; Mana Wyrms are easier and more convenient.|R|BloodElf|S|
-C Thirst Unending|QID|8346|M|35.39,20.24|N|Use Arcane Torrent when you are within 8 yards of a Mana Wyrm.\n[color=FF0000]NOTE: [/color]Arcane Torrent has a 2 minute cooldown.\nThis works on ANY creature that uses mana.|R|BloodElf|
-l Solanian's Belongings|QID|8330|M|60.06,57.11|L|20472|N|Pick up Solanian's Journal, near the big green crystal.|R|BloodElf|
-C Unfortunate Measures|QID|8326|M|54.82,54.34|N|Finish collecting the Lynx collars.|R|BloodElf|US|
+C Thirst Unending|QID|8346|M|35.39,20.24|N|Use Arcane Torrent when you are within 8 yards of a Mana Wyrm.\n[color=FF0000]NOTE: [/color]Arcane Torrent has a 2 minute cooldown.\nThis works on ANY creature that uses mana.|R|BloodElf|S|
+C Solanian's Belongings|QID|8330|M|37.70,24.90|L|20472|N|Pick up Solanian's Journal, near the big green crystal.|R|BloodElf|
+C Unfortunate Measures|QID|8326|M|36.22,22.64|N|Finish collecting the Lynx collars.\n[color=FF0000]NOTE: [/color]If this area is busy, you can find more behind the buildings northeast of you.|R|BloodElf|US|
+C Thirst Unending|QID|8346|M|35.39,20.24|N|Use Arcane Torrent when you are within 8 yards of a Mana Wyrm.\n[color=FF0000]NOTE: [/color]Arcane Torrent has a 2 minute cooldown.\nThis works on ANY creature that uses mana.|R|BloodElf|US|
+C A Fistful of Slivers|QID|8336|M|35.39,20.24|L|20482 6|N|Kill Mana Wyrms to collect the Arcane Slivers.\n[color=FF0000]NOTE: [/color]Any creature that uses mana can drop them; Mana Wyrms are easier and more convenient.|R|BloodElf|US|
 
 L Level 3|AVAILABLE|8327|N|You need to be Level 3 to continue this guide.|LVL|3|R|BloodElf|
 T Thirst Unending|QID|8346|M|37.20,18.95|N|To Arcanist Helion.|R|BloodElf|


### PR DESCRIPTION
- K Mana Wyrm|ACTIVE|8325| missing QO
- Level 2 |LVL| filter corrected
- Sorted class quest by QID
- Added A/T step for Well Watcher Solanian
- Stripped all Z|Sunstrider Isle| tags that were left.
- Made guide BloodElf specific and stripped all R|BloodElf| tags
- His name is 'Solanian'
- QO|Solanian's Journal: 1/1| doesn't work -> QO|3| does