### PR TITLE
Update CLASSIC_BC_Blood_Elf.lua

### DIFF
--- a/WoWPro_Leveling/Classic_BC/Horde/CLASSIC_BC_Blood_Elf.lua
+++ b/WoWPro_Leveling/Classic_BC/Horde/CLASSIC_BC_Blood_Elf.lua
@@ -34,7 +34,7 @@ A Solanian's Belongings|QID|8330|M|38.76,19.36|N|From Well Watcher Solanian.|R|B
 A The Shrine of Dath'Remar|QID|8345|M|38.76,19.36|N|From Well Watcher Solanian.|R|BloodElf|
 A A Fistful of Slivers|QID|8336|M|38.28,19.13|N|From Arcanist Ithanas, on the patio below you. You can jump down from the balcony.|R|BloodElf|
 A Thirst Unending|QID|8346|M|37.18,18.95|N|From Arcanist Helion. You can see him on the patio directly opposite from your current position.|R|BloodElf|
-R Empty your bags|ACTIVE|8346|M|37.14,19.03|N|Empty your bags and repair before venturing further.\n[color=FF0000]NOTE: [/color]Jainthess Thelryn, standing beside you, can help you with that.|R|BloodElf|
+r Empty your bags|ACTIVE|8346|M|37.14,19.03|N|Empty your bags and repair before venturing further.\n[color=FF0000]NOTE: [/color]Jainthess Thelryn, standing beside you, can help you with that.|R|BloodElf|
 
 C Unfortunate Measures|QID|8326|M|36.22,22.64|L|20797 8|N|Kill Springpaw Lynxes and Cubs to collect the Lynx Collars.|R|BloodElf|S|
 C A Fistful of Slivers|QID|8336|M|35.39,20.24|L|20482 6|N|Kill Mana Wyrms to collect the Arcane Slivers.\n[color=FF0000]NOTE: [/color]Any creature that uses mana can drop them; Mana Wyrms are easier and more convenient.|R|BloodElf|S|
@@ -44,47 +44,25 @@ C Unfortunate Measures|QID|8326|M|36.22,22.64|N|Finish collecting the Lynx colla
 C Thirst Unending|QID|8346|M|35.39,20.24|N|Use Arcane Torrent when you are within 8 yards of a Mana Wyrm.\n[color=FF0000]NOTE: [/color]Arcane Torrent has a 2 minute cooldown.\nThis works on ANY creature that uses mana.|R|BloodElf|US|
 C A Fistful of Slivers|QID|8336|M|35.39,20.24|L|20482 6|N|Kill Mana Wyrms to collect the Arcane Slivers.\n[color=FF0000]NOTE: [/color]Any creature that uses mana can drop them; Mana Wyrms are easier and more convenient.|R|BloodElf|US|
 
-L Level 3|AVAILABLE|8327|N|You need to be Level 3 to continue this guide.|LVL|3|R|BloodElf|
 T Thirst Unending|QID|8346|M|37.20,18.95|N|To Arcanist Helion.|R|BloodElf|
-R Empty your bags|ACTIVE|8326|N|Don't forget to repair and empty your bags.|R|BloodElf|
+r Empty your bags|ACTIVE|8326|M|37.14,19.03|N|Don't forget to repair and empty your bags.\n[color=FF0000]NOTE: [/color]Check this step off to continue.|R|BloodElf|
 T Unfortunate Measures|QID|8326|M|38.21,20.83|N|To Magistrix Erona.|R|BloodElf|
 A Report to Lanthan Perilon|QID|8327|M|61.59,44.49|N|From Magistrix Erona.|R|BloodElf|
-A Charge!|QID|27091|M|64.98,42.34|N|From Delios Silverblade.|R|BloodElf|C|Warrior|
-C Charge!|QID|27091|M|62.00,44.00|N|Learn charge from your trainer and Charge the target dummy.|R|BloodElf|C|Warrior|
-T Charge!|QID|27091|M|64.98,42.34|N|To Delios Silverblade.|R|BloodElf|C|Warrior|
-A Steady Shot|QID|10070|M|64.06,42.03|N|From Ranger Sallina.|R|BloodElf|C|Hunter|
-C Steady Shot|QID|10070|M|62.00,44.00|N|Learn Steady Shot from Ranger Sallina. Locate a Training Dummy outside the Sunspire and practice using Steady Shot 5 times.|R|BloodElf|C|Hunter|
-T Steady Shot|QID|10070|M|64.06,42.03|N|To Ranger Sallina.|R|BloodElf|C|Hunter|
-A Arcane Missiles|QID|10068|M|64.67,46.65|N|From Julia Sunstriker.|R|BloodElf|C|Mage|
-C Arcane Missiles|QID|10068|M|62.00,44.00|N|Learn Arcane Missiles from Julia Sunstriker. Locate a Training Dummy outside the Sunspire and practice using Arcane Missiles 2 times.|R|BloodElf|C|Mage|
-T Arcane Missiles|QID|10068|M|64.67,46.65|N|To Julia Sunstriker.|R|BloodElf|C|Mage|
-A Ways of the Light|QID|10069|M|65.60,43.88|N|From Jesthenis Sunstriker.|R|BloodElf|C|Paladin|
-C Ways of the Light|QID|10069|M|62.00,44.00|N|Learn Judgement and Seal of Righteousness from Jesthenis Sunstriker. Cast Seal of Righteousness on yourself, then locate a Training Dummy outside the Sunspire and use Judgement.|R|BloodElf|C|Paladin|
-T Ways of the Light|QID|10069|M|65.60,43.88|N|To Jesthenis Sunstriker.|R|BloodElf|C|Paladin|
-A Evisceration|QID|10071|M|63.75,42.03|N|From Pathstalker Kariel.|R|BloodElf|C|Rogue|
-C Evisceration|QID|10071|M|62.00,44.00|N|Learn Eviscerate from Pathstalker Kariel. Locate a Training Dummy outside the Sunspire and practice using Eviscerate 3 times.|R|BloodElf|C|Rogue|
-T Evisceration|QID|10071|M|63.75,42.03|N|To Pathstalker Kariel.|R|BloodElf|C|Rogue|
-A Learning the Word|QID|10072|M|65.29,43.26|N|From Matron Arena.|R|BloodElf|C|Priest|
-C Learning the Word|QID|10072|M|134.64,115.87|N|Locate a Training Dummy outside the Sunspire and practice using Shadow Word: Pain 5 times.|R|BloodElf|C|Priest|
-T Learning the Word|QID|10072|M|65.29,43.26|N|To Matron Arena|R|BloodElf|C|Priest|
-A Immolation|QID|10073|M|63.75,46.34|N|From Summoner Teli'Larien|R|BloodElf|C|Warlock|
-C Immolation|QID|10073|M|62.00,44.00|N|Learn Immolate from Summoner Teli'Larien. Locate a Training Dummy outside the Sunspire and practice casting Immolate 5 times.|R|BloodElf|C|Warlock|
-T Immolation|QID|10073|M|63.75,46.34|N|To Summoner Teli'Larien|R|BloodElf|C|Warlock|
-T Report to Lanthan Perilon|QID|8327|M|35.4,22.5|N|To Lanthan Perilon.|R|BloodElf|
 
-A Aggression|QID|8334|M|35.4,22.5|N|From Lanthan Perilon.|R|BloodElf|
-C Aggression|QID|8334|N|Kill any Tender and Feral Tender you see.|R|BloodElf|S|
-l Solanian's Scrying Orb|ACTIVE|8330|M|52.15,69.46|L|20470|N|Pick up Solanian's Scrying Orb from the lake's platform, to the south of Sunstrider Isle.|R|BloodElf|
-l Solanian's Belongings|ACTIVE|8330|M|40.48,50.50|L|20471|N|Pick up the Scroll of Scourge Magic, which is northwest.|R|BloodElf|
-C The Shrine of Dath'Remar|QID|8345|M|35.43,40.49|N|Go to the far north-west of the island until you reach the Shrine of Dath'Remar. Click on it to read the plaque.|R|BloodElf|NC|
-C Aggression|QID|8334|N|Finish killing the Feral Tenders and Tenders you need.|R|BloodElf|US|
+T Report to Lanthan Perilon|QID|8327|M|35.37,22.52|N|To Lanthan Perilon.|R|BloodElf|
+A Aggression|QID|8334|M|35.37,22.52|N|From Lanthan Perilon.|R|BloodElf|
+K Aggression|QID|8334|M|34.93,26.52|QO|1;2|N|Kill any Tender and Feral Tender you see.|R|BloodElf|S|
+C Solanian's Belongings|QID|8330|M|35.14,28.90|L|20470|N|Pick up Solanian's Scrying Orb from the lake side platform overhanging the pond.|R|BloodElf|
+C Solanian's Belongings|QID|8330|M|31.33,22.75|L|20471|N|Pick up the Scroll of Scourge Magic, which is northwest.|R|BloodElf|
+C The Shrine of Dath'Remar|QID|8345|M|29.65,19.40|N|The Shrine of Dath'Remar is in the furthest north-west corner of the island. Click on the plaque it to read.|R|BloodElf|NC|
+K Aggression|QID|8334|M|34.93,26.52|QO|1;2|N|Finish killing the Feral Tenders and Tenders you need.|R|BloodElf|US|
 C A Fistful of Slivers|QID|8336|M|59.44,54.04|N|As you head back to the Sunspire, finish collecting the Slivers from the Mana Wyrms and Feral Tenders|R|BloodElf|US|
 T The Shrine of Dath'Remar|QID|8345|M|38.96,20.27|N|To Well Watcher Solanian, inside The Sunspire, up the ramp.|R|BloodElf|
 T Solanian's Belongings|QID|8330|M|38.96,20.27|N|To Well Watcher Solanian.|R|BloodElf|
 T A Fistful of Slivers|QID|8336|M|38.3,19.1|N|To Arcanist Ithanas.|R|BloodElf|
 T Aggression|QID|8334|M|52.98,49.73|N|To Lanthan Perilon.|R|BloodElf|
 
-A Felendren the Banished|QID|8335|M|35.4,22.5|N|From Lanthan Perilon.|R|BloodElf|
+A Felendren the Banished|QID|8335|M|35.37,22.52|N|From Lanthan Perilon.|R|BloodElf|
 K Felendren the Banished|ACTIVE|8335|M|39.03,63.98|QO|1|N|Kill Arcane Wraiths|R|BloodElf|S|
 C Tainted Arcane Sliver|QID|8338|L|20483|N|Kill and loot a Tainted Arcane Wraith, it will drop a Tainted Arcane Sliver.|R|BloodElf|S|
 K Felendren the Banished|QID|8335|M|41.56,61.85;38.05,66.35|CC|L|20799|N|Go up the ramp and to the top of Falthrien Academy. At the first waypoint, there will be two paths to choose, both will merge further on, so either can be taken. At the top, kill Felendren and loot his head.|R|BloodElf|
@@ -96,9 +74,9 @@ L Level 4|QID|8347|LVL|4|N|You need to be Level 4 to continue this guide.|R|Bloo
 H Sunstrider Isle|ACTIVE|8338|M|37.75,21.10|N|Run back if your Hearth is on cooldown.|R|BloodElf|
 T Tainted Arcane Sliver|QID|8338|M|37.2,18.9|N|To Arcanist Helion.|R|BloodElf|
 r Repair/Sell|ACTIVE|8335|M|58.46,38.95|N|Repair and sell unwanted loot to Jainthess Thelryn.\nClose this step to continue.|RANK|3|R|BloodElf|
-T Felendren the Banished|QID|8335|M|35.4,22.5|N|To Lanthan Perilon.|R|BloodElf|
+T Felendren the Banished|QID|8335|M|35.37,22.52|N|To Lanthan Perilon.|R|BloodElf|
 
-A Aiding the Outrunners|QID|8347|M|35.4,22.5|N|From Lanthan Perilon.|R|BloodElf|
+A Aiding the Outrunners|QID|8347|M|35.37,22.52|N|From Lanthan Perilon.|R|BloodElf|
 T Aiding the Outrunners|QID|8347|M|40.4,32.2|N|To Outrunner Alarion.|R|BloodElf|
 A Slain by the Wretched|QID|9704|M|68.37,79.58|N|From Outrunner Alarion.|R|BloodElf|
 ;The guide continues at this point for all races


### PR DESCRIPTION
- Repair steps are 'r' not 'R'
- That block of class quests does not belong in TBC. The QIDs are the same as the 'Well Watcher Solanian' Lead quests.
- The Level 3 step is not required