### PR TITLE
IZ names to areaID or mapID

### DIFF
--- a/WoWPro/WoWPro_Broker.lua
+++ b/WoWPro/WoWPro_Broker.lua
@@ -1995,7 +1995,7 @@ function WoWPro.NextStep(guideIndex, rowIndex)
 				if tonumber(inzone) then
 					local _, mapID = WoWPro.GetZoneText()
 					inzone = tonumber(inzone)
-					if (subzonetext == _G.C_Map.GetAreaInfo(inzone)) then
+					if (subzonetext == _G.C_Map.GetAreaInfo(inzone) or zonetext == _G.C_Map.GetAreaInfo(inzone)) then
 						zonetext = inzone
 					else
 						zonetext = mapID

--- a/WoWPro_Leveling/Alliance/CATA_Duskwood.lua
+++ b/WoWPro_Leveling/Alliance/CATA_Duskwood.lua
@@ -145,7 +145,7 @@ A The Fate of Morbent Fel|QID|26723|M|18.35,58.06|N|From Sven Yorgen.|PRE|26760|
 A The Cries of the Dead|QID|26778|M|20.03,57.81|N|From Sister Eisington.|PRE|26760|
 C The Cries of the Dead|QID|26778|N|Kill any type of Ghoul you see.\n[color=FF0000]NOTE: [/color]Don't stick around if you kill a plague Spreader or Rotting Horror. They cast Corpse Rot; an AoE that lasts 10 seconds.|S|
 C The Fate of Morbent Fel|QID|26723|M|16.97,33.36|N|Head upstairs into the main room and click on the Bloodsoaked Hat that is on the floor inside.|NC|
-N Mor'Ladim|ACTIVE|26723|IZ|Forlorn Rowe|N|[color=FF0000]NOTE: [/color]Keep an eye out for Mor'Ladim. He is an Elite that patrols the road in front of the house and hits extremely hard. Exit the house cautiously and be prepared to defend yourself. You cannot see him if he's out front.|
+N Mor'Ladim|ACTIVE|26723|IZ|243|N|[color=FF0000]NOTE: [/color]Keep an eye out for Mor'Ladim. He is an Elite that patrols the road in front of the house and hits extremely hard. Exit the house cautiously and be prepared to defend yourself. You cannot see him if he's out front.|
 A The Weathered Grave|QID|26793|M|17.72,29.10|N|From "A Weathered Grave".|
 C Bear In Mind|QID|26787|M|13.48,53.07|N|As you head back towards Raven Hill, go through area to the west (river) of the cemetary and finish killing and looting Coalpelt (Black) Bears for their brains.\nDon't worry about the ghouls, you'll get more opportunity later.|US|
 T The Fate of Morbent Fel|QID|26723|M|18.34,58.05|N|To Sven Yorgen.|

--- a/WoWPro_Leveling/Alliance/CATA_Northern_Stranglethorn.lua
+++ b/WoWPro_Leveling/Alliance/CATA_Northern_Stranglethorn.lua
@@ -33,7 +33,7 @@ A Supply and Demand|QID|26343|M|43.62,23.42|N|From Drizzlik.|
 T Krazek's Cookery|QID|26740|M|43.60,23.14|N|To Krazek at Nesingwary's Expedition.|
 A Venture Company Mining|QID|26763|M|43.60,23.14|N|From Krazek.|PRE|26740|
 C The Green Hills of Stranglethorn|QID|26269|M|42.30,21.81|N|This can looted from any of the beast in the area.|S!US|
-t The Green Hills of Stranglethorn|QID|26269|M|44.24,22.13|N|To Barnil Stonepot.|IZ|Nesingwary's Expedition|
+t The Green Hills of Stranglethorn|QID|26269|M|44.24,22.13|N|To Barnil Stonepot.|IZ|100|
 C Tiger Hunting|QID|185|M|41.45,23.37|N|Kill Young Stranglethorn Tigers until complete.|S|
 C Supply and Demand|QID|26343|M|39.01,19.45|N|Follow the river west, kill and loot the River Crocolisk.|
 C Tiger Hunting|QID|185|M|41.45,23.37|N|Kill Young Stranglethorn Tigers until complete.|US|

--- a/WoWPro_Leveling/Classic/Alliance/12_20_Eastern_Kingdom.lua
+++ b/WoWPro_Leveling/Classic/Alliance/12_20_Eastern_Kingdom.lua
@@ -182,7 +182,7 @@ T Return to Verner|QID|119|M|30.98,47.28|Z|Redridge Mountains|N|To Verner Osgood
 A Underbelly Scales|QID|122|M|30.98,47.28|N|From Verner Osgood.|PRE|119|Z|Redridge Mountains
 
 C Redridge Goulash|ACTIVE|92|QO|1;2;3|N|Kill tarantulas, goretusks for the items required.|S|LVL|17|
-C Redridge Goulash|ACTIVE|92|QO|1;3|N|Kill tarantulas and goretusks for the items required.|S|LVL|-17|IZ|Redridge Mountains|
+C Redridge Goulash|ACTIVE|92|QO|1;3|N|Kill tarantulas and goretusks for the items required.|S|LVL|-17|IZ|1433|
 C Underbelly Scales|ACTIVE|122|QO|1|N|Kill Black Dragon Whelps to loot Underbelly Whelp Scales.|S|LVL|17|
 T Hilary's Necklace|QID|3741|M|29.24,53.62|N|To Hilary.|Z|Redridge Mountains|
 T A Free Lunch|QID|129|M|15.28,71.46|N|To Guard Parker. He roams the fork in the road up ahead.|Z|Redridge Mountains|
@@ -218,7 +218,7 @@ A The Defias Brotherhood|QID|141|M|75.79,59.85|Z|Stormwind City|N|From Master Ma
 A Humble Beginnings|QID|399|M|49.19,30.27|Z|Stormwind City|N|From Baros Alexston in Cathedral Square.|
 T Elmore's Task|QID|1097|M|51.74,12.13|Z|Stormwind City|N|To Grimand Elmore in Dwarven District. \n(skip followup -- unless you are inclined to take a trip to Loch Modan on your own.)|
 
-F Ironforge|AVAILABLE|2039|M|66.29,62.13|Z|Stormwind City|N|Fly to Ironforge to start this guide.|IZ|-Ironforge|
+F Ironforge|AVAILABLE|2039|M|66.29,62.13|Z|Stormwind City|N|Fly to Ironforge to start this guide.|IZ|-1455|
 A Find Bingles|QID|2039|LEAD|2038|M|69.14,50.60|Z|Ironforge|N|From Gnoarn.|
 F Thelsamar|ACTIVE|2039|M|55.49,47.75|Z|Ironforge|N|Fly to Thelsamar at Gryth Thurden.|
 

--- a/WoWPro_Leveling/Classic/Alliance/30_41_Alliance.lua
+++ b/WoWPro_Leveling/Classic/Alliance/30_41_Alliance.lua
@@ -18,7 +18,7 @@ B Frost Oil|QID|713|L|3829|N|Crafted with Alchemy.|ITEM|3829|
 B Gyrochronatom|QID|714|L|4389|N|Crafted with Engineering.|ITEM|4389|
 B Patterned Bronze Bracers|QID|716|L|2868|N|Crafted with Blacksmithing.|ITEM|2868|
 
-F Menethil Harbor|ACTIVE|1179|M|55.60,47.40|N|Fly to Menethil Harbor.|IZ|Ironforge|
+F Menethil Harbor|ACTIVE|1179|M|55.60,47.40|N|Fly to Menethil Harbor.|IZ|1455|
 b Theramore Isle|QID|1282|M|5,63.51|Z|Wetlands|N|Take the boat to Theramore.\nNote: If still in Darnassus take the boat from Darkshore to Menethil Harbor first|
 
 f Theramore|QID|1039|M|67.48,51.30|Z|Dustwallow Marsh|N|Get the Flightpoint from Baldruc.|
@@ -259,7 +259,7 @@ T Northfold Manor|QID|681|M|45.83,47.55|Z|Arathi Highlands|N|To Captain Nials.|
 A Worth Its Weight in Gold|QID|691|M|46.20,47.76|Z|Arathi Highlands|N|From Apprentice Kryten.|PRE|690|
 T Hints of a New Plague?|QID|659|M|60.18,53.85|Z|Arathi Highlands|N|To Quae.|
 A Hints of a New Plague?|QID|658|M|60.18,53.85|Z|Arathi Highlands|N|From Quae.|PRE|659|
-K Forsaken Courier|ACTIVE|658|M|61.00,60.00|L|647|S|N|Look out for a group of Forsaken leaving Go'Shek Farm. The Forsaken Courier in the center drops a Sealed Folder. A group is recommended to kill these.\nIf unable to find others use and cooldowns or crowd control available whilst focusing the Courier then reset the Guards and loot the letter|T|Forsaken Courier|IZ|Arathi Highlands|
+K Forsaken Courier|ACTIVE|658|M|61.00,60.00|L|647|S|N|Look out for a group of Forsaken leaving Go'Shek Farm. The Forsaken Courier in the center drops a Sealed Folder. A group is recommended to kill these.\nIf unable to find others use and cooldowns or crowd control available whilst focusing the Courier then reset the Guards and loot the letter|T|Forsaken Courier|IZ|1417|
 L Level 35|N|If you are not yet level 35 grind on the Orcs here|LVL|-35|
 R Thandol Span|AVAILABLE|647|M|60.80,60.65;45.80,59.20;43.25,91.20|CC|Z|Arathi Highlands|CC|N|Head to the road leading out of Go'Shek Farm. Follow the road west and towards Wetlands when the road turns south|
 A MacKreel's Moonshine|QID|647|M|43.25,91.20;43.24,92.64|CC|Z|Arathi Highlands|N|Head to the broken side of the bridge. Stand on the right side of the chain and use Slowfall/Levitate on yourself. Aim yourself towards the Torch on the opposite side. Run and jump off the bridge to float over. Accept the quest from Foggy MacKreel in the room on the right. Be aware this is a timed quest. If you fail the jump swim east until you come to a hill you can run back up.|C|Mage,Priest|

--- a/WoWPro_Leveling/Classic/Horde/01_12_Hendo_Durotar.lua
+++ b/WoWPro_Leveling/Classic/Horde/01_12_Hendo_Durotar.lua
@@ -91,7 +91,7 @@ r Sell junk/reload|ACTIVE|794|M|42.59,67.34|N|At Duokna.\nRight-click this step 
 R Burning Blade Coven|ACTIVE|6394|M|45.31,56.57|N|Head back to the cave entrance you were just at.|
 C Burning Blade Medallion|QID|794|M|42.70,52.91|N|Take the right passage and continue over the stream to the first fork. At the fork, go to the right and head for the opening at the end of the tunnel. Kill Yarrog Baneshadow and loot the Burning Blade Medallion from him.|
 l Thazz'ril's Pick|QID|6394|M|43.73,53.79|QO|1|N|Drop off the ledge and make your way to the other side, atop the waterfall. Follow the stream to the pool at the top. On the far side of the pool, you'll find the Pick leaning against a spire.|
-R Exit cave|ACTIVE|6394|M|45.25,56.62|N|Make your way to the exit.|IZ|Burning Blade Coven|
+R Exit cave|ACTIVE|6394|M|45.25,56.62|N|Make your way to the exit.|IZ|365|
 T Thazz'ril's Pick|QID|6394|M|44.62,68.65|N|Return to Foreman Thazz'ril.|
 T Burning Blade Medallion|QID|794|M|42.85,69.15|N|To Zureetha Fargaze.|
 A Report to Sen'jin Village|QID|805|M|42.85,69.15|N|From Zureetha Fargaze.|PRE|794|
@@ -99,7 +99,7 @@ r Repair/Restock|QID|805|M|42.59,67.34|N|At Duokna.\nRight-click this step when 
 
 N Mage Trainer|QID|805|N|[color=FF0000]NOTE: [/color]Mai'ah (Valley of Trials) and Un'Thuwa (Sen'jin Village) are the only Mage trainers in Durotar. After level 6, Mai'ah will no longer train you. You either go to Orgrimmar, or you return to Sen'jin Village.|C|Mage|
 L Level 6|QID|805|N|You'll want to be level 6 before you leave Sen'jin. You won't be back here for a while and you'll want to do your level 6 training before leaving.\nGrind on your way to Sen'jin Village.|LVL|5;-225|C|Mage|S|
-R Exit Valley of Trials|ACTIVE|805|M|50.55,68.40|N|Follow the road east out of Valley of Trials.|IZ|Valley of Trials|
+R Exit Valley of Trials|ACTIVE|805|M|50.55,68.40|N|Follow the road east out of Valley of Trials.|IZ|363|
 R Sen'jin Village|ACTIVE|805|M|54.30,72.84|N|Continue east, taking the south road when you get to the road marker.|
 L Level 6|QID|805|N|You'll want to be level 6 before you leave Sen'jin. You won't be back here for a while and you'll want to do your level 6 training before leaving.\nGrind on your way to Sen'jin Village.|LVL|5;-225|C|Mage|US|
 T Report to Sen'jin Village|QID|805|M|55.95,74.72|N|To Master Gadrin.|
@@ -197,7 +197,7 @@ A Securing the Lines|QID|835|M|46.37,22.94|N|From Rezlak.|PRE|834|
 L Level 10|QID|837|N|You'll want to be level 10 when you turn in your next quest in Razor Hill. Grind on harpies until you are 2 bubbles from leveling.|LVL|9;-630|
 T Encroachment|QID|837|M|51.95,43.50|N|To Gar'Thok in Razor Hill.|
 
-= Train|QID|840|N|Go learn your level 10 skills/spells. Right-click this step off once you are done.|LVL|10|C|-Mage|IZ|Razor Hill|
+= Train|QID|840|N|Go learn your level 10 skills/spells. Right-click this step off once you are done.|LVL|10|C|-Mage|IZ|362|
 R Sen'jin Village|QID|840|M|54.33,72.91|N|Head to Sen'jin Village.|LVL|10|C|Mage|
 = Train|QID|840|N|Learn your level 10 spells. Right-click this step off once you are done.|LVL|10|C|Mage|
 R Razor Hill|QID|840|M|52.48,44.42|N|Return to Razor Hill.|LVL|10|C|Mage|
@@ -235,21 +235,21 @@ A Hidden Enemies|QID|5726|M|31.75,37.82|Z|Orgrimmar|N|From Thrall.|
 A Finding the Antidote|QID|813|ACTIVE|812|M|47.24,53.58|Z|Orgrimmar|L|-4904|N|From Khorgan in the Cleft of Shadow.\n\n[color=FF0000]NOTE: [/color]As long as you pick up this quest, the 'Need for a Cure' timer is irrelevant.|
 
 ; --- locations of profession trainers in Orgrimmar
-N Cooking|ACTIVE|840|M|57.39,53.95|Z|Orgrimmar|N|Zamja, Cooking Trainer, The Drag - 2nd level.|P|Cooking;185;0;0|IZ|Orgrimmar|
-N Enchanting|ACTIVE|840|M|53.46,38.56|Z|Orgrimmar|N|Jhag, Journeyman Enchanter, The Drag.|P|Enchanting;333;0;0|IZ|Orgrimmar|
-N Leatherworking|ACTIVE|840|M|63.30,44.75|Z|Orgrimmar|N|Kamari, Journeyman Leatherworker, The Drag.|P|Leatherworking;165;0;0|IZ|Orgrimmar|
-N Skinning|ACTIVE|840|M|63.35,45.42|Z|Orgrimmar|N|Thuwd, Skinning Trainer, The Drag.|P|Skinning;393;0;0|IZ|Orgrimmar|
-N Tailoring|ACTIVE|840|M|62.93,49.26|Z|Orgrimmar|N|Snang, Journeyman Tailor, The Drag.|P|Tailoring;197;0;0|IZ|Orgrimmar|
-N Alchemy|ACTIVE|840|M|55.80,32.91|Z|Orgrimmar|N|Whuut, Journeyman Alchemist, The Drag.|P|Alchemy;171;0;0|IZ|Orgrimmar|
-N Herbalism|ACTIVE|840|M|55.61,39.46|Z|Orgrimmar|N|Jandi, Herbalism Trainer, The Drag - 2nd level.|P|Herbalism;182;0;0|IZ|Orgrimmar|
-N Mining|ACTIVE|840|M|73.12,26.08|Z|Orgrimmar|N|Makaru, Mining Trainer, Valley of Honor.|P|Mining;186;0;0|IZ|Orgrimmar|
-N Engineering|ACTIVE|840|M|75.95,24.18|Z|Orgrimmar|N|Thund, Journey Engineer, Valley of Honor.|P|Engineering;202;0;0|IZ|Orgrimmar|
-N Blacksmithing|ACTIVE|840|M|80.76,23.70|Z|Orgrimmar|N|Ug'thok, Journey Blacksmith, Valley of Honor.|P|Blacksmithing;164;0;0|IZ|Orgrimmar|
-N Fishing|ACTIVE|840|M|69.81,29.20|Z|Orgrimmar|N|Lumak, Fishing Trainer, Valley of Honor.|P|Fishing;356;0;0|IZ|Orgrimmar|
-N Weapon Masters|ACTIVE|840|M|81.70,19.53|Z|Orgrimmar|N|Sayoc and Hanashi in Valley of Honor.\nSayoc teaches bows, daggers, fist weapons, one & two-handed axes, and thrown weapons.\nHanashi teaches bows, one & two-handed axes, staves, and thrown weapons.|IZ|Orgrimmar|
-N Weapon Masters|ACTIVE|840|M|57,32|Z|Undercity|N|If you wish to learn swords, you'll have to take the Zepplin to Undercity. Archibald is in the War Quarter. He teaches crossbows, daggers, one & two handed swords and polearms.|IZ|Orgrimmar|
-N Weapon Masters|ACTIVE|840|M|40.94,62.74|Z|Thunder Bluff|N|If you wish to learn maces, you'll have to take the Zepplin to Thunder Bluff. Ansekwa is on the lower plateau. He teaches one & two handed maces, staves and guns.|IZ|Orgrimmar|
-N First Aid|ACTIVE|840|M|34.17,84.55|Z|Orgrimmar|N|Arnok, First Aid Trainer, The Valley of Spirits.|P|First Aid;129;0;0|IZ|Orgrimmar|
+N Cooking|ACTIVE|840|M|57.39,53.95|Z|Orgrimmar|N|Zamja, Cooking Trainer, The Drag - 2nd level.|P|Cooking;185;0;0|IZ|1454|
+N Enchanting|ACTIVE|840|M|53.46,38.56|Z|Orgrimmar|N|Jhag, Journeyman Enchanter, The Drag.|P|Enchanting;333;0;0|IZ|1454|
+N Leatherworking|ACTIVE|840|M|63.30,44.75|Z|Orgrimmar|N|Kamari, Journeyman Leatherworker, The Drag.|P|Leatherworking;165;0;0|IZ|1454|
+N Skinning|ACTIVE|840|M|63.35,45.42|Z|Orgrimmar|N|Thuwd, Skinning Trainer, The Drag.|P|Skinning;393;0;0|IZ|1454|
+N Tailoring|ACTIVE|840|M|62.93,49.26|Z|Orgrimmar|N|Snang, Journeyman Tailor, The Drag.|P|Tailoring;197;0;0|IZ|1454|
+N Alchemy|ACTIVE|840|M|55.80,32.91|Z|Orgrimmar|N|Whuut, Journeyman Alchemist, The Drag.|P|Alchemy;171;0;0|IZ|1454|
+N Herbalism|ACTIVE|840|M|55.61,39.46|Z|Orgrimmar|N|Jandi, Herbalism Trainer, The Drag - 2nd level.|P|Herbalism;182;0;0|IZ|1454|
+N Mining|ACTIVE|840|M|73.12,26.08|Z|Orgrimmar|N|Makaru, Mining Trainer, Valley of Honor.|P|Mining;186;0;0|IZ|1454|
+N Engineering|ACTIVE|840|M|75.95,24.18|Z|Orgrimmar|N|Thund, Journey Engineer, Valley of Honor.|P|Engineering;202;0;0|IZ|1454|
+N Blacksmithing|ACTIVE|840|M|80.76,23.70|Z|Orgrimmar|N|Ug'thok, Journey Blacksmith, Valley of Honor.|P|Blacksmithing;164;0;0|IZ|1454|
+N Fishing|ACTIVE|840|M|69.81,29.20|Z|Orgrimmar|N|Lumak, Fishing Trainer, Valley of Honor.|P|Fishing;356;0;0|IZ|1454|
+N Weapon Masters|ACTIVE|840|M|81.70,19.53|Z|Orgrimmar|N|Sayoc and Hanashi in Valley of Honor.\nSayoc teaches bows, daggers, fist weapons, one & two-handed axes, and thrown weapons.\nHanashi teaches bows, one & two-handed axes, staves, and thrown weapons.|IZ|1454|
+N Weapon Masters|ACTIVE|840|M|57,32|Z|Undercity|N|If you wish to learn swords, you'll have to take the Zepplin to Undercity. Archibald is in the War Quarter. He teaches crossbows, daggers, one & two handed swords and polearms.|IZ|1454|
+N Weapon Masters|ACTIVE|840|M|40.94,62.74|Z|Thunder Bluff|N|If you wish to learn maces, you'll have to take the Zepplin to Thunder Bluff. Ansekwa is on the lower plateau. He teaches one & two handed maces, staves and guns.|IZ|1454|
+N First Aid|ACTIVE|840|M|34.17,84.55|Z|Orgrimmar|N|Arnok, First Aid Trainer, The Valley of Spirits.|P|First Aid;129;0;0|IZ|1454|
 
 ; --- Class quests in Orgrimmar
 ; --- Mage
@@ -263,20 +263,20 @@ A The Shattered Hand|QID|1963|M|42.73,53.44|Z|Orgrimmar|N|From Therzok.|R|Orc,Tr
 T Gan'rul's Summons|QID|1506|M|48.25,45.29|Z|Orgrimmar|N|To Gan'rul Bloodeye.|R|Orc|C|Warlock|
 A Creature of the Void|QID|1501|M|48.20,45.70|Z|Orgrimmar|N|From Gan'rul Bloodeye.|PRE|1506|R|Orc|C|Warlock|
 ; ---
-R Leave Orgrimmar|ACTIVE|812|M|56.39,41.32;49.44,60.35;52.42,84.43|Z|Orgrimmar|CC|N|Exit Orgrimmar through the south gate.|IZ|Orgrimmar|
+R Leave Orgrimmar|ACTIVE|812|M|56.39,41.32;49.44,60.35;52.42,84.43|Z|Orgrimmar|CC|N|Exit Orgrimmar through the south gate.|IZ|1454|
 
 N Sword Training|ACTIVE|840|M|PLAYER|N|If you wish to start using swords, now is the best time to go learn the skill from Archibald in Undercity. The cost is 10 silver.\n[color=FF0000]NOTE: [/color]If you are not interested, then just skip the next few steps.|C|Rogue|
 b Tirisfal Glades|ACTIVE|840|M|50.88,13.83|Z|Durotar|N|Take the Zepplin to Tirisfal Glade.|C|Rogue|
 R Undercity|ACTIVE|840|M|61.86,65.04|Z|Tirisfal Glades|N|Enter Undercity and take the elevator down.|C|Rogue|
-N Archibald|ACTIVE|840|M|57.32,32.74|Z|Undercity|N|Make your way to Undercity's War Quarter inner ring.\n[color=FF0000]NOTE: [/color]Check this step off when you are done.|C|Rogue|IZ|Undercity|
-R Leave Undercity|ACTIVE|840|M|53.40,43.56;63.61,47.52;72.77,40.03;66.15,37.11;66.29,1.94|Z|Undercity|CC|N|Take the elevator up and leave Undercity through the front gates.|C|Rogue|IZ|Undercity|
-b Durotar|ACTIVE|840|M|60.75,58.77|Z|Tirisfal Glades|N|Take the zeppelin to Orgrimmar.|C|Rogue|IZ|Tirisfal Glades|
+N Archibald|ACTIVE|840|M|57.32,32.74|Z|Undercity|N|Make your way to Undercity's War Quarter inner ring.\n[color=FF0000]NOTE: [/color]Check this step off when you are done.|C|Rogue|IZ|1458|
+R Leave Undercity|ACTIVE|840|M|53.40,43.56;63.61,47.52;72.77,40.03;66.15,37.11;66.29,1.94|Z|Undercity|CC|N|Take the elevator up and leave Undercity through the front gates.|C|Rogue|IZ|1458|
+b Durotar|ACTIVE|840|M|60.75,58.77|Z|Tirisfal Glades|N|Take the zeppelin to Orgrimmar.|C|Rogue|IZ|1420|
 
 C Finding the Antidote|QID|813|ACTIVE|812|M|41.49,19.39|QO|1|N|Head back to the area around Rhinag and kill Venomtail Scorpids for their Venomtail Scorpid Sacs.|
 R Orgrimmar|ACTIVE|813|M|45.52,12.07|N|Head back to Orgrimmar.|
 R Cleft of Shadow|ACTIVE|813|M|47.24,53.58;51.75,57.85;56.03,41.16;59.91,49.37;51.26,46.39|Z|Orgrimmar|CC|
 T Finding the Antidote|QID|813|ACTIVE|812|M|47.24,53.58|Z|Orgrimmar|N|Go back to Khorgan and turn in the quest for the Venomtail Antidote. If you lose the antidote, this quest is repeatable.|
-R Leave Orgrimmar|ACTIVE|812|M|56.73,41.96;49.44,60.35;52.42,84.43|Z|Orgrimmar|CC|N|Exit Orgrimmar through the south gate.|IZ|Orgrimmar|
+R Leave Orgrimmar|ACTIVE|812|M|56.73,41.96;49.44,60.35;52.42,84.43|Z|Orgrimmar|CC|N|Exit Orgrimmar through the south gate.|IZ|1454|
 A Need for a Cure|QID|812|M|41.54,18.60|N|From Rhinag.|FAIL|
 T Need for a Cure|QID|812|M|41.54,18.60|N|To Rhinag.|
 
@@ -330,7 +330,7 @@ T Hidden Enemies|QID|5726|M|31.76,37.81|Z|Orgrimmar|N|To Thrall.|
 A Hidden Enemies|QID|5727|M|31.76,37.81|Z|Orgrimmar|N|From Thrall.|PRE|5726|
 R Cleft of Shadow|ACTIVE|829^832|M|40.00,53.30;42.19,57.30|Z|Orgrimmar|CC|N|Make your way to Cleft of Shadow.|
 T Neeru Fireblade|QID|829|M|49.48,50.58|Z|Orgrimmar|N|To Neeru Fireblade. He's in the hut beside the Ragefire Chasm portal.|
-t Burning Shadows|QID|832|ACTIVE|-829|M|49.48,50.58|Z|Orgrimmar|N|To Neeru Fireblade.|IZ|Orgrimmar|
+t Burning Shadows|QID|832|ACTIVE|-829|M|49.48,50.58|Z|Orgrimmar|N|To Neeru Fireblade.|IZ|1454|
 A Ak'Zeloth|QID|809|M|49.48,50.58|Z|Orgrimmar|N|From Neeru Fireblade.|PRE|829|
 C Hidden Enemies|QID|5727|M|49.48,50.58|Z|Orgrimmar|QO|1|N|Chat with Neeru Fireblade.|CHAT|
 R Grommash Hold|ACTIVE|5727|M|40.38,37.00|Z|Orgrimmar|N|Exit Cleft of Shadow and make your way back to Grommash Hold.|
@@ -338,7 +338,7 @@ T Hidden Enemies|QID|5727|M|31.76,37.81|Z|Orgrimmar|N|To Thrall.|
 ; Space breaks auto
 A Hidden Enemies |QID|5728|M|31.75,37.82|Z|Orgrimmar|ELITE|N|[color=E6CC80]Dungeon: Ragefire Chasm[/color]\nFrom Thrall.\nAccept this quest if you are planning on running the RFC dungeon. Otherwise, skip it.|PRE|5727|RANK|3|
 * Lieutenant's Insignia|AVAILABLE|-5727|N|You can safely destroy the Lieutenant's Insignia now.|U|14544|
-N Training/Shopping|ACTIVE|809|N|Make sure you do all of your training, shopping, etc. before leaving.|IZ|Orgrimmar|
+N Training/Shopping|ACTIVE|809|N|Make sure you do all of your training, shopping, etc. before leaving.|IZ|1454|
 R Leave Orgrimmar|ACTIVE|809|M|52.42,84.43|Z|Orgrimmar|CC|N|Exit Orgrimmar through the south gate.|
 
 R Far Watch Post|ACTIVE|809|M|37.58,16.21;36.04,23.69|CC|N|Make your way west to Southfury River and follow it south.\nIt's best if you don't cross the river right away. The mobs on the other side are level 15+.|

--- a/WoWPro_Leveling/Classic/Horde/12_15_Hendo_Silverpine_Forest.lua
+++ b/WoWPro_Leveling/Classic/Horde/12_15_Hendo_Silverpine_Forest.lua
@@ -140,7 +140,7 @@ T Raleigh and the Undercity|QID|441|M|62.00,42.76|Z|Undercity|N|To Raleigh Andre
 
 ; --- Making sure they have the Barrens breadcrumb.
 A Sample for Helbrim|QID|1358|M|50.13,67.95|Z|Undercity|N|From Apothecary Zinge.|PRE|1359|
-R Leave Undercity|ACTIVE|1358|M|65.99,36.85;66.22,0.90;66.22,1.27|Z|Undercity|CC|N|Take the elevator up and leave Undercity through the front gates.|IZ|Undercity|
+R Leave Undercity|ACTIVE|1358|M|65.99,36.85;66.22,0.90;66.22,1.27|Z|Undercity|CC|N|Take the elevator up and leave Undercity through the front gates.|IZ|1458|
 
 ; --- Travel to Durotar (Orgrimmar)
 b Durotar|ACTIVE|1358|M|60.75,58.77|Z|Tirisfal Glades|N|Take the zeppelin to Orgrimmar.|

--- a/WoWPro_Leveling/Classic/Horde/15_21_Hendo_The_Barrens.lua
+++ b/WoWPro_Leveling/Classic/Horde/15_21_Hendo_The_Barrens.lua
@@ -127,7 +127,7 @@ C The Shattered Hand|QID|1963|M|63.91,44.28|L|7209|N|Tazan patrols in The Mercha
 K Southsea Freebooters|ACTIVE|887|M|63.88,44.55|QO|1;2|N|You'll find them all along The Merchant Coast. The Cannoneers are scarcer than the Brigands.\n[color=FF0000]NOTE: [/color]If you run into Baron Longshore, I'd suggest waiting until your next visit. He hits hard and has 2 adds.|
 C The Shattered Hand|QID|1963|M|63.91,44.28|L|7209|N|Tazan patrols in The Merchant Coast. Kill him and loot his satchel.|R|Orc,Troll|C|Rogue|US|
 R Ratchet|ACTIVE|887|M|62.73,40.17|N|Return to Ratchet.|
-t WANTED: Baron Longshore|QID|895|M|62.68,36.23|N|To Gazlowe in Ratchet.|IZ|Ratchet|
+t WANTED: Baron Longshore|QID|895|M|62.68,36.23|N|To Gazlowe in Ratchet.|IZ|392|
 T Southsea Freebooters|QID|887|M|62.68,36.23|N|To Gazlowe in Ratchet.|
 A The Missing Shipment|QID|890|M|62.68,36.23|N|From Gazlowe.|PRE|887|
 T The Missing Shipment|QID|890|M|63.35,38.45|N|To Wharfmaster Dizzywig.|
@@ -135,7 +135,7 @@ A The Missing Shipment|QID|892|M|63.35,38.45|N|From Wharfmaster Dizzywig.|PRE|89
 T The Missing Shipment|QID|892|M|62.68,36.23|N|To Gazlowe.|
 A Stolen Booty|QID|888|M|62.68,36.23|N|From Gazlowe.|PRE|892|
 
-R Exit Ratchet|QID|903|M|58.59,38.42|N|Follow the road west out of Ratchet.|IZ|Ratchet|
+R Exit Ratchet|QID|903|M|58.59,38.42|N|Follow the road west out of Ratchet.|IZ|392|
 C Prowlers of the Barrens|QID|903|M|58.90,37.72|L|5096 7|N|At the top of the hill, look for the Savannah Prowlers in the bushes to the north and south of the road.|
 C Raptor Thieves|QID|869|L|5062 12|N|Finish collecting the Raptor Heads as you make your way back to the Crossroads.|US|
 ; lv 17
@@ -157,7 +157,7 @@ T The Shattered Hand|QID|1858|M|42.74,53.55|Z|Orgrimmar|N|To Therzok.|R|Orc,Trol
 A Zando'zan|QID|2379|M|43.03,53.73|Z|Orgrimmar|N|From Shenthul.|R|Orc,Troll,Undead|C|Rogue|
 T Zando'zan|QID|2379|M|42.73,52.95|Z|Orgrimmar|N|To Zando'zan.|R|Orc,Troll,Undead|C|Rogue|
 A Wrenix of Ratchet|QID|2382|M|42.73,52.95|Z|Orgrimmar|N|From Zando'zan.|PRE|2379|R|Orc,Troll,Undead|C|Rogue|
-F Crossroads|AVAILABLE|853|ACTIVE|2382|M|45.15,63.90|Z|Orgrimmar|N|Fly back to the Crossroads.|R|Orc,Troll,Undead|C|Rogue|IZ|Orgrimmar|
+F Crossroads|AVAILABLE|853|ACTIVE|2382|M|45.15,63.90|Z|Orgrimmar|N|Fly back to the Crossroads.|R|Orc,Troll,Undead|C|Rogue|IZ|1454|
 ; ---
 
 A Apothecary Zamah|QID|853|M|51.46,30.16|N|From Apothecary Helbrim.\n[color=FF0000]NOTE: [/color]This is a timed quest (45 minutes).|PRE|848|
@@ -171,7 +171,7 @@ C Lost in Battle|QID|4921|M|49.33,50.34|QO|1|N|Mankrik's wife is the "Beaten Cor
 R Camp Taurajo|QID|853|M|46.60,57.79|N|[color=FF0000]NOTE: [/color]Stick to the road unless you want to do some grinding.|
 F Thunder Bluff|QID|853|M|44.44,59.15|
 T Apothecary Zamah|QID|853|M|30.04,29.83;22.79,20.90|CC|Z|Thunder Bluff|N|To Apothecary Zamah.\nHead to the Pools of Vision, beneath Spirit Rise.|
-A Serpentbloom |QID|962|M|22.79,20.90|Z|Thunder Bluff|ELITE|N|[color=E6CC80]Dungeon: Wailing Caverns[/color]\nFrom Apothecary Zamah, Spirit Rise.\n[color=FF0000]NOTE: [/color]Skip if you wish.|IZ|Thunder Bluff|
+A Serpentbloom |QID|962|M|22.79,20.90|Z|Thunder Bluff|ELITE|N|[color=E6CC80]Dungeon: Wailing Caverns[/color]\nFrom Apothecary Zamah, Spirit Rise.\n[color=FF0000]NOTE: [/color]Skip if you wish.|IZ|1456|
 N Weapon Master|QID|4921|M|40.92,62.70|Z|Thunder Bluff|N|While you are here, go see Ansekhwa if you wish to train in Guns, One-Handed Maces, Staves or Two-handed Maces.\n[color=FF0000]NOTE: [/color]Check this step off to continue.|
 F Crossroads|QID|4921|M|47.02,49.83|Z|Thunder Bluff|
 
@@ -300,7 +300,7 @@ N Ashenvale FPs|ACTIVE|6541|N|A little side trip to grab the Flight paths in Ash
 R The Mor'shan Rampart|ACTIVE|6541|M|48.02,5.58|CC|N|Follow the road north to the Mor'shan Rampart.|
 T Report to Kadrak|QID|6541|M|48.12,5.42|N|To Kadrak on the first floor of the guard tower on your right.|
 A The Warsong Reports|QID|6543|M|48.12,5.42|N|From Kadrak.|
-R Ashenvale|AVAILABLE|6442|M|68.63,86.82|Z|Ashenvale|N|Follow the road north until you reach Ashenvale (Nightsong Woods).|IZ|-Ashenvale|
+R Ashenvale|AVAILABLE|6442|M|68.63,86.82|Z|Ashenvale|N|Follow the road north until you reach Ashenvale (Nightsong Woods).|IZ|-1440|
 R Splintertree Post|AVAILABLE|6442|M|68.60,84.23;67.24,71.58;70.15,70.09;71.1,67.5|CC|Z|Ashenvale|N|Our first stop will be on the middle floor of a guard tower, just outside Splintertree Post.\n[color=FF0000]NOTE: [/color]Be VERY aware of the much higher level mobs if you choose to venture off the road.|
 U Warsong Reports|ACTIVE|6543|L|16746|N|Open your Bundle of Reports.|U|16783|
 ; Quest is [The Warsong Reports], presuming this is to avoid automatic turn-in.
@@ -456,13 +456,13 @@ A Blood Feeders|QID|6461|M|71.24,95.02|Z|Stonetalon Mountains|N|From Xen'zilla i
 K Blood Feeders|ACTIVE|6461|M|58.18,76.03|Z|Stonetalon Mountains|QO|1;2|N|Kill Deepmoss Creepers and Venomspitters.|S|
 R Webwinder Path|ACTIVE|6461|M|59.34,75.96|Z|Stonetalon Mountains|N|Leave Malaka'jin and follow the road north.|
 A Arachnophobia|QID|6284|M|59.07,75.71|Z|Stonetalon Mountains|ELITE|N|From the Wanted Poster, located beside the road.\n[color=FF0000]NOTE: [/color]This quest is not recommended at your current level. Accept the quest on the off-chance that you find a group to do it.|
-R Sishir Canyon|ACTIVE|6461^1069^6284|M|58.18,76.03|Z|Stonetalon Mountains|N|Follow the path west up the hill.|IZ|Stonetalon Mountains|
+R Sishir Canyon|ACTIVE|6461^1069^6284|M|58.18,76.03|Z|Stonetalon Mountains|N|Follow the path west up the hill.|IZ|1442|
 C Deepmoss Spider Eggs|QID|1069|M|53.48,74.52|Z|Stonetalon Mountains|L|5570 15|N|Pick up the spider eggs from around the area.\n[color=FF0000]NOTE: [/color]1-2 Deepmoss Hatchlings will spawn after opening the egg. On occassion, a Deepmoss Matriarch may also spawn after killing the Hatchlings|S|
 K Bessaleth|ACTIVE|6284|M|53.48,74.52|Z|Stonetalon Mountains|L|16192|N| Bessaleth is a lv 21 Elite mob with multiple spawn points. You'll find her in one of the alcoves along the edge.\n[color=FF0000]NOTE: [/color]It's strongly recommended to only attempt this if you're over level, or you have help to do it.\nSkip this step if you wish to move on.|T|Bessaleth|
 C Deepmoss Spider Eggs|QID|1069|M|53.48,74.52|Z|Stonetalon Mountains|L|5570 15|N|Pick up the spider eggs from around the area.|US|
 K Blood Feeders|ACTIVE|6461|M|53.48,74.52|Z|Stonetalon Mountains|QO|1;2|N|Finish up the spiders needed.|US|
 R Sun Rock Retreat|ACTIVE|6401|M|59.34,75.87;59.67,71.22;53.04,61.58;49.58,60.99|CC|Z|Stonetalon Mountains|N|Head back to Webwinder Path and follow it north; taking the left forks (or just follow the signs).|
-t Arachnophobia|QID|6284|M|47.20,61.16|Z|Stonetalon Mountains|N|To Maggran Earthbinder.|IZ|Sun Rock Retreat|
+t Arachnophobia|QID|6284|M|47.20,61.16|Z|Stonetalon Mountains|N|To Maggran Earthbinder.|IZ|460|
 T Kaya's Alive|QID|6401|M|47.46,58.38|Z|Stonetalon Mountains|N|To Tammra Windfield.|
 f Sun Rock Retreat|QID|6461|M|45.13,59.84|Z|Stonetalon Mountains|N|At Tharm.|TAXI|-Sun Rock Retreat|
 R Malaka'jin|ACTIVE|6461|M|53.18,61.66;71.55,90.59|CC|Z|Stonetalon Mountains|N|Return to Malaka'jin.|
@@ -476,11 +476,11 @@ A Leaders of the Fang |QID|914|M|75.65,31.63|Z|Thunder Bluff|ELITE|N|[color=E6CC
 N Wailing Caverns|ACTIVE|914|N|Having all of the quests for Wailing Cavern, now is a good time to look for a group for this instance.\nAs this guide is dungeon-free, we won't be completing those quests in this guide. Feel free to rejoin this guide when you are done.|
 
 F Orgrimmar|ACTIVE|3923|N|[color=FF0000]NOTE: [/color]No matter what class/race you are, you'll want to be in Orgrimmar at this point.|
-R Enter Orgrimmar|ACTIVE|3923|M|45.52,12.07|CC|Z|Durotar|N|Enter Orgrimmar by the south entrance.|IZ|-Orgrimmar|
+R Enter Orgrimmar|ACTIVE|3923|M|45.52,12.07|CC|Z|Durotar|N|Enter Orgrimmar by the south entrance.|IZ|-1454|
 R Valley of Honor|QID|3923|M|65.54,40.00|Z|Orgrimmar|
 T Rilli Greasygob|QID|3923|M|76.51,24.43|Z|Orgrimmar|N|Look for Rilli Greasygob inside Nogg's Machine Shop.|
 A Samophlange Manual|QID|3924|M|76.51,24.43|Z|Orgrimmar|N|From Rilli Greasygob.|PRE|3923|
-R Southfury River|ACTIVE|3924|N|Leave Orgrimmar through the west gate.|M|11.45,67.06|Z|Orgrimmar|IZ|Orgrimmar|
+R Southfury River|ACTIVE|3924|N|Leave Orgrimmar through the west gate.|M|11.45,67.06|Z|Orgrimmar|IZ|1454|
 C Samophlange Manual Pages|ACTIVE|3924|L|11148 5|QO|1|N|Make your way to Boulder Lode Mine. Kill Venture Co. Enforcers and Overseers to collect the pages.|S|
 C Miner's Fortune|QID|896|L|5097|N|The Cat's Eye Emerald drops from one of the Venture Co. Enforcers or Overseers.|S|
 R Boulder Lode Mine|ACTIVE|3924|M|63.66,4.43;62.74,4.75|CC|QO|1|N|Make your way along the river until the path widens. At this point, there is a short cut up the side of the hill into Boulder Lode Mine.|
@@ -545,8 +545,8 @@ N Rare Spawn Kill Quests|ACTIVE|907|AVAILABLE|883^884^885^897|N|Jorn Skyseer has
 A Lakota'mani|QID|883|N|From Hoof of Lakota'mani.|U|5099|O|
 A Owatanka|QID|884|N|From Owatanka's Tailspike.|U|5102|O|
 T Enraged Thunder Lizards|QID|907|M|44.86,59.14|N|To Jorn Skyseer back at Camp Taurajo.|
-t Lakota'mani|QID|883|M|44.86,59.14|N|To Jorn Skyseer.|IZ|Camp Taurajo|
-t Owatanka|QID|884|M|44.86,59.14|N|To Jorn Skyseer.|IZ|Camp Taurajo|
+t Lakota'mani|QID|883|M|44.86,59.14|N|To Jorn Skyseer.|IZ|378|
+t Owatanka|QID|884|M|44.86,59.14|N|To Jorn Skyseer.|IZ|378|
 A Cry of the Thunderhawk|QID|913|M|44.86,59.14|N|From Jorn Skyseer.|PRE|907|
 C Cry of the Thunderhawk|QID|913|L|5164|N|Kill a Thunderhawk and loot its wings. You will find them all around the outside edge of Camp Taurajo.|
 L Level 22|ACTIVE|2458^2478|N|You'll want to be within a bubble of level 22 before you return to Camp Taurajo.|LVL|21;-1950|R|Orc,Troll,Undead|C|Rogue|
@@ -567,9 +567,9 @@ A The Shattered Salute|QID|2460|M|43.04,53.74|Z|Orgrimmar|N|From Shenthul in Cle
 C The Shattered Salute|QID|2460|M|43.04,53.74|Z|Orgrimmar|QO|1|N|Target Shenthul and use the emote '/salute' to complete the quest.|T|Shenthul|R|Orc,Troll,Undead|C|Rogue|NC|
 T The Shattered Salute|QID|2460|M|43.04,53.74|Z|Orgrimmar|N|To Shenthul.|R|Orc,Troll,Undead|C|Rogue|
 A Deep Cover|QID|2458|M|43.04,53.74|Z|Orgrimmar|N|From Shenthul.|PRE|2460|R|Orc,Troll,Undead|C|Rogue|
-N Dagger|ACTIVE|2458^2478|N|Make sure you have an equipable dagger before you leave Orgrimmar. You'll need it for completing part of your class quest.\n[color=FF0000]NOTE: [/color]Check this step off to continue.|R|Orc,Troll,Undead|C|Rogue|IZ|Orgrimmar|
-N Flash Powder|ACTIVE|2458^2478|M|42.2,49.6|Z|Orgrimmar|L|5140|N|Make sure you pick some up from Rekkul before you leave.|R|Orc,Troll,Undead|C|Rogue|IZ|Orgrimmar|
-R Southfury River|ACTIVE|2458^2478|M|11.45,67.06|Z|Orgrimmar|N|Leave Orgrimmar through the west gate.|R|Orc,Troll,Undead|C|Rogue|IZ|Orgrimmar|
+N Dagger|ACTIVE|2458^2478|N|Make sure you have an equipable dagger before you leave Orgrimmar. You'll need it for completing part of your class quest.\n[color=FF0000]NOTE: [/color]Check this step off to continue.|R|Orc,Troll,Undead|C|Rogue|IZ|1454|
+N Flash Powder|ACTIVE|2458^2478|M|42.2,49.6|Z|Orgrimmar|L|5140|N|Make sure you pick some up from Rekkul before you leave.|R|Orc,Troll,Undead|C|Rogue|IZ|1454|
+R Southfury River|ACTIVE|2458^2478|M|11.45,67.06|Z|Orgrimmar|N|Leave Orgrimmar through the west gate.|R|Orc,Troll,Undead|C|Rogue|IZ|1454|
 R Venture Co. Tower|ACTIVE|2458^2478|M|62.29,7.77;56.59,6.42|CC|N|Make your way around the edge of the mountain to the tower.|R|Orc,Troll,Undead|C|Rogue|
 N Taskmaster Fizzule|ACTIVE|2458|AVAILABLE|2478|M|56.00,6.10|N|Target Taskmaster Fizzule and use the Flare gun to make him non-aggressive, or you won't be able to interact with him.\n[color=FF0000]NOTE: [/color]Check this step off when this is done.|T|Taskmaster Fizzule|U|8051|R|Orc,Troll,Undead|C|Rogue|
 T Deep Cover|QID|2458|M|55.44,5.59|N|To Taskmaster Fizzule. He paths around a bit.\n[color=FF0000]NOTE: [/color]You must target him and use '/salute' before he'll interact with you.|T|Taskmaster Fizzule|R|Orc,Troll,Undead|C|Rogue|
@@ -597,15 +597,15 @@ A Hinott's Assistance|QID|2480|M|61.63,19.19|Z|Hillsbrad Foothills|N|From Serge 
 T Hinott's Assistance|QID|2480|M|61.63,19.19|Z|Hillsbrad Foothills|N|Once Serge Hinott completes the cure, turn the quest in.|R|Orc,Troll,Undead|C|Rogue|
 U Hinott's Oil|AVAILABLE|-2480|ACTIVE|-2480|N|Use the Hinott's Oil to cure your Touch of Zanzil.|U|8095|R|Orc,Troll,Undead|C|Rogue|BUFF|-9991|
 * Hinott's Oil|AVAILABLE|-2480|ACTIVE|-2480|N|For whatever reason, you still have your Hinott's Oil. You can safely destroy this as it's no longer required.|U|8095|R|Orc,Troll,Undead|C|Rogue|BUFF|9991|
-H Camp Taurajo|AVAILABLE|-2480|ACTIVE|-2480|R|Orc,Troll,Undead|C|Rogue|IZ|Hillsbrad Foothills|
+H Camp Taurajo|AVAILABLE|-2480|ACTIVE|-2480|R|Orc,Troll,Undead|C|Rogue|IZ|1424|
 ; ---
 
 ; --- Ashenvale
-F Splintertree Post|ACTIVE|6382^235^742|M|45.13,63.90|Z|Orgrimmar|IZ|Orgrimmar|
-F Splintertree Post|ACTIVE|6382^235^742|M|44.44,59.15|IZ|Camp Taurajo|
+F Splintertree Post|ACTIVE|6382^235^742|M|45.13,63.90|Z|Orgrimmar|IZ|1454|
+F Splintertree Post|ACTIVE|6382^235^742|M|44.44,59.15|IZ|378|
 T The Ashenvale Hunt|QID|6382^235^742|M|73.77,61.46|Z|Ashenvale|N|To Senani Thunderheart.|
 A The Ashenvale Hunt|QID|6383|M|73.77,61.46|Z|Ashenvale|N|From Senani Thunderheart.|
-N The Ashenvale Hunt|AVAILABLE|-6383|N|This quest unlocks 3 drop loot item quests.\nAs the lowest level of the 3 quests does not grey until level 32 AND the mobs are WAY above our current level, we will not being doing it at this time.\n[color=FF0000]NOTE: [/color]This quest doesn't show in your log. It just unlocks the 3 quests (which don't show either).\nCheck this step off to continue.|IZ|Ashenvale|
+N The Ashenvale Hunt|AVAILABLE|-6383|N|This quest unlocks 3 drop loot item quests.\nAs the lowest level of the 3 quests does not grey until level 32 AND the mobs are WAY above our current level, we will not being doing it at this time.\n[color=FF0000]NOTE: [/color]This quest doesn't show in your log. It just unlocks the 3 quests (which don't show either).\nCheck this step off to continue.|IZ|1440|
 ; -- The quests are listed below for future reference
 ;C Shadumbra's Head|QID|24|Z|Ashenvale|N|Kill the cat, Shadumbra, for its head.|PRE|6383|
 ;C Sharptalon's Claw|QID|2|Z|Ashenvale|N|Kill the blue bird, Sharptalon, for its claw.|PRE|6383|

--- a/WoWPro_Leveling/Classic/Horde/21_30_Hendo_HordeChapter1.lua
+++ b/WoWPro_Leveling/Classic/Horde/21_30_Hendo_HordeChapter1.lua
@@ -57,17 +57,17 @@ F Splintertree Post|AVAILABLE|6571|M|47.02,49.83|Z|Thunder Bluff|
 A Warsong Supplies|QID|6571|M|71.40,67.64|Z|Ashenvale|N|From Locke Okarr; by the south watchtower.|
 
 ; --- Silverpine Forest
-F Orgrimmar|AVAILABLE|437^443|M|73.18,61.59|Z|Ashenvale|N|Fly to Orgrimmar.|IZ|Ashenvale|
-h Orgrimmar|AVAILABLE|437^443|M|54.11,68.39|Z|Orgrimmar|N|At Innkeeper Gryshka.\n[color=FF0000]NOTE: [/color]This will be a better option the next time you need to use your hearth.|IZ|Orgrimmar|
+F Orgrimmar|AVAILABLE|437^443|M|73.18,61.59|Z|Ashenvale|N|Fly to Orgrimmar.|IZ|1440|
+h Orgrimmar|AVAILABLE|437^443|M|54.11,68.39|Z|Orgrimmar|N|At Innkeeper Gryshka.\n[color=FF0000]NOTE: [/color]This will be a better option the next time you need to use your hearth.|IZ|1454|
 b Tirisfal Glades|AVAILABLE|437^443|M|50.88,13.83|Z|Durotar|N|Exit Orgrimmar and take the Zeppelin to Tirisfal Glades.|
 ; --- If you don't have the FP in Undercity
 R Undercity|AVAILABLE|437^443|M|61.86,65.04|Z|Tirisfal Glades|N|Enter Undercity.|TAXI|-Undercity|
 f Undercity|AVAILABLE|437^443|M|63.26,48.54|Z|Undercity|N|Grab the flight path from Michael Garrett.|TAXI|-Undercity|
 ; If you have the FP in Sepulcher
 R Undercity|AVAILABLE|437^443|M|61.86,65.04|Z|Tirisfal Glades|N|Enter Undercity.|TAXI|Undercity|
-F The Sepulcher|AVAILABLE|437^443|M|63.26,48.54|Z|Undercity|TAXI|The Sepulcher|IZ|Undercity|
+F The Sepulcher|AVAILABLE|437^443|M|63.26,48.54|Z|Undercity|TAXI|The Sepulcher|IZ|1458|
 ; If you don't have the FP in Sepulcher
-R Leave Undercity|AVAILABLE|437^443|M|65.99,36.85;66.22,0.90|Z|Undercity|CC|N|Take the elevator up and leave Undercity through the front gates.|TAXI|-The Sepulcher|IZ|Undercity|
+R Leave Undercity|AVAILABLE|437^443|M|65.99,36.85;66.22,0.90|Z|Undercity|CC|N|Take the elevator up and leave Undercity through the front gates.|TAXI|-The Sepulcher|IZ|1458|
 ; --- If you don't have the FP in Sepulcher but do have the FP in Undercity (No point going in if you can't go anywhere)
 R Silverpine Forest|AVAILABLE|437^443|M|54.46,74.62|Z|Tirisfal Glades|N|Head over to the road and follow it south into Silverpine Forest.|TAXI|-The Sepulcher|
 R The Sepulcher|AVAILABLE|437^443|M|46.21,41.59|N|Head south until you reach the Sepulcher.|TAXI|-The Sepulcher|
@@ -86,7 +86,7 @@ T Rot Hide Clues|QID|439|M|43.43,40.86|N|To High Executor Hadrec.\nFollow the hi
 ; ---
 A Rot Hide Ichor|QID|443|M|43.43,40.86|Z|Silverpine Forest|N|From High Executor Hadrec inside the crypt.|PRE|439|
 R Fenris Isle|ACTIVE|443|M|52.34,37.21;58.75,35.43;64.79,34.60;65.63,32.89|Z|Silverpine Forest|CC|N|Sticking to the hills to avoid unnecessary fighting, make your way to the lake and swim across.|
-N A Talking Head|AVAILABLE|460|N|This item starts a side quest chain and is found by killing the Gnolls.\nIt has a 3% drop rate.\n[color=FF0000]NOTE: [/color]Check this step off to continue.|RANK|3|IZ|Fenris Isle|S!US|
+N A Talking Head|AVAILABLE|460|N|This item starts a side quest chain and is found by killing the Gnolls.\nIt has a 3% drop rate.\n[color=FF0000]NOTE: [/color]Check this step off to continue.|RANK|3|IZ|172|S!US|
 A Resting in Pieces|QID|460|N|Click on the 'Talking Head' to start the quest.\n[color=FF0000]NOTE: [/color]Do this as soon as you get it.|U|3317|O|
 C Rot Hide Ichor|QID|443|L|3236 8|N|Kill Rot Hide Gnolls for the Ichor.|S|
 T Resting in Pieces|QID|460|M|67.87,24.86|Z|Silverpine Forest|N|Click on the Shallow Grave to turn in the quest.|
@@ -115,13 +115,13 @@ T Report to Hadrec|QID|448|M|43.43,40.86|Z|Silverpine Forest|N|To High Executor 
 A Beren's Peril|QID|516|M|43.98,40.93|Z|Silverpine Forest|N|From Shadow Priest Allister.|
 A The Weaver|QID|480|M|43.98,40.93|Z|Silverpine Forest|N|From Shadow Priest Allister.|PRE|479|
 
-R Ambermill|ACTIVE|480|M|51.34,36.98;55.71,64.46|Z|Silverpine Forest|CC|N|Make your way to Ambermill.|IZ|Silverpine Forest|
+R Ambermill|ACTIVE|480|M|51.34,36.98;55.71,64.46|Z|Silverpine Forest|CC|N|Make your way to Ambermill.|IZ|1421|
 C The Weaver|QID|480|M|63.40,64.28|Z|Silverpine Forest|L|3515|N|Kill Ataeric and loot his staff.\n[color=FF0000]NOTE: [/color]You have to get past 2 Conjurers (plus their voidwalkers) and 2 Warders to get to Ataeric. You can aggro the mages one at a time. But, it's not easy. You may find a Dalaran Spellscribe (a non-elite rare spawn) in the room as well.\nMake sure you take out the Conjurer and Voidwalker that path in and out of the building. You'll be using the foyer to fight the mobs inside the room and you don't want them sneaking up on you.\n\nAtaeric won't stand still. He is a Frost mage who likes to keep his distance. If you don't clear the room, you'll end up fighting the entire room at the same time.|
-R Beren's Peril|ACTIVE|516|M|61.53,64.61;62.88,72.15;60.44,74.46;60.54,73.35|Z|Silverpine Forest|CC|N|Exit the building and follow the road south out of Ambermill. Stick to the mountains on the east side (right) and follow them around the bend.|IZ|Silverpine Forest|
-R Cave Entrance|ACTIVE|516|M|60.58,72.48|Z|Silverpine Forest|CC|N|Make your way to the cave entrance.|IZ|Silverpine Forest|
+R Beren's Peril|ACTIVE|516|M|61.53,64.61;62.88,72.15;60.44,74.46;60.54,73.35|Z|Silverpine Forest|CC|N|Exit the building and follow the road south out of Ambermill. Stick to the mountains on the east side (right) and follow them around the bend.|IZ|1421|
+R Cave Entrance|ACTIVE|516|M|60.58,72.48|Z|Silverpine Forest|CC|N|Make your way to the cave entrance.|IZ|1421|
 K Beren's Peril|ACTIVE|516|QO|1;2|N|Enter the cave and kill Ravenclaw Drudgers and Guardians.|
-R Cave Entrance|ACTIVE|516|M|60.58,72.48|Z|Silverpine Forest|CC|N|Make your way back to the cave entrance.|IZ|Silverpine Forest|
-R The Greymane Wall|QID|530|M|59.70,77.90;53.67,72.47;51.10,72.45;46.89,83.45|Z|Silverpine Forest|CC|N|Exit the cave and head back to the road. Follow the road west to the first intersection and continue west to the next intersection. From here, go south to The Greymane Wall.|IZ|Silverpine Forest|
+R Cave Entrance|ACTIVE|516|M|60.58,72.48|Z|Silverpine Forest|CC|N|Make your way back to the cave entrance.|IZ|1421|
+R The Greymane Wall|QID|530|M|59.70,77.90;53.67,72.47;51.10,72.45;46.89,83.45|Z|Silverpine Forest|CC|N|Exit the cave and head back to the road. Follow the road west to the first intersection and continue west to the next intersection. From here, go south to The Greymane Wall.|IZ|1421|
 C A Husband's Revenge|QID|530|M|46.06,85.64|Z|Silverpine Forest|L|3613|N|Kill Valdred Moray and loot his hands. He paths back and forth in front of the gate.|
 R Hillsbrad Foothills|ACTIVE|1065|M|51.10,72.45;53.67,72.47;67.00,80.28|Z|Silverpine Forest|CC|N|Head back to the main road. Continue east on the main road to the Silverpine Forest/Hillsbrad Foothills border.|
 
@@ -138,9 +138,9 @@ T Time To Strike|QID|494|M|62.28,20.25|Z|Hillsbrad Foothills|N|To High Executor 
 A Battle of Hillsbrad|QID|527|M|62.28,20.25|Z|Hillsbrad Foothills|N|From High Executor Darthalia.|
 A WANTED: Syndicate Personnel|QID|549|M|62.62,20.73|Z|Hillsbrad Foothills|N|From the Wanted post beside the Chapel entrance.|
 A The Rescue|QID|498|M|63.20,20.66|Z|Hillsbrad Foothills|N|From Krusk.|
-C Kill Gray Bears|QID|496|L|3476 10|N|Kill Gray Bears for their Tongue.|S|IZ|-Durnholde Keep|
-C Kill Moss Creepers|QID|496|L|3477 1|N|Kill Moss Creepers for the Creeper Ichor.\nThis shouldn't take long.|S|IZ|-Durnholde Keep|
-C Kill Mountain Lions|QID|501|L|3496 10|N|Kill Mountain Lions for vials of their blood.|S|IZ|-Durnholde Keep|
+C Kill Gray Bears|QID|496|L|3476 10|N|Kill Gray Bears for their Tongue.|S|IZ|-275|
+C Kill Moss Creepers|QID|496|L|3477 1|N|Kill Moss Creepers for the Creeper Ichor.\nThis shouldn't take long.|S|IZ|-275|
+C Kill Mountain Lions|QID|501|L|3496 10|N|Kill Mountain Lions for vials of their blood.|S|IZ|-275|
 R Durnholde Keep|ACTIVE|498|M|76.08,47.11|Z|Hillsbrad Foothills|N|Make your way to the Durnholde Keep entrance.|
 C WANTED: Syndicate Personnel|QID|549|QO|1;2|N|Kill Syndicate Rogues and Watchmen.|S|
 C Blood of Innocents|QID|1066|L|5620 5|N|Kill Syndicate Mages to loot the Vials of Innocent Blood.|S|
@@ -208,7 +208,7 @@ K XT:9|ACTIVE|1068|QO|2|N|Kill XT:9. It patrols the south side of the river.|T|X
 U The Flying Machine Airport|QID|1086|M|66.48,45.40|U|5638|N|Place the Toxic Fogger here.|
 C Gerenzo Wrenchwhistle|QID|1096|M|70.40,40.93;67.99,37.79;64.61,37.96;62.84,40.49|CS|L|5736|N|Make your way to the path leading up to the structure. Once you are there, work your way over to where Gerenzo is and kill him to loot his arm.|
 ;L Level 25
-N Shortcut down|ACTIVE|1096|N|Jump into the water and swim to shore.|IZ|
+N Shortcut down|ACTIVE|1096|N|Jump into the water and swim to shore.|
 K XT:4|ACTIVE|1068|QO|1|N|Kill XT:4. It patrols the north side of the river.|T|XT:4|US|
 K XT:9|ACTIVE|1068|QO|2|N|Kill XT:9. It patrols the south side of the river.|T|XT:9|US|
 T Gerenzo Wrenchwhistle|QID|1096|M|58.99,62.57|N|To Ziz Fizziks.|

--- a/WoWPro_Leveling/Classic/Horde/21_30_Jame_Horde.lua
+++ b/WoWPro_Leveling/Classic/Horde/21_30_Jame_Horde.lua
@@ -84,7 +84,7 @@ F Zoram'gar Outpost|QID|6442|M|73.23,61.58|Z|Ashenvale|N|Fly to Zoram'gar Outpos
 R Zoram'gar Outpost|QID|6442|N|Follow the road all the way to Zoram'gar Outpost, being very careful to avoid Astranaar, the major Alliance settlement in this zone.|M|75.02,65.16;67.17,71.25;44.94,56.20;36.90,55.01;32.53,49.76;30.2,47.28;26.43,42.33;16.51,30.27;12,34|CS|Z|Ashenvale|TAXI|-Zoram'gar Outpost|
 f Zoram'gar Outpost|QID|6442|M|12.20,33.80|Z|Ashenvale|
 A Naga at the Zoram Strand|QID|6442|M|11.69,34.90|Z|Ashenvale|N|From Marukai.|
-N Things to do...|QID|6504|N|Keep any Shredder Operating Manual pages you find from now on.|S!US|IZ|Ashenvale|
+N Things to do...|QID|6504|N|Keep any Shredder Operating Manual pages you find from now on.|S!US|IZ|1440|
 C Naga at the Zoram Strand|QID|6442|M|13.49,25.82|Z|Ashenvale|N|Kill Nagas for their Wrathtail Heads.|
 T Naga at the Zoram Strand|QID|6442|M|11.69,34.90|Z|Ashenvale|N|To Marukai.|
 

--- a/WoWPro_Leveling/Classic/Horde/31_40_Hendo_HordeChapter2.lua
+++ b/WoWPro_Leveling/Classic/Horde/31_40_Hendo_HordeChapter2.lua
@@ -335,7 +335,7 @@ A Prison Break In|QID|544|M|61.59,20.83|Z|Hillsbrad Foothills|N|From Magus Worde
 A Stone Tokens|QID|556|M|61.50,20.94|Z|Hillsbrad Foothills|N|From Keeper Bel'varil.|
 A Soothing Turtle Bisque|QID|7321|M|62.31,19.09|Z|Hillsbrad Foothills|N|From Christoph Jeffcoat.|
 B Soothing Spices|ACTIVE|7321|M|62.29,19.04|Z|Hillsbrad Foothills|L|3713|N|From Christoph Jeffcoat.|
-t Soothing Turtle Bisque|QID|7321|M|62.31,19.09|Z|Hillsbrad Foothills|N|To Christoph Jeffcoat.|IZ|Tarren Mill|
+t Soothing Turtle Bisque|QID|7321|M|62.31,19.09|Z|Hillsbrad Foothills|N|To Christoph Jeffcoat.|IZ|272|
 A Helcular's Revenge|QID|552|M|63.88,19.67|Z|Hillsbrad Foothills|N|From Novice Thaivand.|
 A Infiltration|QID|533|M|63.23,20.66|Z|Hillsbrad Foothills|N|From Krusk.|
 R Darrow Hill|ACTIVE|552|M|49.10,32.22|Z|Hillsbrad Foothills|N|Run to the Cave in Darrow Hill.|
@@ -419,7 +419,7 @@ A Raptor Mastery|QID|194|M|35.66,10.81|Z|Stranglethorn Vale|N|From Hemet Nesingw
 A Tiger Mastery|QID|185|M|35.61,10.63|Z|Stranglethorn Vale|N|From Ajeck Rouack.|PRE|583|
 A Panther Mastery|QID|190|M|35.56,10.54|Z|Stranglethorn Vale|N|From Sir S. J. Erlgadin.|PRE|583|
 A The Green Hills of Stranglethorn|QID|338|N|From Barnil Stonepot.|PRE|583|
-N Chapter Quests|ACTIVE|338|AVAILABLE|339^340^341^342|N|From this point forward, every time you return to the Camp, check in with Barnil Stonepot to see if you have enough pages to finish a Chapter quest. You'll want to get rid of the pages as soon as you can to save bag space.\n[color=FF0000]NOTE: [/color]To save log space, do not accept the Chapter quests until you can complete them.|S!US|IZ|Nesingwary's Expedition|
+N Chapter Quests|ACTIVE|338|AVAILABLE|339^340^341^342|N|From this point forward, every time you return to the Camp, check in with Barnil Stonepot to see if you have enough pages to finish a Chapter quest. You'll want to get rid of the pages as soon as you can to save bag space.\n[color=FF0000]NOTE: [/color]To save log space, do not accept the Chapter quests until you can complete them.|S!US|IZ|100|
 K Tiger Mastery|QID|185|M|32.61,9.55;33.68,11.64;36.40,13.05|Z|Stranglethorn Vale|CC|QO|1|N|Heading in a westerly direction from the camp, kill Young Stranglethorn Tigers. In a looping arc, make your way east to the bridge.|
 K Panther Mastery|QID|190|M|37.69,14.85;39.75,13.70;41.23,12.99;41.27,8.56|Z|Stranglethorn Vale|CC|QO|1|N|As you make your way east under the bridge, kill Young Stranglethorn Panthers. Cross the river to the north side and work your way west in a sweeping arc towards the road.|
 T Panther Mastery|QID|190|M|35.56,10.54|Z|Stranglethorn Vale|N|To Sir S. J. Erlgadin.|
@@ -500,16 +500,16 @@ l Some Assembly Required|ACTIVE|577|L|4104 5|N|Kill Snapjaw Crocolisks to loot t
 R Grom'gol Base Camp|QID|569|M|34.23,28.38|Z|Stranglethorn Vale|N|Return to Grom'gol.|
 T The Defense of Grom'gol|QID|569|M|32.20,28.86|Z|Stranglethorn Vale|N|To Commander Aggro'gosh.|
 ;L Level 37|LVL|37|N|You should be around level 37 by this point.|
-C Singing Blue Shards|ACTIVE|605|Z|Stranglethorn Vale|L|3918 10|N|Kill Crystal Spine Basilisks to loot the Singing Crystal Shards.|S|IZ|Stranglethorn Vale|
+C Singing Blue Shards|ACTIVE|605|Z|Stranglethorn Vale|L|3918 10|N|Kill Crystal Spine Basilisks to loot the Singing Crystal Shards.|S|IZ|1434|
 R Zuuldaia Ruins|QID|582|M|26.97,19.00;23.14,16.56|Z|Stranglethorn Vale|CC|N|Using the north exit, leave Grom'gol and follow the Savage Coast north to the Zuuldaia Ruins.|
 N Bloodscalp Headhunters|ACTIVE|582|M|PLAYER|N|There are not very many of them around the ruins. If you make your way to the arch in the NE corner and walk up the ramp, you'll find several in this area.|
 C Headhunting|ACTIVE|582|L|1532 20|N|Kill Bloodscalp Headhunters to loot the Shrunken Heads. (50% drop rate)|
 C Bloody Bone Necklaces|ACTIVE|596|L|3915 25|N|Kill any Bloodscalp to loot them.|US|
 R The Vile Reef|QID|629|M|23.10,16.49;26.99,18.82;26.54,21.21|Z|Stranglethorn Vale|CC|N|Return to Grom'gol.|
-N Giant Clams|ACTIVE|1107|N|While you're in the area, keep an eye out for Giant Clams. They may contain a 'Blue Pearl'. It's a quest item that can be sold in the AH, if you don't use them for the 'Pearl Diving' quest.|S!US|IZ|The Vile Reef|
-C Encrusted Tail Fins|QID|1107|M|25.15,24.10|N|Kill Saltscale Murlocs to loot Encrusted Tail Fins.\n[color=FF0000]NOTE: [/color]These mobs are Elite and may be too tough for you at this point in time. Skip this step if they are.|S|IZ|The Vile Reef|
+N Giant Clams|ACTIVE|1107|N|While you're in the area, keep an eye out for Giant Clams. They may contain a 'Blue Pearl'. It's a quest item that can be sold in the AH, if you don't use them for the 'Pearl Diving' quest.|S!US|IZ|104|
+C Encrusted Tail Fins|QID|1107|M|25.15,24.10|N|Kill Saltscale Murlocs to loot Encrusted Tail Fins.\n[color=FF0000]NOTE: [/color]These mobs are Elite and may be too tough for you at this point in time. Skip this step if they are.|S|IZ|104|
 C The Vile Reef|QID|629|M|24.8,22.8|Z|Stranglethorn Vale|QO|1|N|Loot the Tablet Shard. It's leaning against the outside wall.\n[color=FF0000]NOTE: [/color]You can get this without aggroing the 2 Elite mobs on the other side. Swim along the surface to the location and dive straight down.\nIf you do it quick, you'll resurface with 1/3 of your breath left.|NC|
-;l Encrusted Tail Fins|QID|1107|M|25.15,24.10|L|5796 10|N|Kill Saltscale Murlocs to loot Encrusted Tail Fins.\n[color=FF0000]NOTE: [/color]These mobs are Elite and may be too tough for you at this point in time. Skip this step if they are.|US|IZ|The Vile Reef|
+;l Encrusted Tail Fins|QID|1107|M|25.15,24.10|L|5796 10|N|Kill Saltscale Murlocs to loot Encrusted Tail Fins.\n[color=FF0000]NOTE: [/color]These mobs are Elite and may be too tough for you at this point in time. Skip this step if they are.|US|IZ|104|
 R Nesingwary's Expedition|ACTIVE|195|M|37.49,11.69|Z|Stranglethorn Vale|N|Head back to Nesingwary's Expedition.|
 T Raptor Mastery|QID|195|M|35.66,10.81|Z|Stranglethorn Vale|N|To Hemet Nesingwary.|
 A Raptor Mastery|QID|196|M|35.66,10.81|Z|Stranglethorn Vale|N|From Hemet Nesingwary.|PRE|195|
@@ -655,7 +655,7 @@ R Darkmist Cavern|ACTIVE|1206|M|36.97,23.99|Z|Dustwallow Marsh|N|Make your way t
 C Jarl Needs Eyes|QID|1206|M|34.99,21.49|Z|Dustwallow Marsh|L|5884 40|N|Kill Darkmist Spiders to collect the Unpopped Darkmist Eyes.|
 R Swamplight Manor|ACTIVE|1206|M|55.20,26.88|Z|Dustwallow Marsh|N|Make your way back to Swamplight Manor.|
 T Jarl Needs Eyes|QID|1206|M|55.44,26.26|Z|Dustwallow Marsh|N|To "Swamp Eye" Jarl.|
-N Jarl Needs a Blade|AVAILABLE|1203|M|PLAYER|N|Do not bother getting this quest. It's not worth the effort.|PRE|1206|IZ|Swamplight Manor|
+N Jarl Needs a Blade|AVAILABLE|1203|M|PLAYER|N|Do not bother getting this quest. It's not worth the effort.|PRE|1206|IZ|497|
 * Unpopped Darkmist Eyes|QID|1203|M|PLAYER|N|Delete any excess quest items.|U|5884|
 R North Point Tower|AVAILABLE|1270|M|46.88,22.86|Z|Dustwallow Marsh|N|Head back to the main road and make your way to the intersection at North Tower.|
 A Stinky's Escape|QID|1270|M|46.88,17.51|Z|Dustwallow Marsh|N|From "Stinky" Ignatz.\n[color=FF0000]NOTE: [/color]The more mobs you clear on your way in, the less you will have to kill later.|
@@ -687,8 +687,8 @@ F Ratchet|ACTIVE|1270|M|45.09,63.88|Z|Orgrimmar|N|Head to the flightmaster and t
 T Stinky's Escape|QID|1270|M|62.37,37.62|Z|The Barrens|N|To Mebok Mizzyrix.|
 
 ; Stranglethorn Vale
-N Bank|ACTIVE|572^605^196|M|62.67,37.44|Z|The Barrens|N|As you are now headed back to STV, make sure you grab all of your quest items from your bank before leaving.|IZ|Ratchet|
-b Booty Bay|ACTIVE|572^605^196|M|63.70,38.63|Z|The Barrens|N|Take the boat to Booty Bay.|IZ|-Stranglethorn Vale|
+N Bank|ACTIVE|572^605^196|M|62.67,37.44|Z|The Barrens|N|As you are now headed back to STV, make sure you grab all of your quest items from your bank before leaving.|IZ|392|
+b Booty Bay|ACTIVE|572^605^196|M|63.70,38.63|Z|The Barrens|N|Take the boat to Booty Bay.|IZ|-1434|
 F Grom'gol Base Camp|ACTIVE|572^605^196|M|26.87,77.10|Z|Stranglethorn Vale|N|Head to the flightmaster and take a flight to Grom'gol Base Camp.|
 R Southern Savage Coast|ACTIVE|605^572^196|M|32.62,35.53|Z|Stranglethorn Vale|N|Exit Grom'gol Base to the south side and swim across to the opposite shore.|
 C Mok'thardin's Enchantment|QID|572|M|33.63,37.87|Z|Stranglethorn Vale|L|3863 10|N|Kill Jungle Stalkers to collect the feathers.|S|
@@ -708,7 +708,7 @@ K Gan'zulah|ACTIVE|584|M|23.26,8.72|Z|Stranglethorn Vale|QO|1|N|Using the same p
 R Nesingwary's Expedition|ACTIVE|584|M|34.91,11.00|Z|Stranglethorn Vale|N|Work your way out of the Ruins the same way you came in. You can avoid some of the fight by dropping down to the lower ledge of the wall and walking around to where the bottom of the ramp is.\n Once you are out of the Ruins, make your way to the Nesingwary's Expedition.|
 T Raptor Mastery|QID|196|M|35.66,10.81|Z|Stranglethorn Vale|N|To Hemet Nesingwary.|
 A Raptor Mastery|QID|197|PRE|196|M|35.66,10.81|Z|Stranglethorn Vale|N|From Hemet Nesingwary.|
-;N Chapter Quests|ACTIVE|338|AVAILABLE|191|N|From this point forward, every time you return to the Camp, check in with Barnil Stonepot to see if you have enough pages to finish a Chapter quest. You'll want to get rid of the pages as soon as you can to save bag space.\n[color=FF0000]NOTE: [/color]To save log space, do not accept the Chapter quests until you can complete them.|S!US|IZ|Nesingwary's Expedition|
+;N Chapter Quests|ACTIVE|338|AVAILABLE|191|N|From this point forward, every time you return to the Camp, check in with Barnil Stonepot to see if you have enough pages to finish a Chapter quest. You'll want to get rid of the pages as soon as you can to save bag space.\n[color=FF0000]NOTE: [/color]To save log space, do not accept the Chapter quests until you can complete them.|S!US|IZ|100|
 R Venture Co. Base Camp|ACTIVE|584|M|44.82,25.69|Z|Stranglethorn Vale|N|Head to the main road and follow it south across the bridge over the river.|
 K Bhag'thera|ACTIVE|193|M|47.35,28.40;49.65,23.63;48.58,19.59|Z|Stranglethorn Vale|CN|N|You'll find Bhag'thera in 1 of 3 locations. When you find him, kill him to loot his fang.\n[color=FF0000]NOTE: [/color]As you are moving between the spots, be sure to give the elite Ogres around the entrance to Mosh'Ogg a VERY wide berth.|
 

--- a/WoWPro_Leveling/Classic_BC/Alliance/INTRO_BCC_Draenai.lua
+++ b/WoWPro_Leveling/Classic_BC/Alliance/INTRO_BCC_Draenai.lua
@@ -102,7 +102,7 @@ C Medicinal Purpose|QID|9463|S|QO|1|Z|Azuremyst Isle|M|54,61|N|Kill and loot Roo
 C Medicinal Purpose|QID|9463|US|QO|1|Z|Azuremyst Isle|M|54,61|N|Kill and loot Root Trappers for the Vines.|T|Root Trapper|R|Draenei|
 C The Great Moongraze Hunt|QID|9454|S|QO|1|Z|Azuremyst Isle|M|54,61|N|Kill and loot Moongraze Stags for the Tenderloin.|T|Moongraze Stag|
 T Medicinal Purpose|QID|9463|Z|Azuremyst Isle|M|48.4,51.8|N|To Anchorite Fateema.|R|Draenei|
-T Bandits!|QID|9616|IZ|Azure Watch|M|47.10,50.59|N|To Exarch Menelaous.|
+T Bandits!|QID|9616|IZ|3576|M|47.10,50.59|N|To Exarch Menelaous.|
 A An Alternative Alternative|QID|9473|PRE|9463|Z|Azuremyst Isle|M|48.4,51.8|N|From Daedal.|R|Draenei|
 T The Great Moongraze Hunt|QID|9454|Z|Azuremyst Isle|M|49.8,51.9|N|To Acteon.|
 A The Great Moongraze Hunt|QID|10324|PRE|9454|Z|Azuremyst Isle|M|49.8,51.9|N|From Acteon.|

--- a/WoWPro_Leveling/Classic_BC/Alliance/VAN_BCC_10_19_Eastern_Kingdom.lua
+++ b/WoWPro_Leveling/Classic_BC/Alliance/VAN_BCC_10_19_Eastern_Kingdom.lua
@@ -183,7 +183,7 @@ T Return to Verner|QID|119|M|30.98,47.28|Z|Redridge Mountains|N|To Verner Osgood
 A Underbelly Scales|QID|122|M|30.98,47.28|N|From Verner Osgood.|PRE|119|Z|Redridge Mountains
 
 C Redridge Goulash|ACTIVE|92|QO|1;2;3|N|Kill tarantulas, goretusks for the items required.|S|LVL|17|
-C Redridge Goulash|ACTIVE|92|QO|1;3|N|Kill tarantulas and goretusks for the items required.|S|LVL|-17|IZ|Redridge Mountains|
+C Redridge Goulash|ACTIVE|92|QO|1;3|N|Kill tarantulas and goretusks for the items required.|S|LVL|-17|IZ|1433|
 C Underbelly Scales|ACTIVE|122|QO|1|N|Kill Black Dragon Whelps to loot Underbelly Whelp Scales.|S|LVL|17|
 T Hilary's Necklace|QID|3741|M|29.24,53.62|N|To Hilary.|Z|Redridge Mountains|
 T A Free Lunch|QID|129|M|15.28,71.46|N|To Guard Parker. He roams the fork in the road up ahead.|Z|Redridge Mountains|

--- a/WoWPro_Leveling/Classic_BC/Alliance/VAN_BCC_30_41_Alliance.lua
+++ b/WoWPro_Leveling/Classic_BC/Alliance/VAN_BCC_30_41_Alliance.lua
@@ -18,7 +18,7 @@ B Frost Oil|QID|713|L|3829|N|Crafted with Alchemy.|ITEM|3829|
 B Gyrochronatom|QID|714|L|4389|N|Crafted with Engineering.|ITEM|4389|
 B Patterned Bronze Bracers|QID|716|L|2868|N|Crafted with Blacksmithing.|ITEM|2868|
 
-F Menethil Harbor|ACTIVE|1179|M|55.60,47.40|N|Fly to Menethil Harbor.|IZ|Ironforge|
+F Menethil Harbor|ACTIVE|1179|M|55.60,47.40|N|Fly to Menethil Harbor.|IZ|1455|
 b Theramore Isle|QID|1282|M|5,63.51|Z|Wetlands|N|Take the boat to Theramore.\nNote: If still in Darnassus take the boat from Darkshore to Menethil Harbor first|
 
 f Theramore|QID|1039|M|67.48,51.30|Z|Dustwallow Marsh|N|Get the Flightpoint from Baldruc.|
@@ -256,7 +256,7 @@ T Northfold Manor|QID|681|M|45.83,47.55|Z|Arathi Highlands|N|To Captain Nials.|
 A Worth Its Weight in Gold|QID|691|M|46.20,47.76|Z|Arathi Highlands|N|From Apprentice Kryten.|PRE|690|
 T Hints of a New Plague?|QID|659|M|60.18,53.85|Z|Arathi Highlands|N|To Quae.|
 A Hints of a New Plague?|QID|658|M|60.18,53.85|Z|Arathi Highlands|N|From Quae.|PRE|659|
-K Forsaken Courier|ACTIVE|658|M|61.00,60.00|L|647|S|N|Look out for a group of Forsaken leaving Go'Shek Farm. The Forsaken Courier in the center drops a Sealed Folder. A group is recommended to kill these.\nIf unable to find others use and cooldowns or crowd control available whilst focusing the Courier then reset the Guards and loot the letter|T|Forsaken Courier|IZ|Arathi Highlands|
+K Forsaken Courier|ACTIVE|658|M|61.00,60.00|L|647|S|N|Look out for a group of Forsaken leaving Go'Shek Farm. The Forsaken Courier in the center drops a Sealed Folder. A group is recommended to kill these.\nIf unable to find others use and cooldowns or crowd control available whilst focusing the Courier then reset the Guards and loot the letter|T|Forsaken Courier|IZ|1417|
 L Level 35|N|If you are not yet level 35 grind on the Orcs here|LVL|-35|
 R Thandol Span|AVAILABLE|647|M|60.80,60.65;45.80,59.20;43.25,91.20|CC|Z|Arathi Highlands|CC|N|Head to the road leading out of Go'Shek Farm. Follow the road west and towards Wetlands when the road turns south|
 A MacKreel's Moonshine|QID|647|M|43.25,91.20;43.24,92.64|CC|Z|Arathi Highlands|N|Head to the broken side of the bridge. Stand on the right side of the chain and use Slowfall/Levitate on yourself. Aim yourself towards the Torch on the opposite side. Run and jump off the bridge to float over. Accept the quest from Foggy MacKreel in the room on the right. Be aware this is a timed quest. If you fail the jump swim east until you come to a hill you can run back up.|C|Mage,Priest|

--- a/WoWPro_Leveling/Classic_BC/Horde/INTRO_BCC_Blood_Elf.lua
+++ b/WoWPro_Leveling/Classic_BC/Horde/INTRO_BCC_Blood_Elf.lua
@@ -133,7 +133,7 @@ A The Ring of Mmmrrrggglll|QID|8885|M|30.23,58.31|N|From Hathvelion Sungaze.|PRE
 H Falconwing Square|QID|8482|M|46.55,48.92|
 T Incriminating Documents|QID|8482|M|48.16,46.00|N|To Aeldon Sunbrand.|
 A The Dwarven Spy|QID|8483|M|48.16,46.00|N|From Aeldon Sunbrand.|PRE|8482|
-r Repair/Empty|ACTIVE|8483|M|47.07,47.49|N|Visit Sleyin before you leave.|IZ|Falconwing Square|
+r Repair/Empty|ACTIVE|8483|M|47.07,47.49|N|Visit Sleyin before you leave.|IZ|3665|
 C The Dwarven Spy|QID|8483|M|44.57,53.30|QO|1|N|Speak to Prospector Anvilward. Follow him inside and up the ramp to the top. Once there, he will attack you.\n[color=FF0000]NOTE: [/color]Be sure to be full health and buffed before you talk to him outside.|CHAT|
 A Roadside Ambush|QID|9035|M|45.19,56.43|N|From Apprentice Ralen.|LEAD|9062|
 T Roadside Ambush|QID|9035|M|44.88,61.03|N|To Apprentice Meledor.|
@@ -169,17 +169,17 @@ A The Party Never Ends|QID|9067|M|38.15,73.56|N|From Lord Saltheril.|
 T Captain Kelisendra's Lost Rutters|QID|8887|M|36.36,66.63|N|To Captain Kelisendra.\n[color=FF0000]NOTE: [/color]Follow the road west until you reach his camp; just before Sunsail Anchorage.|
 A Grimscale Pirates!|QID|8886|M|36.36,66.63|N|From Captain Kelisendra.|
 A Lost Armaments|QID|8480|M|36.36,66.77|N|From Velendris Whitemorn.|
-C Grimscale Pirates!|QID|8886|M|24.93,69.43|L|21771 6|N|Either pick these up from the ground, or loot them from the Murlocs.|S|IZ|Golden Strand|
-K Wretched Thugs and Hooligans|QID|8892|QO|1;2|N|Kill the Wretched Thugs and Hooligans around Sunsail Anchorage.|S|IZ|Sunsail Anchorage|
-C Lost Armaments|QID|8480|M|31.37,70.00|L|22413 8|N|You'll find the Weapon Containers in Sunsail Anchorage on the ground, in the water and inside the building.\n[color=FF0000]NOTE: [/color]Each one is on a ~5 minute respawn timer.|S|IZ|Sunsail Anchorage|
+C Grimscale Pirates!|QID|8886|M|24.93,69.43|L|21771 6|N|Either pick these up from the ground, or loot them from the Murlocs.|S|IZ|3460|
+K Wretched Thugs and Hooligans|QID|8892|QO|1;2|N|Kill the Wretched Thugs and Hooligans around Sunsail Anchorage.|S|IZ|3461|
+C Lost Armaments|QID|8480|M|31.37,70.00|L|22413 8|N|You'll find the Weapon Containers in Sunsail Anchorage on the ground, in the water and inside the building.\n[color=FF0000]NOTE: [/color]Each one is on a ~5 minute respawn timer.|S|IZ|3461|
 K Mmmrrrggglll|ACTIVE|8885|M|25.67,65.74;24.02,73.70|CC|QO|1|N|Follow the water to Golden Strand. He roams the beach along Golden Strand between the two waypoints.|T|Mmmrrrggglll|
-C Grimscale Pirates!|QID|8886|M|24.93,69.43|L|21771 6|N|Either pick these up from the ground, or loot them from the Murlocs.|US|IZ|Golden Strand|
+C Grimscale Pirates!|QID|8886|M|24.93,69.43|L|21771 6|N|Either pick these up from the ground, or loot them from the Murlocs.|US|IZ|3460|
 C Lost Armaments|QID|8480|M|31.37,70.00|L|22413 8|N|You'll find the Weapon Containers in Sunsail Anchorage on the ground, in the water and inside the building.\n[color=FF0000]NOTE: [/color]Each one is on a ~5 minute respawn timer.|US|
 T Grimscale Pirates!|QID|8886|M|36.36,66.63|N|To Captain Kelisendra.|
 T Lost Armaments|QID|8480|M|36.36,66.77|N|To Velendris Whitemorn.|
 A Wretched Ringleader|QID|9076|M|36.36,66.77|N|From Velendris Whitemorn.|PRE|8480|
 K Aldaron|QID|9076|M|32.70,68.4|QO|1|N|Head inside the white building and fight your way up to the top. You'll find Aldaron the Reckless with two guards here.\n[color=FF0000]NOTE: [/color]If you're careful, you can probably pull the guards solo before you kill Aldaron.|
-K Wretched Thugs and Hooligans|QID|8892|QO|1;2|N|Finish killing the Wretched Thugs and Hooligans around Sunsail Anchorage.|US|IZ|Sunsail Anchorage|
+K Wretched Thugs and Hooligans|QID|8892|QO|1;2|N|Finish killing the Wretched Thugs and Hooligans around Sunsail Anchorage.|US|IZ|3461|
 T Wretched Ringleader|QID|9076|M|36.36,66.77|N|To Velendris Whitemorn.|
 T The Ring of Mmmrrrggglll|QID|8885|M|30.23,58.31|N|To Hathvelion Sungaze.|
 C Pelt Collection|QID|8491|M|38.42,64.67|N|Finish collecting the Pelts.|US|

--- a/WoWPro_Leveling/Classic_BC/Horde/INTRO_BCC_Orc_Troll.lua
+++ b/WoWPro_Leveling/Classic_BC/Horde/INTRO_BCC_Orc_Troll.lua
@@ -91,7 +91,7 @@ r Sell junk/reload|ACTIVE|794|M|42.59,67.34|N|At Duokna.\nRight-click this step 
 R Burning Blade Coven|ACTIVE|6394|M|45.31,56.57|N|Head back to the cave entrance you were just at.|
 C Burning Blade Medallion|QID|794|M|42.70,52.91|N|Take the right passage and continue over the stream to the first fork. At the fork, go to the right and head for the opening at the end of the tunnel. Kill Yarrog Baneshadow and loot the Burning Blade Medallion from him.|
 l Thazz'ril's Pick|QID|6394|M|43.73,53.79|QO|1|N|Drop off the ledge and make your way to the other side, atop the waterfall. Follow the stream to the pool at the top. On the far side of the pool, you'll find the Pick leaning against a spire.|
-R Exit cave|ACTIVE|6394|M|45.25,56.62|N|Make your way to the exit.|IZ|Burning Blade Coven|
+R Exit cave|ACTIVE|6394|M|45.25,56.62|N|Make your way to the exit.|IZ|365|
 T Thazz'ril's Pick|QID|6394|M|44.62,68.65|N|Return to Foreman Thazz'ril.|
 T Burning Blade Medallion|QID|794|M|42.85,69.15|N|To Zureetha Fargaze.|
 A Report to Sen'jin Village|QID|805|M|42.85,69.15|N|From Zureetha Fargaze.|PRE|794|
@@ -99,7 +99,7 @@ r Repair/Restock|QID|805|M|42.59,67.34|N|At Duokna.\nRight-click this step when 
 
 N Mage Trainer|QID|805|N|[color=FF0000]NOTE: [/color]Mai'ah (Valley of Trials) and Un'Thuwa (Sen'jin Village) are the only Mage trainers in Durotar. After level 6, Mai'ah will no longer train you. You either go to Orgrimmar, or you return to Sen'jin Village.|C|Mage|
 L Level 6|QID|805|N|You'll want to be level 6 before you leave Sen'jin. You won't be back here for a while and you'll want to do your level 6 training before leaving.\nGrind on your way to Sen'jin Village.|LVL|5;-225|C|Mage|S|
-R Exit Valley of Trials|ACTIVE|805|M|50.55,68.40|N|Follow the road east out of Valley of Trials.|IZ|Valley of Trials|
+R Exit Valley of Trials|ACTIVE|805|M|50.55,68.40|N|Follow the road east out of Valley of Trials.|IZ|363|
 R Sen'jin Village|ACTIVE|805|M|54.30,72.84|N|Continue east, taking the south road when you get to the road marker.|
 L Level 6|QID|805|N|You'll want to be level 6 before you leave Sen'jin. You won't be back here for a while and you'll want to do your level 6 training before leaving.\nGrind on your way to Sen'jin Village.|LVL|5;-225|C|Mage|US|
 T Report to Sen'jin Village|QID|805|M|55.95,74.72|N|To Master Gadrin.|
@@ -197,7 +197,7 @@ A Securing the Lines|QID|835|M|46.37,22.94|N|From Rezlak.|PRE|834|
 L Level 10|QID|837|N|You'll want to be level 10 when you turn in your next quest in Razor Hill. Grind on harpies until you are 2 bubbles from leveling.|LVL|9;-630|
 T Encroachment|QID|837|M|51.95,43.50|N|To Gar'Thok in Razor Hill.|
 
-= Train|QID|840|N|Go learn your level 10 skills/spells. Right-click this step off once you are done.|LVL|10|C|-Mage|IZ|Razor Hill|
+= Train|QID|840|N|Go learn your level 10 skills/spells. Right-click this step off once you are done.|LVL|10|C|-Mage|IZ|362|
 R Sen'jin Village|QID|840|M|54.33,72.91|N|Head to Sen'jin Village.|LVL|10|C|Mage|
 = Train|QID|840|N|Learn your level 10 spells. Right-click this step off once you are done.|LVL|10|C|Mage|
 R Razor Hill|QID|840|M|52.48,44.42|N|Return to Razor Hill.|LVL|10|C|Mage|
@@ -235,21 +235,21 @@ A Hidden Enemies|QID|5726|M|31.75,37.82|Z|Orgrimmar|N|From Thrall.|
 A Finding the Antidote|QID|813|ACTIVE|812|M|47.24,53.58|Z|Orgrimmar|L|-4904|N|From Khorgan in the Cleft of Shadow.\n\n[color=FF0000]NOTE: [/color]As long as you pick up this quest, the 'Need for a Cure' timer is irrelevant.|
 
 ; --- locations of profession trainers in Orgrimmar
-N Cooking|ACTIVE|840|M|57.39,53.95|Z|Orgrimmar|N|Zamja, Cooking Trainer, The Drag - 2nd level.|P|Cooking;185;0;0|IZ|Orgrimmar|
-N Enchanting|ACTIVE|840|M|53.46,38.56|Z|Orgrimmar|N|Jhag, Journeyman Enchanter, The Drag.|P|Enchanting;333;0;0|IZ|Orgrimmar|
-N Leatherworking|ACTIVE|840|M|63.30,44.75|Z|Orgrimmar|N|Kamari, Journeyman Leatherworker, The Drag.|P|Leatherworking;165;0;0|IZ|Orgrimmar|
-N Skinning|ACTIVE|840|M|63.35,45.42|Z|Orgrimmar|N|Thuwd, Skinning Trainer, The Drag.|P|Skinning;393;0;0|IZ|Orgrimmar|
-N Tailoring|ACTIVE|840|M|62.93,49.26|Z|Orgrimmar|N|Snang, Journeyman Tailor, The Drag.|P|Tailoring;197;0;0|IZ|Orgrimmar|
-N Alchemy|ACTIVE|840|M|55.80,32.91|Z|Orgrimmar|N|Whuut, Journeyman Alchemist, The Drag.|P|Alchemy;171;0;0|IZ|Orgrimmar|
-N Herbalism|ACTIVE|840|M|55.61,39.46|Z|Orgrimmar|N|Jandi, Herbalism Trainer, The Drag - 2nd level.|P|Herbalism;182;0;0|IZ|Orgrimmar|
-N Mining|ACTIVE|840|M|73.12,26.08|Z|Orgrimmar|N|Makaru, Mining Trainer, Valley of Honor.|P|Mining;186;0;0|IZ|Orgrimmar|
-N Engineering|ACTIVE|840|M|75.95,24.18|Z|Orgrimmar|N|Thund, Journey Engineer, Valley of Honor.|P|Engineering;202;0;0|IZ|Orgrimmar|
-N Blacksmithing|ACTIVE|840|M|80.76,23.70|Z|Orgrimmar|N|Ug'thok, Journey Blacksmith, Valley of Honor.|P|Blacksmithing;164;0;0|IZ|Orgrimmar|
-N Fishing|ACTIVE|840|M|69.81,29.20|Z|Orgrimmar|N|Lumak, Fishing Trainer, Valley of Honor.|P|Fishing;356;0;0|IZ|Orgrimmar|
-N Weapon Masters|ACTIVE|840|M|81.70,19.53|Z|Orgrimmar|N|Sayoc and Hanashi in Valley of Honor.\nSayoc teaches bows, daggers, fist weapons, one & two-handed axes, and thrown weapons.\nHanashi teaches bows, one & two-handed axes, staves, and thrown weapons.|IZ|Orgrimmar|
-N Weapon Masters|ACTIVE|840|M|57,32|Z|Undercity|N|If you wish to learn swords, you'll have to take the Zepplin to Undercity. Archibald is in the War Quarter. He teaches crossbows, daggers, one & two handed swords and polearms.|IZ|Orgrimmar|
-N Weapon Masters|ACTIVE|840|M|40.94,62.74|Z|Thunder Bluff|N|If you wish to learn maces, you'll have to take the Zepplin to Thunder Bluff. Ansekwa is on the lower plateau. He teaches one & two handed maces, staves and guns.|IZ|Orgrimmar|
-N First Aid|ACTIVE|840|M|34.17,84.55|Z|Orgrimmar|N|Arnok, First Aid Trainer, The Valley of Spirits.|P|First Aid;129;0;0|IZ|Orgrimmar|
+N Cooking|ACTIVE|840|M|57.39,53.95|Z|Orgrimmar|N|Zamja, Cooking Trainer, The Drag - 2nd level.|P|Cooking;185;0;0|IZ|1454|
+N Enchanting|ACTIVE|840|M|53.46,38.56|Z|Orgrimmar|N|Jhag, Journeyman Enchanter, The Drag.|P|Enchanting;333;0;0|IZ|1454|
+N Leatherworking|ACTIVE|840|M|63.30,44.75|Z|Orgrimmar|N|Kamari, Journeyman Leatherworker, The Drag.|P|Leatherworking;165;0;0|IZ|1454|
+N Skinning|ACTIVE|840|M|63.35,45.42|Z|Orgrimmar|N|Thuwd, Skinning Trainer, The Drag.|P|Skinning;393;0;0|IZ|1454|
+N Tailoring|ACTIVE|840|M|62.93,49.26|Z|Orgrimmar|N|Snang, Journeyman Tailor, The Drag.|P|Tailoring;197;0;0|IZ|1454|
+N Alchemy|ACTIVE|840|M|55.80,32.91|Z|Orgrimmar|N|Whuut, Journeyman Alchemist, The Drag.|P|Alchemy;171;0;0|IZ|1454|
+N Herbalism|ACTIVE|840|M|55.61,39.46|Z|Orgrimmar|N|Jandi, Herbalism Trainer, The Drag - 2nd level.|P|Herbalism;182;0;0|IZ|1454|
+N Mining|ACTIVE|840|M|73.12,26.08|Z|Orgrimmar|N|Makaru, Mining Trainer, Valley of Honor.|P|Mining;186;0;0|IZ|1454|
+N Engineering|ACTIVE|840|M|75.95,24.18|Z|Orgrimmar|N|Thund, Journey Engineer, Valley of Honor.|P|Engineering;202;0;0|IZ|1454|
+N Blacksmithing|ACTIVE|840|M|80.76,23.70|Z|Orgrimmar|N|Ug'thok, Journey Blacksmith, Valley of Honor.|P|Blacksmithing;164;0;0|IZ|1454|
+N Fishing|ACTIVE|840|M|69.81,29.20|Z|Orgrimmar|N|Lumak, Fishing Trainer, Valley of Honor.|P|Fishing;356;0;0|IZ|1454|
+N Weapon Masters|ACTIVE|840|M|81.70,19.53|Z|Orgrimmar|N|Sayoc and Hanashi in Valley of Honor.\nSayoc teaches bows, daggers, fist weapons, one & two-handed axes, and thrown weapons.\nHanashi teaches bows, one & two-handed axes, staves, and thrown weapons.|IZ|1454|
+N Weapon Masters|ACTIVE|840|M|57,32|Z|Undercity|N|If you wish to learn swords, you'll have to take the Zepplin to Undercity. Archibald is in the War Quarter. He teaches crossbows, daggers, one & two handed swords and polearms.|IZ|1454|
+N Weapon Masters|ACTIVE|840|M|40.94,62.74|Z|Thunder Bluff|N|If you wish to learn maces, you'll have to take the Zepplin to Thunder Bluff. Ansekwa is on the lower plateau. He teaches one & two handed maces, staves and guns.|IZ|1454|
+N First Aid|ACTIVE|840|M|34.17,84.55|Z|Orgrimmar|N|Arnok, First Aid Trainer, The Valley of Spirits.|P|First Aid;129;0;0|IZ|1454|
 
 ; --- Class quests in Orgrimmar
 ; --- Mage
@@ -263,20 +263,20 @@ A The Shattered Hand|QID|1963|M|42.73,53.44|Z|Orgrimmar|N|From Therzok.|R|Orc,Tr
 T Gan'rul's Summons|QID|1506|M|48.25,45.29|Z|Orgrimmar|N|To Gan'rul Bloodeye.|R|Orc|C|Warlock|
 A Creature of the Void|QID|1501|M|48.20,45.70|Z|Orgrimmar|N|From Gan'rul Bloodeye.|PRE|1506|R|Orc|C|Warlock|
 ; ---
-R Leave Orgrimmar|ACTIVE|812|M|56.39,41.32;49.44,60.35;52.42,84.43|Z|Orgrimmar|CC|N|Exit Orgrimmar through the south gate.|IZ|Orgrimmar|
+R Leave Orgrimmar|ACTIVE|812|M|56.39,41.32;49.44,60.35;52.42,84.43|Z|Orgrimmar|CC|N|Exit Orgrimmar through the south gate.|IZ|1454|
 
 N Sword Training|ACTIVE|840|M|PLAYER|N|If you wish to start using swords, now is the best time to go learn the skill from Archibald in Undercity. The cost is 10 silver.\n[color=FF0000]NOTE: [/color]If you are not interested, then just skip the next few steps.|C|Rogue|
 b Tirisfal Glades|ACTIVE|840|M|50.88,13.83|Z|Durotar|N|Take the Zepplin to Tirisfal Glade.|C|Rogue|
 R Undercity|ACTIVE|840|M|61.86,65.04|Z|Tirisfal Glades|N|Enter Undercity and take the elevator down.|C|Rogue|
-N Archibald|ACTIVE|840|M|57.32,32.74|Z|Undercity|N|Make your way to Undercity's War Quarter inner ring.\n[color=FF0000]NOTE: [/color]Check this step off when you are done.|C|Rogue|IZ|Undercity|
-R Leave Undercity|ACTIVE|840|M|53.40,43.56;63.61,47.52;72.77,40.03;66.15,37.11;66.29,1.94|Z|Undercity|CC|N|Take the elevator up and leave Undercity through the front gates.|C|Rogue|IZ|Undercity|
-b Durotar|ACTIVE|840|M|60.75,58.77|Z|Tirisfal Glades|N|Take the zeppelin to Orgrimmar.|C|Rogue|IZ|Tirisfal Glades|
+N Archibald|ACTIVE|840|M|57.32,32.74|Z|Undercity|N|Make your way to Undercity's War Quarter inner ring.\n[color=FF0000]NOTE: [/color]Check this step off when you are done.|C|Rogue|IZ|1458|
+R Leave Undercity|ACTIVE|840|M|53.40,43.56;63.61,47.52;72.77,40.03;66.15,37.11;66.29,1.94|Z|Undercity|CC|N|Take the elevator up and leave Undercity through the front gates.|C|Rogue|IZ|1458|
+b Durotar|ACTIVE|840|M|60.75,58.77|Z|Tirisfal Glades|N|Take the zeppelin to Orgrimmar.|C|Rogue|IZ|1420|
 
 C Finding the Antidote|QID|813|ACTIVE|812|M|41.49,19.39|QO|1|N|Head back to the area around Rhinag and kill Venomtail Scorpids for their Venomtail Scorpid Sacs.|
 R Orgrimmar|ACTIVE|813|M|45.52,12.07|N|Head back to Orgrimmar.|
 R Cleft of Shadow|ACTIVE|813|M|47.24,53.58;51.75,57.85;56.03,41.16;59.91,49.37;51.26,46.39|Z|Orgrimmar|CC|
 T Finding the Antidote|QID|813|ACTIVE|812|M|47.24,53.58|Z|Orgrimmar|N|Go back to Khorgan and turn in the quest for the Venomtail Antidote. If you lose the antidote, this quest is repeatable.|
-R Leave Orgrimmar|ACTIVE|812|M|56.73,41.96;49.44,60.35;52.42,84.43|Z|Orgrimmar|CC|N|Exit Orgrimmar through the south gate.|IZ|Orgrimmar|
+R Leave Orgrimmar|ACTIVE|812|M|56.73,41.96;49.44,60.35;52.42,84.43|Z|Orgrimmar|CC|N|Exit Orgrimmar through the south gate.|IZ|1454|
 A Need for a Cure|QID|812|M|41.54,18.60|N|From Rhinag.|FAIL|
 T Need for a Cure|QID|812|M|41.54,18.60|N|To Rhinag.|
 
@@ -330,7 +330,7 @@ T Hidden Enemies|QID|5726|M|31.76,37.81|Z|Orgrimmar|N|To Thrall.|
 A Hidden Enemies|QID|5727|M|31.76,37.81|Z|Orgrimmar|N|From Thrall.|PRE|5726|
 R Cleft of Shadow|ACTIVE|829^832|M|40.00,53.30;42.19,57.30|Z|Orgrimmar|CC|N|Make your way to Cleft of Shadow.|
 T Neeru Fireblade|QID|829|M|49.48,50.58|Z|Orgrimmar|N|To Neeru Fireblade. He's in the hut beside the Ragefire Chasm portal.|
-t Burning Shadows|QID|832|ACTIVE|-829|M|49.48,50.58|Z|Orgrimmar|N|To Neeru Fireblade.|IZ|Orgrimmar|
+t Burning Shadows|QID|832|ACTIVE|-829|M|49.48,50.58|Z|Orgrimmar|N|To Neeru Fireblade.|IZ|1454|
 A Ak'Zeloth|QID|809|M|49.48,50.58|Z|Orgrimmar|N|From Neeru Fireblade.|PRE|829|
 C Hidden Enemies|QID|5727|M|49.48,50.58|Z|Orgrimmar|QO|1|N|Chat with Neeru Fireblade.|CHAT|
 R Grommash Hold|ACTIVE|5727|M|40.38,37.00|Z|Orgrimmar|N|Exit Cleft of Shadow and make your way back to Grommash Hold.|
@@ -338,7 +338,7 @@ T Hidden Enemies|QID|5727|M|31.76,37.81|Z|Orgrimmar|N|To Thrall.|
 ; Space breaks auto
 A Hidden Enemies |QID|5728|M|31.75,37.82|Z|Orgrimmar|ELITE|N|[color=E6CC80]Dungeon: Ragefire Chasm[/color]\nFrom Thrall.\nAccept this quest if you are planning on running the RFC dungeon. Otherwise, skip it.|PRE|5727|RANK|3|
 * Lieutenant's Insignia|AVAILABLE|-5727|N|You can safely destroy the Lieutenant's Insignia now.|U|14544|
-N Training/Shopping|ACTIVE|809|N|Make sure you do all of your training, shopping, etc. before leaving.|IZ|Orgrimmar|
+N Training/Shopping|ACTIVE|809|N|Make sure you do all of your training, shopping, etc. before leaving.|IZ|1454|
 R Leave Orgrimmar|ACTIVE|809|M|52.42,84.43|Z|Orgrimmar|CC|N|Exit Orgrimmar through the south gate.|
 
 R Far Watch Post|ACTIVE|809|M|37.58,16.21;36.04,23.69|CC|N|Make your way west to Southfury River and follow it south.\nIt's best if you don't cross the river right away. The mobs on the other side are level 15+.|

--- a/WoWPro_Leveling/Classic_BC/Horde/VAN_BCC_10_15_Silverpine_Forest.lua
+++ b/WoWPro_Leveling/Classic_BC/Horde/VAN_BCC_10_15_Silverpine_Forest.lua
@@ -140,7 +140,7 @@ T Raleigh and the Undercity|QID|441|M|62.00,42.76|Z|Undercity|N|To Raleigh Andre
 
 ; --- Making sure they have the Barrens breadcrumb.
 A Sample for Helbrim|QID|1358|M|50.13,67.95|Z|Undercity|N|From Apothecary Zinge.|PRE|1359|
-R Leave Undercity|ACTIVE|1358|M|65.99,36.85;66.22,0.90;66.22,1.27|Z|Undercity|CC|N|Take the elevator up and leave Undercity through the front gates.|IZ|Undercity|
+R Leave Undercity|ACTIVE|1358|M|65.99,36.85;66.22,0.90;66.22,1.27|Z|Undercity|CC|N|Take the elevator up and leave Undercity through the front gates.|IZ|1458|
 
 ; --- Travel to Durotar (Orgrimmar)
 b Durotar|ACTIVE|1358|M|60.75,58.77|Z|Tirisfal Glades|N|Take the zeppelin to Orgrimmar.|

--- a/WoWPro_Leveling/Classic_BC/Horde/VAN_BCC_10_17_The_Barrens.lua
+++ b/WoWPro_Leveling/Classic_BC/Horde/VAN_BCC_10_17_The_Barrens.lua
@@ -127,7 +127,7 @@ C The Shattered Hand|QID|1963|M|63.91,44.28|L|7209|N|Tazan patrols in The Mercha
 K Southsea Freebooters|ACTIVE|887|M|63.88,44.55|QO|1;2|N|You'll find them all along The Merchant Coast. The Cannoneers are scarcer than the Brigands.\n[color=FF0000]NOTE: [/color]If you run into Baron Longshore, I'd suggest waiting until your next visit. He hits hard and has 2 adds.|
 C The Shattered Hand|QID|1963|M|63.91,44.28|L|7209|N|Tazan patrols in The Merchant Coast. Kill him and loot his satchel.|R|Orc,Troll|C|Rogue|US|
 R Ratchet|ACTIVE|887|M|62.73,40.17|N|Return to Ratchet.|
-t WANTED: Baron Longshore|QID|895|M|62.68,36.23|N|To Gazlowe in Ratchet.|IZ|Ratchet|
+t WANTED: Baron Longshore|QID|895|M|62.68,36.23|N|To Gazlowe in Ratchet.|IZ|392|
 T Southsea Freebooters|QID|887|M|62.68,36.23|N|To Gazlowe in Ratchet.|
 A The Missing Shipment|QID|890|M|62.68,36.23|N|From Gazlowe.|PRE|887|
 T The Missing Shipment|QID|890|M|63.35,38.45|N|To Wharfmaster Dizzywig.|
@@ -135,7 +135,7 @@ A The Missing Shipment|QID|892|M|63.35,38.45|N|From Wharfmaster Dizzywig.|PRE|89
 T The Missing Shipment|QID|892|M|62.68,36.23|N|To Gazlowe.|
 A Stolen Booty|QID|888|M|62.68,36.23|N|From Gazlowe.|PRE|892|
 
-R Exit Ratchet|QID|903|M|58.59,38.42|N|Follow the road west out of Ratchet.|IZ|Ratchet|
+R Exit Ratchet|QID|903|M|58.59,38.42|N|Follow the road west out of Ratchet.|IZ|392|
 C Prowlers of the Barrens|QID|903|M|58.90,37.72|L|5096 7|N|At the top of the hill, look for the Savannah Prowlers in the bushes to the north and south of the road.|
 C Raptor Thieves|QID|869|L|5062 12|N|Finish collecting the Raptor Heads as you make your way back to the Crossroads.|US|
 ; lv 17
@@ -157,7 +157,7 @@ T The Shattered Hand|QID|1858|M|42.74,53.55|Z|Orgrimmar|N|To Therzok.|R|Orc,Trol
 A Zando'zan|QID|2379|M|43.03,53.73|Z|Orgrimmar|N|From Shenthul.|R|Orc,Troll,Undead|C|Rogue|
 T Zando'zan|QID|2379|M|42.73,52.95|Z|Orgrimmar|N|To Zando'zan.|R|Orc,Troll,Undead|C|Rogue|
 A Wrenix of Ratchet|QID|2382|M|42.73,52.95|Z|Orgrimmar|N|From Zando'zan.|PRE|2379|R|Orc,Troll,Undead|C|Rogue|
-F Crossroads|AVAILABLE|853|ACTIVE|2382|M|45.15,63.90|Z|Orgrimmar|N|Fly back to the Crossroads.|R|Orc,Troll,Undead|C|Rogue|IZ|Orgrimmar|
+F Crossroads|AVAILABLE|853|ACTIVE|2382|M|45.15,63.90|Z|Orgrimmar|N|Fly back to the Crossroads.|R|Orc,Troll,Undead|C|Rogue|IZ|1454|
 ; ---
 
 A Apothecary Zamah|QID|853|M|51.46,30.16|N|From Apothecary Helbrim.\n[color=FF0000]NOTE: [/color]This is a timed quest (45 minutes).|PRE|848|
@@ -171,7 +171,7 @@ C Lost in Battle|QID|4921|M|49.33,50.34|QO|1|N|Mankrik's wife is the "Beaten Cor
 R Camp Taurajo|QID|853|M|46.60,57.79|N|[color=FF0000]NOTE: [/color]Stick to the road unless you want to do some grinding.|
 F Thunder Bluff|QID|853|M|44.44,59.15|
 T Apothecary Zamah|QID|853|M|30.04,29.83;22.79,20.90|CC|Z|Thunder Bluff|N|To Apothecary Zamah.\nHead to the Pools of Vision, beneath Spirit Rise.|
-A Serpentbloom |QID|962|M|22.79,20.90|Z|Thunder Bluff|ELITE|N|[color=E6CC80]Dungeon: Wailing Caverns[/color]\nFrom Apothecary Zamah, Spirit Rise.\n[color=FF0000]NOTE: [/color]Skip if you wish.|IZ|Thunder Bluff|
+A Serpentbloom |QID|962|M|22.79,20.90|Z|Thunder Bluff|ELITE|N|[color=E6CC80]Dungeon: Wailing Caverns[/color]\nFrom Apothecary Zamah, Spirit Rise.\n[color=FF0000]NOTE: [/color]Skip if you wish.|IZ|1456|
 N Weapon Master|QID|4921|M|40.92,62.70|Z|Thunder Bluff|N|While you are here, go see Ansekhwa if you wish to train in Guns, One-Handed Maces, Staves or Two-handed Maces.\n[color=FF0000]NOTE: [/color]Check this step off to continue.|
 F Crossroads|QID|4921|M|47.02,49.83|Z|Thunder Bluff|
 
@@ -456,13 +456,13 @@ A Blood Feeders|QID|6461|M|71.24,95.02|Z|Stonetalon Mountains|N|From Xen'zilla i
 K Blood Feeders|ACTIVE|6461|M|58.18,76.03|Z|Stonetalon Mountains|QO|1;2|N|Kill Deepmoss Creepers and Venomspitters.|S|
 R Webwinder Path|ACTIVE|6461|M|59.34,75.96|Z|Stonetalon Mountains|N|Leave Malaka'jin and follow the road north.|
 A Arachnophobia|QID|6284|M|59.07,75.71|Z|Stonetalon Mountains|ELITE|N|From the Wanted Poster, located beside the road.\n[color=FF0000]NOTE: [/color]This quest is not recommended at your current level. Accept the quest on the off-chance that you find a group to do it.|
-R Sishir Canyon|ACTIVE|6461^1069^6284|M|58.18,76.03|Z|Stonetalon Mountains|N|Follow the path west up the hill.|IZ|Stonetalon Mountains|
+R Sishir Canyon|ACTIVE|6461^1069^6284|M|58.18,76.03|Z|Stonetalon Mountains|N|Follow the path west up the hill.|IZ|1442|
 C Deepmoss Spider Eggs|QID|1069|M|53.48,74.52|Z|Stonetalon Mountains|L|5570 15|N|Pick up the spider eggs from around the area.\n[color=FF0000]NOTE: [/color]1-2 Deepmoss Hatchlings will spawn after opening the egg. On occassion, a Deepmoss Matriarch may also spawn after killing the Hatchlings|S|
 K Bessaleth|ACTIVE|6284|M|53.48,74.52|Z|Stonetalon Mountains|L|16192|N| Bessaleth is a lv 21 Elite mob with multiple spawn points. You'll find her in one of the alcoves along the edge.\n[color=FF0000]NOTE: [/color]It's strongly recommended to only attempt this if you're over level, or you have help to do it.\nSkip this step if you wish to move on.|T|Bessaleth|
 C Deepmoss Spider Eggs|QID|1069|M|53.48,74.52|Z|Stonetalon Mountains|L|5570 15|N|Pick up the spider eggs from around the area.|US|
 K Blood Feeders|ACTIVE|6461|M|53.48,74.52|Z|Stonetalon Mountains|QO|1;2|N|Finish up the spiders needed.|US|
 R Sun Rock Retreat|ACTIVE|6401|M|59.34,75.87;59.67,71.22;53.04,61.58;49.58,60.99|CC|Z|Stonetalon Mountains|N|Head back to Webwinder Path and follow it north; taking the left forks (or just follow the signs).|
-t Arachnophobia|QID|6284|M|47.20,61.16|Z|Stonetalon Mountains|N|To Maggran Earthbinder.|IZ|Sun Rock Retreat|
+t Arachnophobia|QID|6284|M|47.20,61.16|Z|Stonetalon Mountains|N|To Maggran Earthbinder.|IZ|460|
 T Kaya's Alive|QID|6401|M|47.46,58.38|Z|Stonetalon Mountains|N|To Tammra Windfield.|
 f Sun Rock Retreat|QID|6461|M|45.13,59.84|Z|Stonetalon Mountains|N|At Tharm.|TAXI|-Sun Rock Retreat|
 R Malaka'jin|ACTIVE|6461|M|53.18,61.66;71.55,90.59|CC|Z|Stonetalon Mountains|N|Return to Malaka'jin.|
@@ -476,11 +476,11 @@ A Leaders of the Fang |QID|914|M|75.65,31.63|Z|Thunder Bluff|ELITE|N|[color=E6CC
 N Wailing Caverns|ACTIVE|914|N|Having all of the quests for Wailing Cavern, now is a good time to look for a group for this instance.\nAs this guide is dungeon-free, we won't be completing those quests in this guide. Feel free to rejoin this guide when you are done.|
 
 F Orgrimmar|ACTIVE|3923|N|[color=FF0000]NOTE: [/color]No matter what class/race you are, you'll want to be in Orgrimmar at this point.|
-R Enter Orgrimmar|ACTIVE|3923|M|45.52,12.07|CC|Z|Durotar|N|Enter Orgrimmar by the south entrance.|IZ|-Orgrimmar|
+R Enter Orgrimmar|ACTIVE|3923|M|45.52,12.07|CC|Z|Durotar|N|Enter Orgrimmar by the south entrance.|IZ|-1454|
 R Valley of Honor|QID|3923|M|65.54,40.00|Z|Orgrimmar|
 T Rilli Greasygob|QID|3923|M|76.51,24.43|Z|Orgrimmar|N|Look for Rilli Greasygob inside Nogg's Machine Shop.|
 A Samophlange Manual|QID|3924|M|76.51,24.43|Z|Orgrimmar|N|From Rilli Greasygob.|PRE|3923|
-R Southfury River|ACTIVE|3924|N|Leave Orgrimmar through the west gate.|M|11.45,67.06|Z|Orgrimmar|IZ|Orgrimmar|
+R Southfury River|ACTIVE|3924|N|Leave Orgrimmar through the west gate.|M|11.45,67.06|Z|Orgrimmar|IZ|1454|
 C Samophlange Manual Pages|ACTIVE|3924|L|11148 5|QO|1|N|Make your way to Boulder Lode Mine. Kill Venture Co. Enforcers and Overseers to collect the pages.|S|
 C Miner's Fortune|QID|896|L|5097|N|The Cat's Eye Emerald drops from one of the Venture Co. Enforcers or Overseers.|S|
 R Boulder Lode Mine|ACTIVE|3924|M|63.66,4.43;62.74,4.75|CC|QO|1|N|Make your way along the river until the path widens. At this point, there is a short cut up the side of the hill into Boulder Lode Mine.|
@@ -545,8 +545,8 @@ N Rare Spawn Kill Quests|ACTIVE|907|AVAILABLE|883^884^885^897|N|Jorn Skyseer has
 A Lakota'mani|QID|883|N|From Hoof of Lakota'mani.|U|5099|O|
 A Owatanka|QID|884|N|From Owatanka's Tailspike.|U|5102|O|
 T Enraged Thunder Lizards|QID|907|M|44.86,59.14|N|To Jorn Skyseer back at Camp Taurajo.|
-t Lakota'mani|QID|883|M|44.86,59.14|N|To Jorn Skyseer.|IZ|Camp Taurajo|
-t Owatanka|QID|884|M|44.86,59.14|N|To Jorn Skyseer.|IZ|Camp Taurajo|
+t Lakota'mani|QID|883|M|44.86,59.14|N|To Jorn Skyseer.|IZ|378|
+t Owatanka|QID|884|M|44.86,59.14|N|To Jorn Skyseer.|IZ|378|
 A Cry of the Thunderhawk|QID|913|M|44.86,59.14|N|From Jorn Skyseer.|PRE|907|
 C Cry of the Thunderhawk|QID|913|L|5164|N|Kill a Thunderhawk and loot its wings. You will find them all around the outside edge of Camp Taurajo.|
 L Level 22|ACTIVE|2458^2478|N|You'll want to be within a bubble of level 22 before you return to Camp Taurajo.|LVL|21;-1950|R|Orc,Troll,Undead|C|Rogue|
@@ -567,9 +567,9 @@ A The Shattered Salute|QID|2460|M|43.04,53.74|Z|Orgrimmar|N|From Shenthul in Cle
 C The Shattered Salute|QID|2460|M|43.04,53.74|Z|Orgrimmar|QO|1|N|Target Shenthul and use the emote '/salute' to complete the quest.|T|Shenthul|R|Orc,Troll,Undead|C|Rogue|NC|
 T The Shattered Salute|QID|2460|M|43.04,53.74|Z|Orgrimmar|N|To Shenthul.|R|Orc,Troll,Undead|C|Rogue|
 A Deep Cover|QID|2458|M|43.04,53.74|Z|Orgrimmar|N|From Shenthul.|PRE|2460|R|Orc,Troll,Undead|C|Rogue|
-N Dagger|ACTIVE|2458^2478|N|Make sure you have an equipable dagger before you leave Orgrimmar. You'll need it for completing part of your class quest.\n[color=FF0000]NOTE: [/color]Check this step off to continue.|R|Orc,Troll,Undead|C|Rogue|IZ|Orgrimmar|
-N Flash Powder|ACTIVE|2458^2478|M|42.2,49.6|Z|Orgrimmar|L|5140|N|Make sure you pick some up from Rekkul before you leave.|R|Orc,Troll,Undead|C|Rogue|IZ|Orgrimmar|
-R Southfury River|ACTIVE|2458^2478|M|11.45,67.06|Z|Orgrimmar|N|Leave Orgrimmar through the west gate.|R|Orc,Troll,Undead|C|Rogue|IZ|Orgrimmar|
+N Dagger|ACTIVE|2458^2478|N|Make sure you have an equipable dagger before you leave Orgrimmar. You'll need it for completing part of your class quest.\n[color=FF0000]NOTE: [/color]Check this step off to continue.|R|Orc,Troll,Undead|C|Rogue|IZ|1454|
+N Flash Powder|ACTIVE|2458^2478|M|42.2,49.6|Z|Orgrimmar|L|5140|N|Make sure you pick some up from Rekkul before you leave.|R|Orc,Troll,Undead|C|Rogue|IZ|1454|
+R Southfury River|ACTIVE|2458^2478|M|11.45,67.06|Z|Orgrimmar|N|Leave Orgrimmar through the west gate.|R|Orc,Troll,Undead|C|Rogue|IZ|1454|
 R Venture Co. Tower|ACTIVE|2458^2478|M|62.29,7.77;56.59,6.42|CC|N|Make your way around the edge of the mountain to the tower.|R|Orc,Troll,Undead|C|Rogue|
 N Taskmaster Fizzule|ACTIVE|2458|AVAILABLE|2478|M|56.00,6.10|N|Target Taskmaster Fizzule and use the Flare gun to make him non-aggressive, or you won't be able to interact with him.\n[color=FF0000]NOTE: [/color]Check this step off when this is done.|T|Taskmaster Fizzule|U|8051|R|Orc,Troll,Undead|C|Rogue|
 T Deep Cover|QID|2458|M|55.44,5.59|N|To Taskmaster Fizzule. He paths around a bit.\n[color=FF0000]NOTE: [/color]You must target him and use '/salute' before he'll interact with you.|T|Taskmaster Fizzule|R|Orc,Troll,Undead|C|Rogue|
@@ -597,15 +597,15 @@ A Hinott's Assistance|QID|2480|M|61.63,19.19|Z|Hillsbrad Foothills|N|From Serge 
 T Hinott's Assistance|QID|2480|M|61.63,19.19|Z|Hillsbrad Foothills|N|Once Serge Hinott completes the cure, turn the quest in.|R|Orc,Troll,Undead|C|Rogue|
 U Hinott's Oil|AVAILABLE|-2480|ACTIVE|-2480|N|Use the Hinott's Oil to cure your Touch of Zanzil.|U|8095|R|Orc,Troll,Undead|C|Rogue|BUFF|-9991|
 * Hinott's Oil|AVAILABLE|-2480|ACTIVE|-2480|N|For whatever reason, you still have your Hinott's Oil. You can safely destroy this as it's no longer required.|U|8095|R|Orc,Troll,Undead|C|Rogue|BUFF|9991|
-H Camp Taurajo|AVAILABLE|-2480|ACTIVE|-2480|R|Orc,Troll,Undead|C|Rogue|IZ|Hillsbrad Foothills|
+H Camp Taurajo|AVAILABLE|-2480|ACTIVE|-2480|R|Orc,Troll,Undead|C|Rogue|IZ|1424|
 ; ---
 
 ; --- Ashenvale
-F Splintertree Post|ACTIVE|6382^235^742|M|45.13,63.90|Z|Orgrimmar|IZ|Orgrimmar|
-F Splintertree Post|ACTIVE|6382^235^742|M|44.44,59.15|IZ|Camp Taurajo|
+F Splintertree Post|ACTIVE|6382^235^742|M|45.13,63.90|Z|Orgrimmar|IZ|1454|
+F Splintertree Post|ACTIVE|6382^235^742|M|44.44,59.15|IZ|378|
 T The Ashenvale Hunt|QID|6382^235^742|M|73.77,61.46|Z|Ashenvale|N|To Senani Thunderheart.|
 A The Ashenvale Hunt|QID|6383|M|73.77,61.46|Z|Ashenvale|N|From Senani Thunderheart.|
-N The Ashenvale Hunt|AVAILABLE|-6383|N|This quest unlocks 3 drop loot item quests.\nAs the lowest level of the 3 quests does not grey until level 32 AND the mobs are WAY above our current level, we will not being doing it at this time.\n[color=FF0000]NOTE: [/color]This quest doesn't show in your log. It just unlocks the 3 quests (which don't show either).\nCheck this step off to continue.|IZ|Ashenvale|
+N The Ashenvale Hunt|AVAILABLE|-6383|N|This quest unlocks 3 drop loot item quests.\nAs the lowest level of the 3 quests does not grey until level 32 AND the mobs are WAY above our current level, we will not being doing it at this time.\n[color=FF0000]NOTE: [/color]This quest doesn't show in your log. It just unlocks the 3 quests (which don't show either).\nCheck this step off to continue.|IZ|1440|
 ; -- The quests are listed below for future reference
 ;C Shadumbra's Head|QID|24|Z|Ashenvale|N|Kill the cat, Shadumbra, for its head.|PRE|6383|
 ;C Sharptalon's Claw|QID|2|Z|Ashenvale|N|Kill the blue bird, Sharptalon, for its claw.|PRE|6383|

--- a/WoWPro_Leveling/Classic_BC/Horde/VAN_BCC_21_30_HordeChapter1.lua
+++ b/WoWPro_Leveling/Classic_BC/Horde/VAN_BCC_21_30_HordeChapter1.lua
@@ -57,17 +57,17 @@ F Splintertree Post|AVAILABLE|6571|M|47.02,49.83|Z|Thunder Bluff|
 A Warsong Supplies|QID|6571|M|71.40,67.64|Z|Ashenvale|N|From Locke Okarr; by the south watchtower.|
 
 ; --- Silverpine Forest
-F Orgrimmar|AVAILABLE|437^443|M|73.18,61.59|Z|Ashenvale|N|Fly to Orgrimmar.|IZ|Ashenvale|
-h Orgrimmar|AVAILABLE|437^443|M|54.11,68.39|Z|Orgrimmar|N|At Innkeeper Gryshka.\n[color=FF0000]NOTE: [/color]This will be a better option the next time you need to use your hearth.|IZ|Orgrimmar|
+F Orgrimmar|AVAILABLE|437^443|M|73.18,61.59|Z|Ashenvale|N|Fly to Orgrimmar.|IZ|1440|
+h Orgrimmar|AVAILABLE|437^443|M|54.11,68.39|Z|Orgrimmar|N|At Innkeeper Gryshka.\n[color=FF0000]NOTE: [/color]This will be a better option the next time you need to use your hearth.|IZ|1454|
 b Tirisfal Glades|AVAILABLE|437^443|M|50.88,13.83|Z|Durotar|N|Exit Orgrimmar and take the Zeppelin to Tirisfal Glades.|
 ; --- If you don't have the FP in Undercity
 R Undercity|AVAILABLE|437^443|M|61.86,65.04|Z|Tirisfal Glades|N|Enter Undercity.|TAXI|-Undercity|
 f Undercity|AVAILABLE|437^443|M|63.26,48.54|Z|Undercity|N|Grab the flight path from Michael Garrett.|TAXI|-Undercity|
 ; If you have the FP in Sepulcher
 R Undercity|AVAILABLE|437^443|M|61.86,65.04|Z|Tirisfal Glades|N|Enter Undercity.|TAXI|Undercity|
-F The Sepulcher|AVAILABLE|437^443|M|63.26,48.54|Z|Undercity|TAXI|The Sepulcher|IZ|Undercity|
+F The Sepulcher|AVAILABLE|437^443|M|63.26,48.54|Z|Undercity|TAXI|The Sepulcher|IZ|1458|
 ; If you don't have the FP in Sepulcher
-R Leave Undercity|AVAILABLE|437^443|M|65.99,36.85;66.22,0.90|Z|Undercity|CC|N|Take the elevator up and leave Undercity through the front gates.|TAXI|-The Sepulcher|IZ|Undercity|
+R Leave Undercity|AVAILABLE|437^443|M|65.99,36.85;66.22,0.90|Z|Undercity|CC|N|Take the elevator up and leave Undercity through the front gates.|TAXI|-The Sepulcher|IZ|1458|
 ; --- If you don't have the FP in Sepulcher but do have the FP in Undercity (No point going in if you can't go anywhere)
 R Silverpine Forest|AVAILABLE|437^443|M|54.46,74.62|Z|Tirisfal Glades|N|Head over to the road and follow it south into Silverpine Forest.|TAXI|-The Sepulcher|
 R The Sepulcher|AVAILABLE|437^443|M|46.21,41.59|N|Head south until you reach the Sepulcher.|TAXI|-The Sepulcher|
@@ -86,7 +86,7 @@ T Rot Hide Clues|QID|439|M|43.43,40.86|N|To High Executor Hadrec.\nFollow the hi
 ; ---
 A Rot Hide Ichor|QID|443|M|43.43,40.86|Z|Silverpine Forest|N|From High Executor Hadrec inside the crypt.|PRE|439|
 R Fenris Isle|ACTIVE|443|M|52.34,37.21;58.75,35.43;64.79,34.60;65.63,32.89|Z|Silverpine Forest|CC|N|Sticking to the hills to avoid unnecessary fighting, make your way to the lake and swim across.|
-N A Talking Head|AVAILABLE|460|N|This item starts a side quest chain and is found by killing the Gnolls.\nIt has a 3% drop rate.\n[color=FF0000]NOTE: [/color]Check this step off to continue.|RANK|3|IZ|Fenris Isle|S!US|
+N A Talking Head|AVAILABLE|460|N|This item starts a side quest chain and is found by killing the Gnolls.\nIt has a 3% drop rate.\n[color=FF0000]NOTE: [/color]Check this step off to continue.|RANK|3|IZ|172|S!US|
 A Resting in Pieces|QID|460|N|Click on the 'Talking Head' to start the quest.\n[color=FF0000]NOTE: [/color]Do this as soon as you get it.|U|3317|O|
 C Rot Hide Ichor|QID|443|L|3236 8|N|Kill Rot Hide Gnolls for the Ichor.|S|
 T Resting in Pieces|QID|460|M|67.87,24.86|Z|Silverpine Forest|N|Click on the Shallow Grave to turn in the quest.|
@@ -115,13 +115,13 @@ T Report to Hadrec|QID|448|M|43.43,40.86|Z|Silverpine Forest|N|To High Executor 
 A Beren's Peril|QID|516|M|43.98,40.93|Z|Silverpine Forest|N|From Shadow Priest Allister.|
 A The Weaver|QID|480|M|43.98,40.93|Z|Silverpine Forest|N|From Shadow Priest Allister.|PRE|479|
 
-R Ambermill|ACTIVE|480|M|51.34,36.98;55.71,64.46|Z|Silverpine Forest|CC|N|Make your way to Ambermill.|IZ|Silverpine Forest|
+R Ambermill|ACTIVE|480|M|51.34,36.98;55.71,64.46|Z|Silverpine Forest|CC|N|Make your way to Ambermill.|IZ|1421|
 C The Weaver|QID|480|M|63.40,64.28|Z|Silverpine Forest|L|3515|N|Kill Ataeric and loot his staff.\n[color=FF0000]NOTE: [/color]You have to get past 2 Conjurers (plus their voidwalkers) and 2 Warders to get to Ataeric. You can aggro the mages one at a time. But, it's not easy. You may find a Dalaran Spellscribe (a non-elite rare spawn) in the room as well.\nMake sure you take out the Conjurer and Voidwalker that path in and out of the building. You'll be using the foyer to fight the mobs inside the room and you don't want them sneaking up on you.\n\nAtaeric won't stand still. He is a Frost mage who likes to keep his distance. If you don't clear the room, you'll end up fighting the entire room at the same time.|
-R Beren's Peril|ACTIVE|516|M|61.53,64.61;62.88,72.15;60.44,74.46;60.54,73.35|Z|Silverpine Forest|CC|N|Exit the building and follow the road south out of Ambermill. Stick to the mountains on the east side (right) and follow them around the bend.|IZ|Silverpine Forest|
-R Cave Entrance|ACTIVE|516|M|60.58,72.48|Z|Silverpine Forest|CC|N|Make your way to the cave entrance.|IZ|Silverpine Forest|
+R Beren's Peril|ACTIVE|516|M|61.53,64.61;62.88,72.15;60.44,74.46;60.54,73.35|Z|Silverpine Forest|CC|N|Exit the building and follow the road south out of Ambermill. Stick to the mountains on the east side (right) and follow them around the bend.|IZ|1421|
+R Cave Entrance|ACTIVE|516|M|60.58,72.48|Z|Silverpine Forest|CC|N|Make your way to the cave entrance.|IZ|1421|
 K Beren's Peril|ACTIVE|516|QO|1;2|N|Enter the cave and kill Ravenclaw Drudgers and Guardians.|
-R Cave Entrance|ACTIVE|516|M|60.58,72.48|Z|Silverpine Forest|CC|N|Make your way back to the cave entrance.|IZ|Silverpine Forest|
-R The Greymane Wall|QID|530|M|59.70,77.90;53.67,72.47;51.10,72.45;46.89,83.45|Z|Silverpine Forest|CC|N|Exit the cave and head back to the road. Follow the road west to the first intersection and continue west to the next intersection. From here, go south to The Greymane Wall.|IZ|Silverpine Forest|
+R Cave Entrance|ACTIVE|516|M|60.58,72.48|Z|Silverpine Forest|CC|N|Make your way back to the cave entrance.|IZ|1421|
+R The Greymane Wall|QID|530|M|59.70,77.90;53.67,72.47;51.10,72.45;46.89,83.45|Z|Silverpine Forest|CC|N|Exit the cave and head back to the road. Follow the road west to the first intersection and continue west to the next intersection. From here, go south to The Greymane Wall.|IZ|1421|
 C A Husband's Revenge|QID|530|M|46.06,85.64|Z|Silverpine Forest|L|3613|N|Kill Valdred Moray and loot his hands. He paths back and forth in front of the gate.|
 R Hillsbrad Foothills|ACTIVE|1065|M|51.10,72.45;53.67,72.47;67.00,80.28|Z|Silverpine Forest|CC|N|Head back to the main road. Continue east on the main road to the Silverpine Forest/Hillsbrad Foothills border.|
 

--- a/WoWPro_Leveling/Classic_BC/Horde/VAN_BCC_30_40_HordeChapter2.lua
+++ b/WoWPro_Leveling/Classic_BC/Horde/VAN_BCC_30_40_HordeChapter2.lua
@@ -335,7 +335,7 @@ A Prison Break In|QID|544|M|61.59,20.83|Z|Hillsbrad Foothills|N|From Magus Worde
 A Stone Tokens|QID|556|M|61.50,20.94|Z|Hillsbrad Foothills|N|From Keeper Bel'varil.|
 A Soothing Turtle Bisque|QID|7321|M|62.31,19.09|Z|Hillsbrad Foothills|N|From Christoph Jeffcoat.|
 B Soothing Spices|ACTIVE|7321|M|62.29,19.04|Z|Hillsbrad Foothills|L|3713|N|From Christoph Jeffcoat.|
-t Soothing Turtle Bisque|QID|7321|M|62.31,19.09|Z|Hillsbrad Foothills|N|To Christoph Jeffcoat.|IZ|Tarren Mill|
+t Soothing Turtle Bisque|QID|7321|M|62.31,19.09|Z|Hillsbrad Foothills|N|To Christoph Jeffcoat.|IZ|272|
 A Helcular's Revenge|QID|552|M|63.88,19.67|Z|Hillsbrad Foothills|N|From Novice Thaivand.|
 A Infiltration|QID|533|M|63.23,20.66|Z|Hillsbrad Foothills|N|From Krusk.|
 R Darrow Hill|ACTIVE|552|M|49.10,32.22|Z|Hillsbrad Foothills|N|Run to the Cave in Darrow Hill.|
@@ -419,7 +419,7 @@ A Raptor Mastery|QID|194|M|35.66,10.81|Z|Stranglethorn Vale|N|From Hemet Nesingw
 A Tiger Mastery|QID|185|M|35.61,10.63|Z|Stranglethorn Vale|N|From Ajeck Rouack.|PRE|583|
 A Panther Mastery|QID|190|M|35.56,10.54|Z|Stranglethorn Vale|N|From Sir S. J. Erlgadin.|PRE|583|
 A The Green Hills of Stranglethorn|QID|338|N|From Barnil Stonepot.|PRE|583|
-N Chapter Quests|ACTIVE|338|AVAILABLE|339^340^341^342|N|From this point forward, every time you return to the Camp, check in with Barnil Stonepot to see if you have enough pages to finish a Chapter quest. You'll want to get rid of the pages as soon as you can to save bag space.\n[color=FF0000]NOTE: [/color]To save log space, do not accept the Chapter quests until you can complete them.|S!US|IZ|Nesingwary's Expedition|
+N Chapter Quests|ACTIVE|338|AVAILABLE|339^340^341^342|N|From this point forward, every time you return to the Camp, check in with Barnil Stonepot to see if you have enough pages to finish a Chapter quest. You'll want to get rid of the pages as soon as you can to save bag space.\n[color=FF0000]NOTE: [/color]To save log space, do not accept the Chapter quests until you can complete them.|S!US|IZ|100|
 K Tiger Mastery|QID|185|M|32.61,9.55;33.68,11.64;36.40,13.05|Z|Stranglethorn Vale|CC|QO|1|N|Heading in a westerly direction from the camp, kill Young Stranglethorn Tigers. In a looping arc, make your way east to the bridge.|
 K Panther Mastery|QID|190|M|37.69,14.85;39.75,13.70;41.23,12.99;41.27,8.56|Z|Stranglethorn Vale|CC|QO|1|N|As you make your way east under the bridge, kill Young Stranglethorn Panthers. Cross the river to the north side and work your way west in a sweeping arc towards the road.|
 T Panther Mastery|QID|190|M|35.56,10.54|Z|Stranglethorn Vale|N|To Sir S. J. Erlgadin.|
@@ -500,16 +500,16 @@ l Some Assembly Required|ACTIVE|577|L|4104 5|N|Kill Snapjaw Crocolisks to loot t
 R Grom'gol Base Camp|QID|569|M|34.23,28.38|Z|Stranglethorn Vale|N|Return to Grom'gol.|
 T The Defense of Grom'gol|QID|569|M|32.20,28.86|Z|Stranglethorn Vale|N|To Commander Aggro'gosh.|
 ;L Level 37|LVL|37|N|You should be around level 37 by this point.|
-C Singing Blue Shards|ACTIVE|605|Z|Stranglethorn Vale|L|3918 10|N|Kill Crystal Spine Basilisks to loot the Singing Crystal Shards.|S|IZ|Stranglethorn Vale|
+C Singing Blue Shards|ACTIVE|605|Z|Stranglethorn Vale|L|3918 10|N|Kill Crystal Spine Basilisks to loot the Singing Crystal Shards.|S|IZ|1434|
 R Zuuldaia Ruins|QID|582|M|26.97,19.00;23.14,16.56|Z|Stranglethorn Vale|CC|N|Using the north exit, leave Grom'gol and follow the Savage Coast north to the Zuuldaia Ruins.|
 N Bloodscalp Headhunters|ACTIVE|582|M|PLAYER|N|There are not very many of them around the ruins. If you make your way to the arch in the NE corner and walk up the ramp, you'll find several in this area.|
 C Headhunting|ACTIVE|582|L|1532 20|N|Kill Bloodscalp Headhunters to loot the Shrunken Heads. (50% drop rate)|
 C Bloody Bone Necklaces|ACTIVE|596|L|3915 25|N|Kill any Bloodscalp to loot them.|US|
 R The Vile Reef|QID|629|M|23.10,16.49;26.99,18.82;26.54,21.21|Z|Stranglethorn Vale|CC|N|Return to Grom'gol.|
-N Giant Clams|ACTIVE|1107|N|While you're in the area, keep an eye out for Giant Clams. They may contain a 'Blue Pearl'. It's a quest item that can be sold in the AH, if you don't use them for the 'Pearl Diving' quest.|S!US|IZ|The Vile Reef|
-C Encrusted Tail Fins|QID|1107|M|25.15,24.10|N|Kill Saltscale Murlocs to loot Encrusted Tail Fins.\n[color=FF0000]NOTE: [/color]These mobs are Elite and may be too tough for you at this point in time. Skip this step if they are.|S|IZ|The Vile Reef|
+N Giant Clams|ACTIVE|1107|N|While you're in the area, keep an eye out for Giant Clams. They may contain a 'Blue Pearl'. It's a quest item that can be sold in the AH, if you don't use them for the 'Pearl Diving' quest.|S!US|IZ|104|
+C Encrusted Tail Fins|QID|1107|M|25.15,24.10|N|Kill Saltscale Murlocs to loot Encrusted Tail Fins.\n[color=FF0000]NOTE: [/color]These mobs are Elite and may be too tough for you at this point in time. Skip this step if they are.|S|IZ|104|
 C The Vile Reef|QID|629|M|24.8,22.8|Z|Stranglethorn Vale|QO|1|N|Loot the Tablet Shard. It's leaning against the outside wall.\n[color=FF0000]NOTE: [/color]You can get this without aggroing the 2 Elite mobs on the other side. Swim along the surface to the location and dive straight down.\nIf you do it quick, you'll resurface with 1/3 of your breath left.|NC|
-;l Encrusted Tail Fins|QID|1107|M|25.15,24.10|L|5796 10|N|Kill Saltscale Murlocs to loot Encrusted Tail Fins.\n[color=FF0000]NOTE: [/color]These mobs are Elite and may be too tough for you at this point in time. Skip this step if they are.|US|IZ|The Vile Reef|
+;l Encrusted Tail Fins|QID|1107|M|25.15,24.10|L|5796 10|N|Kill Saltscale Murlocs to loot Encrusted Tail Fins.\n[color=FF0000]NOTE: [/color]These mobs are Elite and may be too tough for you at this point in time. Skip this step if they are.|US|IZ|104|
 R Nesingwary's Expedition|ACTIVE|195|M|37.49,11.69|Z|Stranglethorn Vale|N|Head back to Nesingwary's Expedition.|
 T Raptor Mastery|QID|195|M|35.66,10.81|Z|Stranglethorn Vale|N|To Hemet Nesingwary.|
 A Raptor Mastery|QID|196|M|35.66,10.81|Z|Stranglethorn Vale|N|From Hemet Nesingwary.|PRE|195|
@@ -655,7 +655,7 @@ R Darkmist Cavern|ACTIVE|1206|M|36.97,23.99|Z|Dustwallow Marsh|N|Make your way t
 C Jarl Needs Eyes|QID|1206|M|34.99,21.49|Z|Dustwallow Marsh|L|5884 40|N|Kill Darkmist Spiders to collect the Unpopped Darkmist Eyes.|
 R Swamplight Manor|ACTIVE|1206|M|55.20,26.88|Z|Dustwallow Marsh|N|Make your way back to Swamplight Manor.|
 T Jarl Needs Eyes|QID|1206|M|55.44,26.26|Z|Dustwallow Marsh|N|To "Swamp Eye" Jarl.|
-N Jarl Needs a Blade|AVAILABLE|1203|M|PLAYER|N|Do not bother getting this quest. It's not worth the effort.|PRE|1206|IZ|Swamplight Manor|
+N Jarl Needs a Blade|AVAILABLE|1203|M|PLAYER|N|Do not bother getting this quest. It's not worth the effort.|PRE|1206|IZ|497|
 * Unpopped Darkmist Eyes|QID|1203|M|PLAYER|N|Delete any excess quest items.|U|5884|
 R North Point Tower|AVAILABLE|1270|M|46.88,22.86|Z|Dustwallow Marsh|N|Head back to the main road and make your way to the intersection at North Tower.|
 A Stinky's Escape|QID|1270|M|46.88,17.51|Z|Dustwallow Marsh|N|From "Stinky" Ignatz.\n[color=FF0000]NOTE: [/color]The more mobs you clear on your way in, the less you will have to kill later.|
@@ -687,8 +687,8 @@ F Ratchet|ACTIVE|1270|M|45.09,63.88|Z|Orgrimmar|N|Head to the flightmaster and t
 T Stinky's Escape|QID|1270|M|62.37,37.62|Z|The Barrens|N|To Mebok Mizzyrix.|
 
 ; Stranglethorn Vale
-N Bank|ACTIVE|572^605^196|M|62.67,37.44|Z|The Barrens|N|As you are now headed back to STV, make sure you grab all of your quest items from your bank before leaving.|IZ|Ratchet|
-b Booty Bay|ACTIVE|572^605^196|M|63.70,38.63|Z|The Barrens|N|Take the boat to Booty Bay.|IZ|-Stranglethorn Vale|
+N Bank|ACTIVE|572^605^196|M|62.67,37.44|Z|The Barrens|N|As you are now headed back to STV, make sure you grab all of your quest items from your bank before leaving.|IZ|392|
+b Booty Bay|ACTIVE|572^605^196|M|63.70,38.63|Z|The Barrens|N|Take the boat to Booty Bay.|IZ|-1434|
 F Grom'gol Base Camp|ACTIVE|572^605^196|M|26.87,77.10|Z|Stranglethorn Vale|N|Head to the flightmaster and take a flight to Grom'gol Base Camp.|
 R Southern Savage Coast|ACTIVE|605^572^196|M|32.62,35.53|Z|Stranglethorn Vale|N|Exit Grom'gol Base to the south side and swim across to the opposite shore.|
 C Mok'thardin's Enchantment|QID|572|M|33.63,37.87|Z|Stranglethorn Vale|L|3863 10|N|Kill Jungle Stalkers to collect the feathers.|S|
@@ -708,7 +708,7 @@ K Gan'zulah|ACTIVE|584|M|23.26,8.72|Z|Stranglethorn Vale|QO|1|N|Using the same p
 R Nesingwary's Expedition|ACTIVE|584|M|34.91,11.00|Z|Stranglethorn Vale|N|Work your way out of the Ruins the same way you came in. You can avoid some of the fight by dropping down to the lower ledge of the wall and walking around to where the bottom of the ramp is.\n Once you are out of the Ruins, make your way to the Nesingwary's Expedition.|
 T Raptor Mastery|QID|196|M|35.66,10.81|Z|Stranglethorn Vale|N|To Hemet Nesingwary.|
 A Raptor Mastery|QID|197|PRE|196|M|35.66,10.81|Z|Stranglethorn Vale|N|From Hemet Nesingwary.|
-;N Chapter Quests|ACTIVE|338|AVAILABLE|191|N|From this point forward, every time you return to the Camp, check in with Barnil Stonepot to see if you have enough pages to finish a Chapter quest. You'll want to get rid of the pages as soon as you can to save bag space.\n[color=FF0000]NOTE: [/color]To save log space, do not accept the Chapter quests until you can complete them.|S!US|IZ|Nesingwary's Expedition|
+;N Chapter Quests|ACTIVE|338|AVAILABLE|191|N|From this point forward, every time you return to the Camp, check in with Barnil Stonepot to see if you have enough pages to finish a Chapter quest. You'll want to get rid of the pages as soon as you can to save bag space.\n[color=FF0000]NOTE: [/color]To save log space, do not accept the Chapter quests until you can complete them.|S!US|IZ|100|
 R Venture Co. Base Camp|ACTIVE|584|M|44.82,25.69|Z|Stranglethorn Vale|N|Head to the main road and follow it south across the bridge over the river.|
 K Bhag'thera|ACTIVE|193|M|47.35,28.40;49.65,23.63;48.58,19.59|Z|Stranglethorn Vale|CN|N|You'll find Bhag'thera in 1 of 3 locations. When you find him, kill him to loot his fang.\n[color=FF0000]NOTE: [/color]As you are moving between the spots, be sure to give the elite Ogres around the entrance to Mosh'Ogg a VERY wide berth.|
 

--- a/WoWPro_Leveling/Horde/CATA_Ashenvale.lua
+++ b/WoWPro_Leveling/Horde/CATA_Ashenvale.lua
@@ -35,7 +35,7 @@ C Management Material|QID|13640|M|71.51,82.40|N|Talk to a Demoralized Peon and f
 T Management Material|QID|13640|M|72.93,80.44|N|To Gorka.|
 A Needs a Little Lubrication|QID|13651|M|72.93,80.44|N|From Gorka.|PRE|13640|RANK|1|
 C Needs a Little Lubrication|QID|13651|M|74.25,73.56|N|Kill Rotting Slime until you have 5 Natural Oil.|
-K Sharptalon|AVAILABLE|2|M|72.33,76.83|L|16305|N|Keep an eye out for Sharptalon. Kill and loot the claw. Use the claw to start the quest.|T|Sharptalon|S|IZ|The Dor'Danil Barrow Den|RANK|3|
+K Sharptalon|AVAILABLE|2|M|72.33,76.83|L|16305|N|Keep an eye out for Sharptalon. Kill and loot the claw. Use the claw to start the quest.|T|Sharptalon|S|IZ|432|RANK|3|
 A Sharptalon's Claw|QID|2|M|PLAYER|N|From Sharptalon's Claw.|U|16305|O|
 T Needs a Little Lubrication|QID|13651|M|72.93,80.44|N|To Gorka.|
 A Crisis at Splintertree|QID|13653|M|72.93,80.44|N|From Gorka.|PRE|13651|RANK|1|
@@ -43,7 +43,7 @@ C Crisis at Splintertree|QID|13653|M|72.93,80.44|N|Speak to Gorka when you are r
 T Crisis at Splintertree|QID|13653|M|42.69,14.97|Z|Northern Barrens|N|To Kadrak.|
 A To the Rescue!|QID|13712|M|42.69,14.97|Z|Northern Barrens|N|From Kadrak.|PRE|13653|RANK|1|
 r Repair|ACTIVE|13712|M|42.38,14.97|Z|Northern Barrens|N|Speak with Ornag to repair/restock/unload, if necessary. Then check off this step.|
-F Splintertree Post|ACTIVE|13712|M|42.69,14.97|Z|Northern Barrens|N|Speak to Kadrak for a free ride to Splintertree Post.|IZ|The Mor'shan Ramparts|CHAT|
+F Splintertree Post|ACTIVE|13712|M|42.69,14.97|Z|Northern Barrens|N|Speak to Kadrak for a free ride to Splintertree Post.|IZ|1703|CHAT|
 f Splintertree Post|ACTIVE|13712|M|73.18,61.60|N|Get the flight point from Vhulgra.|TAXI|-Splintertree Post|
 T To the Rescue!|QID|13712|M|73.61,62.14|N|To Kadrak in Splintertree Post.|
 A Blood of the Weak|QID|13803|M|73.61,62.14|N|From Kadrak.|PRE|13712|RANK|1|
@@ -52,7 +52,7 @@ A Ashenvale Outrunners|QID|6503|M|73.56,60.86|N|From Kuray'bin.|RANK|1|
 A Destroy the Legion|QID|26448|M|73.17,60.11|N|From Valusha.|RANK|1|
 T Blood of the Weak|QID|13803|M|73.30,59.63;72.91,58.03;73.23,57.45;72.20,57.65|CC|N|To Durak inside the Splintertree Mine.|
 A Pierce Their Heart!|QID|13805|M|72.20,57.65|N|From Durak.|PRE|13803|RANK|1|
-R Exit the mine|ACTIVE|13805|M|73.31,59.81|N|Head back outside the mine.|IZ|Splintertree Mine|
+R Exit the mine|ACTIVE|13805|M|73.31,59.81|N|Head back outside the mine.|IZ|4693|
 A Playing With Felfire|QID|13730|M|73.33,62.13|N|From Splintertree Demolisher.|PRE|13803|RANK|1|
 A Dead Elves Walking|QID|13801|M|73.86,62.47|N|From Pixel.|PRE|13803|RANK|1|
 K Ashenvale Outrunners|ACTIVE|6503|M|75.52,70.28|QO|1|N|Kill Ashenvale Outrunners while questing.|S|
@@ -85,10 +85,10 @@ A Dirty Deeds|QID|13797|M|72.20,57.65|N|From Durak.|PRE|13751|RANK|1|
 l Dirty Deeds|ACTIVE|13797|M|73.21,55.91|QO|1|N|Throughout the mine, search the piles of Fresh Rubble to find the Chunks of Ore.|
 T Dirty Deeds|QID|13797|M|72.20,57.65|N|To Durak.|
 A Rain of Destruction|QID|13798|M|72.20,57.65|N|From Durak.\n[color=FF0000]NOTE: [/color]You will receive an Imp disguise buff when you accept this quest.|PRE|13797|RANK|1|
-R Exit the mine|ACTIVE|13798|M|73.31,59.81|QO|1|N|Head back outside the mine.|IZ|Splintertree Mine|
+R Exit the mine|ACTIVE|13798|M|73.31,59.81|QO|1|N|Head back outside the mine.|IZ|4693|
 C Rain of Destruction|QID|13798|M|74.19,62.95|QO|1;2|N|Climb one of the two guard towers and use the Accursed Ore to target Elves and Ancients until complete.|U|45598|
 T Rain of Destruction|QID|13798|M|72.20,57.65|N|To Durak.|
-R Exit the mine|AVAILABLE|13841|M|73.31,59.81|N|Head back outside the mine.|IZ|Splintertree Mine|
+R Exit the mine|AVAILABLE|13841|M|73.31,59.81|N|Head back outside the mine.|IZ|4693|
 A All Apologies|QID|13841|M|73.33,62.13|N|From Splintertree Demolisher.|PRE|13798|RANK|1|
 R Demon Fall Canyon|ACTIVE|26449|M|84.21,72.25|N|Follow the road east out of Splintertree through Felfire Hill. Go south at the fork before the 2nd bridge.|
 K Gorgannon|ACTIVE|26449|M|87.41,78.98;89.57,76.78|CS|QO|1|N|Follow the waypoints to Gorgannon to kill him and loot the Sword.|
@@ -125,7 +125,7 @@ T Sheelah's Last Wish|QID|13873|M|89.59,48.67|N|To Guardian Gurtar at the Warson
 A Gurtar's Request|QID|13875|M|89.59,48.67|N|From Guardian Gurtar.|RANK|3|
 l Thorned Bloodcup|ACTIVE|13875|M|86.52,54.98|L|46315 8|N|These are tricky to see, but, you'll find the red flowers can be found on the ground all over the area of the camp.\n[color=FF0000]NOTE: [/color]'Find Herbs' does not work on them.|
 C Gurtar's Request|QID|13875|M|PLAYER|N|Use the Orc-Hair Braid to make the Bloodcup Braid.|U|46316|
-H Splintertree Post|ACTIVE|13875^13806^6441|M|73.51,63.51|N|If Hearthstone isn't ready, just run back to Splintertree Post.|IZ|-Splintertree Post|
+H Splintertree Post|ACTIVE|13875^13806^6441|M|73.51,63.51|N|If Hearthstone isn't ready, just run back to Splintertree Post.|IZ|-431|
 T Gurtar's Request|QID|13875|M|73.33,62.13|N|To Splintertree Demolisher.|
 T Demon Duty|QID|13806|M|73.77,61.62|N|To Locke Okarr.|
 T Satyr Horns|QID|6441|M|73.86,62.47|N|To Pixel.|
@@ -138,9 +138,9 @@ C Dread Head Redemption|QID|13842|M|72.20,57.65|N|Head back into the mine and an
 F Orgrimmar|ACTIVE|13842|M|73.18,61.60|N|Fly back to Orgrimmar.|
 R Grommash Hold|ACTIVE|13842|M|51.19,63.02;50.01,75.86|CC|Z|Orgrimmar|N|Take the elevator down and head to the entrance on the south side of the central building.|FLY|OLD|
 T Dread Head Redemption|QID|13842|M|49.22,72.27|Z|Orgrimmar|N|To Eitrigg.| ; Completes Splintertree's Demonic Defense
-F Splintertree Post|ACTIVE|13848|M|49.6,59.17|Z|Orgrimmar|N|Fly back to Splintertree Post.|IZ|Orgrimmar|
+F Splintertree Post|ACTIVE|13848|M|49.6,59.17|Z|Orgrimmar|N|Fly back to Splintertree Post.|IZ|85|
 F Zoram'gar Outpost|ACTIVE|13848|M|73.18,61.60|N|Talk to Vhulgra for a free flight to Zoram'gar Outpost.|CHAT|
-f Zoram'gar Outpost|ACTIVE|13848|M|11.16,34.42|N|Get the flight point from Andruk.|TAXI|-Zoram'gar Outpost|IZ|Zoram'gar Outpost|
+f Zoram'gar Outpost|ACTIVE|13848|M|11.16,34.42|N|Get the flight point from Andruk.|TAXI|-Zoram'gar Outpost|IZ|2897|
 h Zoram'gar Outpost|AVAILABLE|13848|M|12.99,34.15|N|Set your hearth with Innkeeper Duras.|
 T Bad News Bear-er|QID|13848|M|12.10,33.85|N|Turn in to Commander Grimfang.|
 A Keep the Fires Burning|QID|13890|M|12.10,33.85|N|From Commander Grimfang.|RANK|1|
@@ -210,7 +210,7 @@ T Troll Charm|QID|6462|M|38.89,42.38|N|To Mitsuwa.|
 T Between a Rock and a Thistlefur|QID|216|M|37.76,43.49|N|To Karang Amakkar.|
 R Silverwind Refuge|ACTIVE|13974|M|38.09,42.23|N|Run to Silverwind Refuge.|TAXI|-Silverwind Refuge|FLY|OLD|
 A We're Here to Do One Thing, Maybe Two...|QID|25945|M|49.88,65.78|N|From Blood Guard Aldo Rockrain.\n[color=FF0000]NOTE: [/color]Skip this if you don't plan on going to Stonetalon Mountains.\nDon't get on the caravan until you're ready to leave Ashenvale.|RANK|3|
-t Sharptalon's Claw|QID|2|M|49.75,65.08|N|To Senani Thunderheart.|IZ|Silverwind Refuge|
+t Sharptalon's Claw|QID|2|M|49.75,65.08|N|To Senani Thunderheart.|IZ|420|
 f Silverwind Refuge|ACTIVE|13974|M|49.29,65.25|N|Get flightpath from Wind Tamer Shosok.|TAXI|-Silverwind Refuge|
 F Splintertree Post|ACTIVE|6482|M|49.29,65.25|N|Fly to Splintertree Post.|
 T Freedom to Ruul|QID|6482|M|74.11,60.91|N|To Yama Snowhoof.|

--- a/WoWPro_Leveling/Horde/CATA_Azshara.lua
+++ b/WoWPro_Leveling/Horde/CATA_Azshara.lua
@@ -51,9 +51,9 @@ K Basilisk Bashin'|ACTIVE|14161|M|25.50,68.50|QO|1|N|Kill Greystone Basilisks.|S
 C Stone Cold|QID|14165|M|25.66,68.79|N|Seek out a Stonified Miner.\n[color=FF0000]NOTE: [/color]You may have to click on it twice to pick it up.|BUFF|67032^91695^69619|
 R Orgrimmar Rocketway Exchange|QID|14165|M|27.77,67.70|N|With the Goblin on your back, head back to Horzak Zignibble.\n[color=FF0000]NOTE: [/color]You will lose the goblin if you mount.\nDon't worry about losing it during a fight; unless you die.|
 T Stone Cold|QID|14165|M|29.15,66.24|N|To Horzak Zignibble.|
-t Basilisk Bashin'|QID|14161|M|29.15,66.24|N|To Horzak Zignibble.|IZ|Orgrimmar Rocketway Exchange|
+t Basilisk Bashin'|QID|14161|M|29.15,66.24|N|To Horzak Zignibble.|IZ|4830|
 A The Perfect Prism|QID|14190|M|29.15,66.24|N|From Horzak Zignibble.|PRE|14165| ; Storyline
-t A Quota to Meet|QID|14197|M|29.15,66.27|N|To Foreman Fisk, who wanders.|IZ|Orgrimmar Rocketway Exchange|
+t A Quota to Meet|QID|14197|M|29.15,66.27|N|To Foreman Fisk, who wanders.|IZ|4830|
 C The Perfect Prism|QID|14190|M|21.61,69.50|N|Kill Talrendis Saboteurs until you loot a Crystal Pendant.|
 l A Quota to Meet|QID|14197|M|23.20,67.44|QO|1|N|Gather 20 ingots of Mountainfoot Iron.|US|
 T The Perfect Prism|QID|14190|M|20.26,70.40|N|To the Headquarters Radio (inside the building).|
@@ -170,7 +170,7 @@ C Azsharite Experiment Number Two|QID|14388|M|50.38,74.29;47.71,75.51|CS|N|Talk 
 C Azsharite Experiment Number Two|QID|14388|M|50.38,74.29;47.71,75.51|CS|N|Talk to Assistant Greely when you're ready to shrink. Hop on a rat and run to Gormungan. Chat with him to complete the quest.|V|
 T Azsharite Experiment Number Two|QID|14388|M|50.41,74.29|N|To Assistant Greely.| ; Completes Storyline 'The Rarest Substance on Azeroth'
 A A Hello to Arms|QID|24458|M|50.53,74.77|N|From Hobart Grapplehammer.\nHe paces around a bit.|PRE|14383&14388|
-F Bilgewater Harbor|QID|24458|M|51.48,74.28|N|Speak with Friz Groundspin for a free airlift.|IZ|Southern Rocketway|
+F Bilgewater Harbor|QID|24458|M|51.48,74.28|N|Speak with Friz Groundspin for a free airlift.|IZ|4828|
 f Bilgewater Harbor|QID|24458|M|52.92,49.85|N|Head down to the docks to get the flight point.|TAXI|-Bilgewater Harbor|
 A Operation Fishgut|QID|14478|M|52.31,50.30|N|From the Wrenchmen Recruitment Poster on the column.|PRE|24452| ; Storyline - Heart of Arkkoroc
 h Bilgewater Harbor|QID|24458|M|57.02,50.29|N|At Grimy Greasefingers.|
@@ -214,7 +214,7 @@ T Ticker Required|QID|14485|M|34.46,44.73|N|To Sergeant Zelks.|
 T Extermination|QID|14480|M|34.46,44.73|N|From Sergeant Zelks.|
 T Handling the Goods|QID|14486|M|34.52,44.68|N|To Tora Halotrix.|
 A Shore Leave|QID|24449|M|34.31,44.90|N|From Captain Tork.|PRE|14480&14484&14485&14486&14487| ; Storyline - Heart of Arkkoroc
-F Bilgewater Harbor|ACTIVE|24449|M|34.51,44.52|N|Hop into the Military Gyrocopter when ready to leave.|IZ|Ruins of Eldarath|V|
+F Bilgewater Harbor|ACTIVE|24449|M|34.51,44.52|N|Hop into the Military Gyrocopter when ready to leave.|IZ|1221|V|
 T Shore Leave|QID|24449|M|60.61,50.53|N|To Uncle Bedlam.| ; Completes Storyline - Heart of Arkkoroc
 A Azshara Blues|QID|14407|M|59.33,50.74|N|From Teemo.| ; Storyline
 T Azshara Blues|QID|14407|M|55.49,52.14|N|To Kalec. He's in the tunnel under the road.|
@@ -253,7 +253,7 @@ l A Pale Brew|QID|14432|M|30.72,36.80|QO|1|N|Gather up 10 samples of Briaroot Br
 T A Pale Brew|QID|14432|M|42.43,23.61|N|To Haggrum Bloodfist.|
 T Diplomacy by Another Means|QID|14433|M|42.43,23.61|N|To Haggrum Bloodfist.|
 A The Blackmaw Doublecross|QID|14435|M|42.43,23.61|N|From Haggrum Bloodfist.|PRE|14432&14433|
-P Blackmaw Hold|ACTIVE|14435|M|42.61,23.70|N|When you're ready, stand beside Haggrum's Smokepit and use the Ambassador Disguise. Immediately after using the Disguise, talk to Andorel to have him teleport you.\n[color=FF0000]NOTE: [/color]The Disguise only lasts 5 minutes and you have to be near the Smokepit to re-apply it.|U|49368|CHAT|IZ|Northern Rocketway Exchange|
+P Blackmaw Hold|ACTIVE|14435|M|42.61,23.70|N|When you're ready, stand beside Haggrum's Smokepit and use the Ambassador Disguise. Immediately after using the Disguise, talk to Andorel to have him teleport you.\n[color=FF0000]NOTE: [/color]The Disguise only lasts 5 minutes and you have to be near the Smokepit to re-apply it.|U|49368|CHAT|IZ|4825|
 C The Blackmaw Doublecross|QID|14435|M|30.97,29.99|QO|1|N|Speak with Ungarl to wreck the negotiations. Be prepared for a 3 NPC fight when you finish the conversation.\n[color=FF0000]NOTE: [/color]If your Disguise fades before you complete this step, you have basically failed and will have to go back and start again at the Smokepit.\nSpeak with him as quickly as you can.|CHAT|
 K The Blackmaw Doublecross|QID|14435|M|32.41,31.64|QO|2;3|N|Kill 4 Blackmaw Warriors and 4 Blackmaw Shaman on your way out.\n[color=FF0000]NOTE: [/color]To exit, go up the stairs to the right of where Ungarl was standing, cross over the bridge and go to the left of the fork.|
 T The Blackmaw Doublecross|QID|14435|M|42.43,23.61|N|To Haggrum Bloodfist.|
@@ -293,24 +293,24 @@ T Watch Your Step|QID|14296|M|55.95,12.17|N|To the Image of Archmage Xylem.|
 A The Trial of Fire|QID|14300|M|55.95,12.17|N|From the Image of Archmage Xylem.|PRE|14296| ; Storyline
 A The Trial of Frost|QID|24478|M|55.95,12.17|N|From the Image of Archmage Xylem.|PRE|14296| ; Storyline
 A The Trial of Shadow|QID|24479|M|55.95,12.17|N|From the Image of Archmage Xylem.|PRE|14296| ; Storyline
-P Grim Intention|ACTIVE|24479|M|56.11,11.95|N|Click on the Shadow Portal Stone to activate the portal. Then, click on the portal to enter it.|IZ|Arcane Pinnacle|
+P Grim Intention|ACTIVE|24479|M|56.11,11.95|N|Click on the Shadow Portal Stone to activate the portal. Then, click on the portal to enter it.|IZ|4801|
 C The Trial of Shadow|QID|24479|M|30.76,27.26|N|Click on the Altar (floating stone) to begin. Lure 20 Weeping Souls into the shadow runes by standing on the other side of it. Every time one hits you, you lose one.|
 T The Trial of Shadow|QID|24479|M|31.06,26.76|N|To the Image of Archmage Xylem.|
-P Waning Sanity|ACTIVE|14300|M|31.17,26.65|N|Click on the Waning Sanity Portal to return to Arcane Pinnacle.|IZ|Trial of Shadow|
-P Burning Determination|ACTIVE|14300|M|56.08,11.96|N|Click on the Fire Portal Stone to activate the portal. Then, click on the portal to enter it.|IZ|Arcane Pinnacle|
+P Waning Sanity|ACTIVE|14300|M|31.17,26.65|N|Click on the Waning Sanity Portal to return to Arcane Pinnacle.|IZ|4800|
+P Burning Determination|ACTIVE|14300|M|56.08,11.96|N|Click on the Fire Portal Stone to activate the portal. Then, click on the portal to enter it.|IZ|4801|
 C The Trial of Fire|QID|14300|M|32.98,23.59|N|Stand in the fire runes without getting hit by Flame Strike for 10 consecutive bursts.\n[color=FF0000]NOTE: [/color]Just follow Darwin. When and where he moves, you move.|
 T The Trial of Fire|QID|14300|M|32.97,23.56|N|To the Image of Archmage Xylem.|
-P Waning Sanity|ACTIVE|24478|M|32.85,23.39|N|Click on the Waning Sanity Portal to return to Arcane Pinnacle.|IZ|Trial of Fire|
-P Icy Mortality|ACTIVE|24478|M|56.05,11.92|N|Click on the Frost Portal Stone to activate the portal. Then, click on the portal to enter it.|IZ|Arcane Pinnacle|
+P Waning Sanity|ACTIVE|24478|M|32.85,23.39|N|Click on the Waning Sanity Portal to return to Arcane Pinnacle.|IZ|4799|
+P Icy Mortality|ACTIVE|24478|M|56.05,11.92|N|Click on the Frost Portal Stone to activate the portal. Then, click on the portal to enter it.|IZ|4801|
 C The Trial of Frost|QID|24478|M|62.17,20.84|N|Mount up (if you have one) and circle around the outside edge in a counter-clockwise direction; keeping a safe distance from the Frostburns. To collect an ice orb, stand near it for a couple seconds. Getting hit by a Frostburn will take away an orb.\nAvoid the Frostburns by standing on the edge of the hill top. Avoid the runes because they'll toss you up in the air and you will take falling damage when you land.\n[color=FF0000]NOTE: [/color]If you fall off the hill, you'll have to do the jumps to climb back up to Arcane Pinnacle and take the portal again (Unless you can fly).|
 T The Trial of Frost|QID|24478|M|62.20,21.08|N|To the Image of Archmage Xylem.|
-P Waning Sanity|QID|14299|M|62.11,21.25|N|Click on the Waning Sanity Portal to return to Arcane Pinnacle.|IZ|Trial of Frost|
+P Waning Sanity|QID|14299|M|62.11,21.25|N|Click on the Waning Sanity Portal to return to Arcane Pinnacle.|IZ|5333|
 A Xylem's Asylum|QID|14299|M|55.95,12.17|N|From the Image of Archmage Xylem.|PRE|14300&24478&24479| ; Storyline
-P Bear's Head|ACTIVE|14299|M|56.19,12.07|N|Click on the portal to be transported to Bear's Head.|IZ|Arcane Pinnacle|
+P Bear's Head|ACTIVE|14299|M|56.19,12.07|N|Click on the portal to be transported to Bear's Head.|IZ|4801|
 R Xylem's Tower|ACTIVE|14299|M|24.98,38.74|N|Walk up the winding 'path' to the top up.|FLY|OLD|
 T Xylem's Asylum|QID|14299|M|25.58,37.96|N|To Joanna inside Xylem's Tower.|
 A Wasn't It Obvious?|QID|14389|M|25.58,37.96|N|From Joanna.|PRE|14299| ; Storyline
-P Ambitious Reach|ACTIVE|14389|M|25.73,37.97|N|Click on the portal behind Joanna.\n[color=FF0000]NOTE: [/color]Relax... you're suppose to 'die'.|IZ|Xylem's Tower|
+P Ambitious Reach|ACTIVE|14389|M|25.73,37.97|N|Click on the portal behind Joanna.\n[color=FF0000]NOTE: [/color]Relax... you're suppose to 'die'.|IZ|8495|
 C Wasn't It Obvious?|QID|14389|M|27.73,40.70|N|Walk towards Anara.|
 T Wasn't It Obvious?|QID|14389|M|PLAYER|N|(UI Alert)|
 A Easy is Boring|QID|14390|M|PLAYER|N|(UI Alert)|PRE|14389| ; Storyline
@@ -320,7 +320,7 @@ A Turning the Tables|QID|14391|M|PLAYER|N|UI Alert|PRE|14390| ; Storyline
 s Rez|ACTIVE|14430|M|27.60,39.58|N|Speak with Anara to resurrect yourself.|BUFF|-69812|
 R Northern Rocketway Exchange|ACTIVE|14430|N|Run to the road behind you and follow it east.|FLY|OLD|
 T Hacking the Construct|QID|14430|M|42.61,23.72|N|To Andorel Sunsworn.|
-R Northern Rocketway Terminus|ACTIVE|14391|M|42.53,24.57|N|Speak with Bilgewater Rocket-jockey to get a ride there.\n[color=FF0000]NOTE: [/color]Make sure click the exit button when you get to the end or you will overshoot and have to run back.|CHAT|FLY|OLD|IZ|-Bitter Reaches|
+R Northern Rocketway Terminus|ACTIVE|14391|M|42.53,24.57|N|Speak with Bilgewater Rocket-jockey to get a ride there.\n[color=FF0000]NOTE: [/color]Make sure click the exit button when you get to the end or you will overshoot and have to run back.|CHAT|FLY|OLD|IZ|-2497|
 f Northern Rocketway Terminus|QID|14391|M|66.50,21.00|N|At Blitz Blastospazz.|TAXI|-Northern Rocketway Terminus|
 T Turning the Tables|QID|14391|M|66.55,20.36|N|To Kalec.|
 A Fade to Black|QID|24467|M|66.55,20.36|N|From Kalec.|PRE|14391| ; Storyline - The Best Apprentice
@@ -339,14 +339,14 @@ A Farewell, Minnow|QID|14392|M|67.05,20.41|N|From Azuregos.|PRE|14261&14297&2446
 H Bilgewater Harbor|QID|14392|M|PLAYER|N|Hearth to Bilgewater Harbor.|FLY|OLD|
 T Farewell, Minnow|QID|14392|M|53.25,49.96|N|Speak to Sorata Firespinner down by the dock.| ; Completes Storyline - The Best Apprentice
 A Airborne Again|QID|24497|M|52.98,49.78|N|Secure a ride to Valermok with the Airborne Priests in the eastern portion of Bilgewater Harbor.|PRE|14392| ; Storyline
-F Valormok|QID|24497|M|60.47,52.25|N|Hop into a Wings of Steel and fly to Valormok.|V|IZ|Bilgewater Harbor|
+F Valormok|QID|24497|M|60.47,52.25|N|Hop into a Wings of Steel and fly to Valormok.|V|IZ|4821|
 T Airborne Again|QID|24497|M|14.01,64.85|N|To Chawg.\n[color=FF0000]NOTE: [/color]Much like the rockets, be prepared to jump out early. If you ride to the end, you will land in the South Fury River and have to foot it back quite a distance.\nI suggest jumping as soon as you enter Valormok.|PRE|14392|
 A Where's My Head?|QID|14462|M|14.01,64.85|N|From Chawg.| ; Storyline
 A Let Them Feast on Fear|QID|24433|M|14.01,64.85|N|From Chawg.| ; Storyline - Heart of Arkkoroc
 A Commando Drop|QID|24434|M|13.87,64.50|N|From Andorel Sunsworn.| ; Storyline
 A Grounded!|QID|14475|M|14.35,65.03|N|From Kroum.| ; Storyline
 F Orgrimmar|QID|14462|M|14.35,65.03|N|Train, repair, sell, etc. if you wish.\n[color=FF0000]NOTE: [/color]Skip this step if you don't want/need to go.|
-F Valormok|QID|14462|M|49.67,59.24|Z|Orgrimmar|N|Fly back to Valormok.|IZ|Orgrimmar|
+F Valormok|QID|14462|M|49.67,59.24|Z|Orgrimmar|N|Fly back to Valormok.|IZ|85|
 K Let Them Feast on Fear|QID|24433|M|12.74,74.19|QO|1;2|N|Slay 12 Talrendis Defenders and 6 Talrendis Sentinels.|S|
 K Commando Drop|QID|24434|M|10.06,71.18|QO|1|N|Slay 5 Talrendis Lorekeepers.|
 T Commando Drop|QID|24434|M|10.56,69.85|N|To the Lorekeeper's Summoning Stone.|

--- a/WoWPro_Leveling/Horde/CATA_Stonetalon_Mountains.lua
+++ b/WoWPro_Leveling/Horde/CATA_Stonetalon_Mountains.lua
@@ -7,9 +7,9 @@ N It's Chromie Time!|AVAILABLE|62568|M|40.82,80.13|Z|Orgrimmar|JUMP|Chromie Time
 N This guide starts in Orgrimmar|QID|25945^28532|M|PLAYER|N|This guide starts in Orgrimmar and heads to Ashenvale.|
 H Silverwind Refuge|ACTIVE|25945|M|49.67,59.24|Z|Orgrimmar|N|Hearth back to Silverwind Refuge. Fly/run if your Hearth is on CD.|
 R Silverwind Refuge|ACTIVE|-28352|AVAILABLE|25945|M|49.29,65.25|Z|Ashenvale|N|In Ashenvale.|TAXI|-Silverwind Refuge|
-F Silverwind Refuge|ACTIVE|-28352|AVAILABLE|25945|M|49.67,59.24|Z|Orgrimmar|N|Fly to Silverwind Refuge.|TAXI|Silverwind Refuge|IZ|Orgrimmar|
+F Silverwind Refuge|ACTIVE|-28352|AVAILABLE|25945|M|49.67,59.24|Z|Orgrimmar|N|Fly to Silverwind Refuge.|TAXI|Silverwind Refuge|IZ|85|
 R Silverwind Refuge|ACTIVE|28352|M|49.29,65.25|Z|Ashenvale|N|In Ashenvale.|TAXI|-Silverwind Refuge|FLY|OLD|
-F Silverwind Refuge|ACTIVE|28532|M|49.67,59.24|Z|Orgrimmar|N|Fly to Silverwind Refuge.|TAXI|Silverwind Refuge|IZ|Orgrimmar|
+F Silverwind Refuge|ACTIVE|28532|M|49.67,59.24|Z|Orgrimmar|N|Fly to Silverwind Refuge.|TAXI|Silverwind Refuge|IZ|85|
 T Warchief's Command: Stonetalon Mountains!|QID|28532|M|49.90,65.74|Z|Ashenvale|N|To Blood Guard Aldo Rockrain in Ashenvale.|
 A We're Here to Do One Thing, Maybe Two...|QID|25945|M|49.90,65.74|Z|Ashenvale|N|From Blood Guard Aldo Rockrain.|RANK|1|
 R The Fold|QID|25945|M|48.55,66.44|Z|Ashenvale|N|Hop on the Krom'gar Wagon and enjoy the free ride.|V|
@@ -31,7 +31,7 @@ R Krom'gar Fortress|QID|26004|M|66.54,62.80|N|Run to Krom'gar Fortress.|FLY|OLD|
 f Krom'gar Fortress|QID|26004|M|66.53,62.75|N|Get the flight point.|
 h Krom'gar Fortress|QID|26004|M|66.48,64.24|N|If you like, set your hearth at Felonius Stark.|
 T Krom'gar Fortress|QID|26004|M|66.12,63.70|N|To Overlord Krom'gar.|
-A Seek and Destroy|QID|26009|M|66.12,63.70|N|From Overlord Krom'gar.\n[color=FF0000]NOTE: [/color]A daily Rep quest that is available until you complete 'To Be Horde...'\nSkip this step if don't wish to repeat it.|PRE|26004|REP|Orgrimmar;76|RANK|3|IZ|Krom'gar Fortress| ; There is some discrepancy as to when the Rep limits kick in, if there's any all.
+A Seek and Destroy|QID|26009|M|66.12,63.70|N|From Overlord Krom'gar.\n[color=FF0000]NOTE: [/color]A daily Rep quest that is available until you complete 'To Be Horde...'\nSkip this step if don't wish to repeat it.|PRE|26004|REP|Orgrimmar;76|RANK|3|IZ|4933| ; There is some discrepancy as to when the Rep limits kick in, if there's any all.
 A Ashes to Ashes|QID|26010|M|66.12,63.70|N|From Overlord Krom'gar.|PRE|26004|RANK|1|
 A Dream of a Better Tomorrow|QID|26026|M|66.13,64.23|N|From Clarissa.|PRE|26004|RANK|2|
 A Might of the Krom'gar|QID|28084|M|65.85,64.13|N|From the Krom'gar Quartermaster. The quartermaster will sell you items depending on your rank in the army. Your current rank is listed up in your buffs.|PRE|26004|RANK|2|
@@ -50,7 +50,7 @@ l BD-816 War Apparatus|ACTIVE|26026|M|63.05,45.65|QO|1|N|It's located on the pla
 K Cragjaw|ACTIVE|26043|M|65.52,47.31|QO|1|N|If you'd like to try to take on Cragjaw, drop into the water and swim over to him. He swims in a circle in the northeast corner of the lake.\n[color=FF0000]NOTE: [/color]Feel free to skip this quest if it's too hard and you can't find someone to help you.|
 H Krom'gar Fortress|QID|26011|M|64.49,62.26|N|Run back if you didn't set your hearth there, or if you hearth is on cooldown.|
 T Enemy of the Horde: Marshal Paltrow|QID|26011|M|65.77,63.31|N|To Spy-Mistress Anara, back at Krom'gar Fortress.|
-t BEWARE OF CRAGJAW!|QID|26043|M|65.77,63.31|N|To Spy-Mistress Anara.|IZ|Krom'gar Fortress|
+t BEWARE OF CRAGJAW!|QID|26043|M|65.77,63.31|N|To Spy-Mistress Anara.|IZ|4933|
 T Seek and Destroy|QID|26009|M|66.12,63.70|N|To Overlord Krom'gar.|
 T Ashes to Ashes|QID|26010|M|66.12,63.70|N|To Overlord Krom'gar.| ; Completes Storyline A Short-Lived Victory
 A Report to Bombgutz|QID|26020|M|66.12,63.70|N|From Overlord Krom'gar.|PRE|26010|RANK|1|
@@ -76,7 +76,7 @@ T Between a Rock and a Hard Place|QID|26046|M|67.10,64.56|N|Back to Scout Utvoch
 T And That's Why They Call Them Peons...|QID|26047|M|67.18,64.47|N|To Blastgineer Igore.|
 T I Got Your Parts Right Here...|QID|26045|M|67.14,64.52|N|To Sergeant Dontrag.|
 A Spare Parts Up In Here!|QID|26048|M|67.14,64.52|N|From Sergeant Dontrag.|PRE|26045&26046&26047|RANK|1|
-R Exit Deep Reaches|ACTIVE|26048|M|66.49,60.47|N|Make your way out of Deep Reaches.|IZ|The Deep Reaches|
+R Exit Deep Reaches|ACTIVE|26048|M|66.49,60.47|N|Make your way out of Deep Reaches.|IZ|4932|
 T Spare Parts Up In Here!|QID|26048|M|66.25,62.94|N|To Chief Blastgineer Bombgutz, back on top of the hill at Krom'gar Fortress.|
 A In Defense of Krom'gar Fortress|QID|26058|M|66.25,62.94|N|From Chief Blastgineer Bombgutz.|PRE|26048|RANK|1|
 C In Defense of Krom'gar Fortress|QID|26058|M|66.09,63.01|N|Right-click one of the guns to get in. Shoot down the flying machines and make sure to shoot the pilots after you destroy the machine. When you are done, you need to exit the gun manually.|
@@ -87,7 +87,7 @@ r Quartermaster|ACTIVE|26059|M|65.85,64.12|N|You've gone up a rank in the Krom'g
 F Malaka'jin|QID|26059|M|66.52,62.77|N|Fly to Malaka'jin.|TAXI|Malaka'jin|
 R Webwinder Path|ACTIVE|26059|M|60.96,71.09|N|Take the west ramp down and follow the 'road' south through Windshear Valley and out of Windshear Crag to Webwinder Path.|TAXI|-Malaka'jin|FLY|OLD|
 R Malaka'jin|ACTIVE|26059|M|70.51,87.49|N|Follow Webwinder Path south to Malaka'jin.\n[color=FF0000]NOTE: [/color]Just go around the barricade.|TAXI|-Malaka'jin|FLY|OLD|
-R Malaka'jin|QID|26059|M|70.51,87.49|N|Fly to Malaka'jin.|TAXI|-Malaka'jin|IZ|-Malaka'jin|
+R Malaka'jin|QID|26059|M|70.51,87.49|N|Fly to Malaka'jin.|TAXI|-Malaka'jin|IZ|-2539|
 f Malaka'jin|ACTIVE|26059|M|70.61,89.46|N|Get the Malaka'jin FP from Zillane./n(Access to him is from a path in the western corner of the village)|TAXI|-Malaka'jin|
 T Eyes and Ears: Malaka'jin|QID|26059|M|71.12,91.23|N|To Witch Doctor Jin'Zil.|
 A Da Voodoo: Stormer Heart|QID|26060|M|71.12,91.23|N|From Witch Doctor Jin'Zil.|PRE|26059|RANK|1|

--- a/WoWPro_Leveling/Horde/INTRO_Orc_Troll_Part2.lua
+++ b/WoWPro_Leveling/Horde/INTRO_Orc_Troll_Part2.lua
@@ -86,7 +86,7 @@ A Raggaran's Fury|QID|25192|PRE|25190|M|42.73,49.85|N|From Raggaran.|RANK|2|
 C Raggaran's Fury|QID|25192|M|39.89,52.55|N|Kill the Razormane Dustrunners and Razormane Battleguards. Beware the Captain.|
 T Raggaran's Fury|QID|25192|M|42.65,49.89|N|To Raggaran.|
 A Unbidden Visitors|QID|25194|ACTIVE|25188|M|35.87,41.37|N|From Zen'Taji.|RANK|2|
-K Death Flayer|ACTIVE|25188|M|35.09,44.47|IZ|Southfury Watershed|N|Death Flayer is a silver rare scorpid that paths around the shore of the island. It has a fairly quick respawn rate (~30 minutes). Skip this if you don't want to wait. Close this step if you kill it.\n[color=FF0000]NOTE: [/color]This rare is tameable by hunters.|T|Death Flayer|RARE|S!US|
+K Death Flayer|ACTIVE|25188|M|35.09,44.47|IZ|4981|N|Death Flayer is a silver rare scorpid that paths around the shore of the island. It has a fairly quick respawn rate (~30 minutes). Skip this if you don't want to wait. Close this step if you kill it.\n[color=FF0000]NOTE: [/color]This rare is tameable by hunters.|T|Death Flayer|RARE|S!US|
 C Unbidden Visitors|QID|25194|M|34.84,43.35|N|Attack 3 Wayward Plainstriders until they flee toward the Barrens.|
 T Unbidden Visitors|QID|25194|M|35.79,41.49|N|To Zen'Taji.|
 A That's the End of That Raptor|QID|25195|PRE|25194|M|35.79,41.49|N|From Zen'Taji.|RANK|2|

--- a/WoWPro_Leveling/Horde/MOP_JadeForest.lua
+++ b/WoWPro_Leveling/Horde/MOP_JadeForest.lua
@@ -459,7 +459,7 @@ C Pages of History|QID|30002|M|55.70,59.95|N|Click on an Infested Book to releas
 T Moth-Ridden|QID|30001|M|56.27,60.43|N|To Lorewalker Stonestep.|
 A Everything In Its Place|QID|30004|M|56.27,60.43|N|From Lorewalker Stonestep.|PRE|30001&30002|
 T Pages of History|QID|30002|M|55.70,59.95|N|To Lorewalker Stonestep.|
-R Exit the Scrollkeeper's Sanctum|ACTIVE|29999|M|56.41,58.90|IZ|The Scrollkeeper's Sanctum|N|Go up the stairs and wind your way around the room until you reach the stairs going back down to the exit.|
+R Exit the Scrollkeeper's Sanctum|ACTIVE|29999|M|56.41,58.90|IZ|6118|N|Go up the stairs and wind your way around the room until you reach the stairs going back down to the exit.|
 C Emerald Serpent|QID|29999|M|56.51,58.44|QO|3|N|Click on the serpent to pick it up.\nIt moves around a bit, but always in the general vicinity.|NC|
 C The Scryer's Dilemma|QID|29997|M|56.79,55.84|N|Kill the water elementals until the staff drops.|
 T The Scryer's Dilemma|QID|29997|M|57.57,56.03|N|To Wise Mari.|

--- a/WoWPro_Leveling/Horde/MOP_Krasarang_Wilds.lua
+++ b/WoWPro_Leveling/Horde/MOP_Krasarang_Wilds.lua
@@ -6,7 +6,7 @@ WoWPro:GuideNextGuide(guide, 'Kun-Lai Summit')
 WoWPro:GuideSteps(guide, function()
 return [[
 N It's Chromie Time!|AVAILABLE|62568|M|40.82,80.13|Z|Orgrimmar|JUMP|Chromie Time|S!US|N|You can now accept Chromie's Call at the Warchief's Command Board in Orgrimmar. This will allow you to choose which expansion you want to level in and scale the content to your level.\n\nYou're free to continue your current guide by skipping this and continuing on, but it won't continue to scale. If you want to enable Chromie Time, click the guide button next to this frame to direct you to Chromie in  Orgrimmar!|LVL|-50|CT|
-F Zhu's Watch|AVAILABLE|30079|M|79.95,2.31|N|This guide starts at Zhu's watch. If you aren't there, fly or run there.|IZ|-Zhu's Watch|
+F Zhu's Watch|AVAILABLE|30079|M|79.95,2.31|N|This guide starts at Zhu's watch. If you aren't there, fly or run there.|IZ|-6000|
 T Ken-Ken|QID|29873|M|80.14,0.93|N|To Ken-Ken. This was accepted from Xiao at the beginning of Valley of the 4 Winds.|
 A What's Eating Zhu's Watch?|QID|30079|M|80.14,0.93|N|From Ken-Ken.|
 C Speak with Mei|QID|30079|M|79.74,1.50|QO|4|N|up the stairs, outside.|CHAT|

--- a/WoWPro_Leveling/Neutral/INTRO_Pandaren.lua
+++ b/WoWPro_Leveling/Neutral/INTRO_Pandaren.lua
@@ -175,7 +175,7 @@ T Do No Evil|QID|29780|M|PLAYER|N|To Ji Firepaw, beside you.|
 C Monkey Advisory Warning|QID|29781|M|20.93,34.36|N|Collect the Stolen Firework Bundle from where Ruk-Ruk was, or elsewhere in the village.|US|
 T Monkey Advisory Warning|QID|29781|M|24.44,30.62|N|To Ji Firepaw.|
 K The Direct Solution|QID|29779|M|24.44,30.62|QO|1|N|Finish killing Fe-Fang Hozen. Ji Firepaw has a great AoE kick, so feel free to pull a few.|US|
-T The Direct Solution|QID|29779|N|[color=FF0000]NOTE: [/color]Do NOT turn this quest in yet. Ji Firepaw will stop helping you if you do.|IZ|Fe-Feng Village|
+T The Direct Solution|QID|29779|N|[color=FF0000]NOTE: [/color]Do NOT turn this quest in yet. Ji Firepaw will stop helping you if you do.|IZ|5831|
 T Stronger Than Bone|QID|29782|M|29.92,39.77|N|To Jojo Ironbrow.|
 T The Direct Solution|QID|29779|M|30.97,36.74|N|To Ji Firepaw at the dock. Once you leave Fe-Feng Village, he will despawn and be at this location.\n[color=FF0000]NOTE: [/color]Ji Firepaw will stop helping you once you've turned it in.|
 A Balanced Perspective|QID|29784|M|30.97,36.74|N|From Ji Firepaw.|PRE|29779&29780&29781&29782|

--- a/WoWPro_Leveling/Neutral/LEGION_Order_Hall_Druid.lua
+++ b/WoWPro_Leveling/Neutral/LEGION_Order_Hall_Druid.lua
@@ -107,7 +107,7 @@ t Halls of Valor: Essence of Ferocity|QID|44075|M|44.57,50.12|N|To Keeper Remulo
 t Darkheart Thicket: Essence of Regrowth|QID|44076|M|44.57,50.12|N|To Keeper Remulos.|
 t Eye of Azshara: Essence of Balance|QID|44077|M|44.57,50.12|N|To Keeper Remulos.|
 ;lights heart intro questline
-P Dalaran|QID|44009|QO|1|M|56.51,43.13|N|Back to the outside world to continue leveling.|PRE|42585|IZ|The Dreamgrove|
+P Dalaran|QID|44009|QO|1|M|56.51,43.13|N|Back to the outside world to continue leveling.|PRE|42585|IZ|7846|
 A A Falling Star|QID|44009|M|28.44,48.35|Z|Dalaran@Dalaran70|N|From Archmage Khadgar in The Violet Citadel.|PRE|42516|
 C A Falling Star|QID|44009|QO|1|M|69.69,51.34|Z|Dalaran@Dalaran70|CHAT|N|Tell Flightmaster Aludane Whitecloud 'I'm ready to go to Suramar'.|
 C A Falling Star|QID|44009|QO|2|M|91.96,61.20|Z|Suramar|NC|N|Swim out to see and then straight down to invistigate the site on the ocean floor.|
@@ -427,8 +427,8 @@ C Lyessa Must Survive|ACTIVE|41689|SO|4;2|M|61.21,26.36|Z|Mount Hyjal|N|Lyessa i
 C Give Corrupted G'Hanir to Lyessa|ACTIVE|41689|SO|5;1|M|60.55,25.48|Z|Mount Hyjal|NC|N|Click on Lyessa to give Corrupted G'Hanir to Lyessa.|
 C Witness G'Hanir's rebirth|ACTIVE|41689|SO|5;2|M|61.19,26.08|Z|Mount Hyjal|N|Use the button provided in your questlog to witness G'Hanir's rebirth.|EAB|
 C G'Hanir Reborn|ACTIVE|41689|SO|6;1|Z|Mount Hyjal|N|Pick up the staff.|
-P Mt. Hyjal Portal|ACTIVE|41689|M|55.74,29.9|Z|Mount Hyjal|N|Run back to the Emerald Dreamway|IZ|Nordrassil|
-P The Dreamway Portal|ACTIVE|41689|M|45.31,24.43|Z|EmeraldDreamway|N|Run through the portal.|IZ|Emerald Dreamway|
+P Mt. Hyjal Portal|ACTIVE|41689|M|55.74,29.9|Z|Mount Hyjal|N|Run back to the Emerald Dreamway|IZ|8091|
+P The Dreamway Portal|ACTIVE|41689|M|45.31,24.43|Z|EmeraldDreamway|N|Run through the portal.|IZ|7979|
 T Cleansing the Mother Tree|QID|41689|M|45.18,51.85|N|To Lyessa Bloomwatcher.|
 ;Druid Class Hall
 A Sowing The Seed|QID|41255|QO|1|M|44.50,51.10|N|From Rensar Greathoof.|PRE|40900^42430^41918^41689|

--- a/WoWPro_Leveling/Neutral/MOP_Valley_of_the_Four_Winds.lua
+++ b/WoWPro_Leveling/Neutral/MOP_Valley_of_the_Four_Winds.lua
@@ -7,7 +7,7 @@ WoWPro:GuideSteps(guide, function()
 return [[
 N It's Chromie Time!|AVAILABLE|62567|M|62.25,29.93|Z|Stormwind City|JUMP|Chromie Time|S!US|N|You can now accept Chromie's Call at the Hero's Call board in Stormwind. This will allow you to choose which expansion you want to level in and scale the content to your level.\n\nYou're free to continue your current guide by skipping this and continuing on, but it won't continue to scale. If you want to enable Chromie Time, click the guide button next to this frame to direct you to Chromie in Stormwind!|LVL|-50|CT|FACTION|Alliance|
 N It's Chromie Time!|AVAILABLE|62568|M|40.82,80.13|Z|Orgrimmar|JUMP|Chromie Time|S!US|N|You can now accept Chromie's Call at the Warchief's Command Board in Orgrimmar. This will allow you to choose which expansion you want to level in and scale the content to your level.\n\nYou're free to continue your current guide by skipping this and continuing on, but it won't continue to scale. If you want to enable Chromie Time, click the guide button next to this frame to direct you to Chromie in  Orgrimmar!|LVL|-50|CT|FACTION|Horde|
-R Valley of the Four Winds|N|Make your way to Valley of the Four Winds.|IZ|-Valley of the Four Winds|
+R Valley of the Four Winds|N|Make your way to Valley of the Four Winds.|IZ|-376|
 ; -- Breadcrumb quest turn-in
 T Hero's Call: Valley of the Four Winds!|QID|49557|M|85.94,22.10|N|To Chen Stormstout.|
 T Warchief's Command: Valley of the Four Winds!|QID|49539|M|85.94,22.10|N|To Chen Stormstout.|
@@ -154,7 +154,7 @@ R Mudmug's Place|ACTIVE|29950|M|68.87,46.3|FLY|OLD|
 T Li Li's Day Off|QID|29950|M|68.77,43.43|N|To Li Li.|
 T Muddy Water|QID|29951|M|68.71,43.12|N|To Mudmug.|
 A Broken Dreams|QID|29952|M|68.85,43.41|N|From Chen Stormstout.|PRE|29950|
-C Broken Dreams|QID|29952|M|68.85,43.41|N|Chat with Chen to get transported to an instance where you relive Chen's experience as he goes to the brewery. Look for the old uncle and follow after him, (because Chen is trying to talk to him).|IZ|Mudmug's Place|CHAT|
+C Broken Dreams|QID|29952|M|68.85,43.41|N|Chat with Chen to get transported to an instance where you relive Chen's experience as he goes to the brewery. Look for the old uncle and follow after him, (because Chen is trying to talk to him).|IZ|5957|CHAT|
 T Broken Dreams|QID|29952|M|68.85,43.41|N|To Chen Stormstout.|
 A Chen's Resolution|QID|30046|M|68.81,43.50|N|From Chen Stormstout.|PRE|29951&29952|
 R Halfhill|ACTIVE|30046|M|58.90,44.97|N|Head to Halfhill to meet up with Chen.|FLY|OLD|
@@ -164,7 +164,7 @@ A Li Li and the Grain|QID|30048|M|55.89,49.44|N|From Chen Stormstout.|PRE|30046|
 A Doesn't Hold Water|QID|30049|M|55.89,49.44|N|From Chen Stormstout.|PRE|30046|
 A Children of the Water|QID|32045|M|55.13,47.38|N|From Stonecarver Mac, up on Halfhill|
 f Halfhill|ACTIVE|30049|M|56.50,50.36|N|From Wing Nga.|TAXI|-Halfhill|
-N Fishing quest and cooking training|AVAILABLE|31281|N|If you want to, this is a good time to do the fishing quest and cooking training. Perhaps not the most efficient. But, if you are going to do it, might as well do it while you get XP.|IZ|Halfhill|RANK|3|
+N Fishing quest and cooking training|AVAILABLE|31281|N|If you want to, this is a good time to do the fishing quest and cooking training. Perhaps not the most efficient. But, if you are going to do it, might as well do it while you get XP.|IZ|5980|RANK|3|
 ; -- Fishing quest
 A You Want Fish?|QID|32684|M|53.58,51.22|N|From Sungshin Ironpaw.\n[color=FF0000]NOTE: [/color]As stated earlier, this is optional. Skip it if you so wish.|
 T You Want Fish?|QID|32684|M|58.92,46.92|N|To Ben of the Booming Voice down by the shore of the Gilding Stream.|
@@ -189,7 +189,7 @@ T Ready for Greatness|QID|31302|M|53.58,51.22|N|To Sungshin Ironpaw.|
 N Advanced Pandaren Cooking|AVAILABLE|31479^31311^31478^31472^31475^31470|M|PLAYER|N|Upon turning in 'Ready for Greatness', you'll unlock 6 quests to unlock further cooking skills and dailies.\nThis guide will go no further into it.|RANK|3|JUMP|Pandaren Cooking|
 ; --
 ; -- The Tillers Quest chain
-N The Tillers Rep Guide Intro|AVAILABLE|30252|N|[color=FF0000]NOTE: [/color]This chain for The Tillers and is optional. It's quick and easy XP; even if you don't plan on doing the farming portion.|IZ|Valley of the Four Winds|RANK|3|
+N The Tillers Rep Guide Intro|AVAILABLE|30252|N|[color=FF0000]NOTE: [/color]This chain for The Tillers and is optional. It's quick and easy XP; even if you don't plan on doing the farming portion.|IZ|376|RANK|3|
 A A Helping Hand|QID|30252|M|52.01,47.99|N|From Farmer Yoon in Sunsong Ranch.\n[color=FF0000]NOTE: [/color]Skip this step if you don't wish to do the quest chain.|RANK|3| ; Started at 22,992 xp
 C Remove the rocks|QID|30252|M|52.8,49.81|N|Click on the Unbudging Rock to dig it up. You'll find them spread out around Sunsong Ranch.\n[color=FF0000]NOTE: [/color]You are phased and no one (outside of your party) can take yours.|NC|
 T A Helping Hand|QID|30252|M|52.75,47.94|N|To Farmer Yoon.|

--- a/WoWPro_Leveling/Neutral/SL_Ardenweald.lua
+++ b/WoWPro_Leveling/Neutral/SL_Ardenweald.lua
@@ -46,8 +46,8 @@ T Restoring Balance|QID|62739|M|49.33,52.36|Z|Ardenweald!The Shadowlands|N|To La
 A Support the Court|QID|62763|PRE|63036|M|49.13,38.92|Z|The Trunk@Heart of the Forest!Dungeon|N|From Lady Moonberry.|TOF|
 A Support the Court|QID|62763|PRE|62739|M|49.33,52.36|Z|Ardenweald!The Shadowlands|N|From Lady Moonberry.|TOF|
 l Support the Court|QID|62763|QO|1|S!US|N|Literally everything you do in Ardenweald counts towards this quest. You may [color=40C7EB]return[/color] to [color=40C7EB]Heart of the Forest[/color] to turn in and be done with the zone anytime after this step closes.|TOF|
-t Support the Court|QID|62763|IZ|Heart of the Forest|M|49.13,38.92|Z|The Trunk@Heart of the Forest!Dungeon|N|To Lady Moonberry.|TOF|COV|NightFae
-t Support the Court|QID|62763|IZ|Heart of the Forest|M|49.35,52.36|Z|Ardenweald!The Shadowlands|N|To Lady Moonberry.|TOF|
+t Support the Court|QID|62763|IZ|12858|M|49.13,38.92|Z|The Trunk@Heart of the Forest!Dungeon|N|To Lady Moonberry.|TOF|COV|NightFae
+t Support the Court|QID|62763|IZ|12858|M|49.35,52.36|Z|Ardenweald!The Shadowlands|N|To Lady Moonberry.|TOF|
 A Return to Oribos|QID|62776|PRE|62763|M|PLAYER|Z|Ardenweald!The Shadowlands|N|From Lady Moonberry.|TOF|
 T Forest Refugees|QID|62807|M|48.40,50.51|Z|Ardenweald!The Shadowlands|N|To Flwngyrr.|TOF|PRE|62763|
 F Oribos|ACTIVE|62776|M|51.27,7.56|Z|The Trunk@Heart of the Forest!Dungeon|N|At Ceridwyn.|TOF|TAXI|Heart of the Forest|
@@ -555,7 +555,7 @@ C Battle for Hibernal Hollow|QID|58869|M|60.03,53.09|Z|Ardenweald!The Shadowland
 T Battle for Hibernal Hollow|QID|58869|M|59.92,53.09|Z|Ardenweald!The Shadowlands|N|To Droman Aliothe.|MS|
 T Blooming Villains|QID|58265|M|60.63,51.40|Z|Ardenweald!The Shadowlands|N|To Guardian Molan.|
 T Beneath the Mask|QID|58267|M|60.63,51.40|Z|Ardenweald!The Shadowlands|N|To Guardian Molan.|
-F Heart of the Forest|ACTIVE|62763^62807|M|60.32,53.45|Z|Ardenweald!The Shadowlands|N|At Na'lor.|COV|NightFae|IZ|Hibernal Hollow|
+F Heart of the Forest|ACTIVE|62763^62807|M|60.32,53.45|Z|Ardenweald!The Shadowlands|N|At Na'lor.|COV|NightFae|IZ|11531|
 F Refugee Camp|ACTIVE|62763^62807|M|60.32,53.45|Z|Ardenweald!The Shadowlands|N|At Na'lor.|TOF|TAXI|-Heart of the Forest|
 A Dying Dreams|QID|60661|M|59.94,52.97|Z|Ardenweald!The Shadowlands|N|From Lady Moonberry.|PRE|58869|MS|
 C Dying Dreams|QID|60661|M|59.94,52.97|Z|Ardenweald!The Shadowlands|QO|1|CHAT|N|Speak with Moonberry.|MS|
@@ -569,11 +569,11 @@ A The Court of Winter|QID|58723|M|45.27,63.14|Z|Ardenweald!The Shadowlands|N|Fro
 C The Court of Winter|QID|58723|M|45.27,63.14|Z|Ardenweald!The Shadowlands|QO|1|CHAT|N|Deliver Primus's Message.|MS|
 
 R Garden of Night|QID|61126^61074|M|38.85,60.10|Z|Ardenweald!The Shadowlands|N|The next few treasure steps are done in a level 60 area, check them off manually if you aren't comfortable there, results in cool mount.|ACH|14313;9|ITEM|180731|TZ|Garden of Night|; $ I was able to pick up all the pieces, combine and talk to twinklestar pre 60 --all but obtain the mount, i assume because I already had the mount learned
-$ Gardener's Wand|QID|61126^61074|M|38.85,60.10|Z|Ardenweald!The Shadowlands|L|180757|N|Pick up Gardener's Wand under the cart, between the wheels.|ACH|14313;9|IZ|Garden of Night|
-$ Gardener's Flute|QID|61126^61074|M|38.49,58.08|Z|Ardenweald!The Shadowlands|L|180756|N|Pick up Gardener's Flute where some spriggans are dancing.|ACH|14313;9|IZ|Garden of Night|
-$ Gardener's Hammer|QID|61126^61074|M|39.75,54.40|Z|Ardenweald!The Shadowlands|L|180754|N|Pick up Gardener's Hammer inside the cart.|ACH|14313;9|IZ|Garden of Night|
-$ Gardener's Basket|QID|61126^61074|M|40.31,52.62|Z|Ardenweald!The Shadowlands|L|180758|N|Pick up Gardener's Basket on the ground beside the fountain.|ACH|14313;9|IZ|Garden of Night|
-$ Diary of the Night|QID|61126^61074|CS|M|40.11,53.70;38.99,56.96|Z|Ardenweald!The Shadowlands|L|180759|N|Pick up diary on a table on the second platform|ACH|14313;9|IZ|Garden of Night|
+$ Gardener's Wand|QID|61126^61074|M|38.85,60.10|Z|Ardenweald!The Shadowlands|L|180757|N|Pick up Gardener's Wand under the cart, between the wheels.|ACH|14313;9|IZ|12884|
+$ Gardener's Flute|QID|61126^61074|M|38.49,58.08|Z|Ardenweald!The Shadowlands|L|180756|N|Pick up Gardener's Flute where some spriggans are dancing.|ACH|14313;9|IZ|12884|
+$ Gardener's Hammer|QID|61126^61074|M|39.75,54.40|Z|Ardenweald!The Shadowlands|L|180754|N|Pick up Gardener's Hammer inside the cart.|ACH|14313;9|IZ|12884|
+$ Gardener's Basket|QID|61126^61074|M|40.31,52.62|Z|Ardenweald!The Shadowlands|L|180758|N|Pick up Gardener's Basket on the ground beside the fountain.|ACH|14313;9|IZ|12884|
+$ Diary of the Night|QID|61126^61074|CS|M|40.11,53.70;38.99,56.96|Z|Ardenweald!The Shadowlands|L|180759|N|Pick up diary on a table on the second platform|ACH|14313;9|IZ|12884|
 
 T Forest Refugees|QID|62807|M|48.40,50.51|Z|Ardenweald!The Shadowlands|N|To Flwngyrr.|
 f Refugee Camp|ACTIVE|62807^58723|M|49.31,51.84|Z|Ardenweald!The Shadowlands|N|At Derwynnthlmn.|MS|

--- a/WoWPro_Leveling/Neutral/SL_Bastion.lua
+++ b/WoWPro_Leveling/Neutral/SL_Bastion.lua
@@ -47,8 +47,8 @@ T The Elysian Fields|QID|62707|M|51.12,46.80|Z|Bastion!The Shadowlands|N|To Kali
 T The Elysian Fields|QID|63034|M|37.01,61.22|Z|1707|N|To Kalisthene.|TOF|
 A Bolstering Bastion|QID|62723|PRE|62707^63034|M|PLAYER|N|From Kalisthene.|TOF|
 l Bolstering Bastion|QID|62723|QO|1|M|51.12,46.80|Z|Bastion!The Shadowlands|S!US|N|Literally everything you do in Bastion counts towards this quest. You may [color=40C7EB]return[/color] to [color=40C7EB]Hero's Rest[/color], or [color=40C7EB]Elysian Hold[/color] if you're a member of the Kyrian, when this step closes|TOF|
-t Bolstering Bastion|QID|62723|M|37.01,61.22|Z|1707|N|To Kalisthene.|IZ|Elysian Hold|COV|Kyrian|TOF|;need proper coords. i appear to have lost some changes.
-t Bolstering Bastion|QID|62723|M|51.12,46.80|Z|Bastion!The Shadowlands|N|To Kalisthene.|IZ|Hero's Rest|TOF|
+t Bolstering Bastion|QID|62723|M|37.01,61.22|Z|1707|N|To Kalisthene.|IZ|1707|COV|Kyrian|TOF|;need proper coords. i appear to have lost some changes.
+t Bolstering Bastion|QID|62723|M|51.12,46.80|Z|Bastion!The Shadowlands|N|To Kalisthene.|IZ|11381|TOF|
 A Return to Oribos|QID|62729|PRE|62723|M|PLAYER|Z|Bastion!The Shadowlands|N|From Kalisthene.|TOF|
 F Oribos|ACTIVE|62729|M|50.96,49.08|Z|1707|N|At Cassius.|COV|Kyrian|TOF|
 F Oribos|ACTIVE|62729|M|51.36,46.80|Z|Bastion!The Shadowlands|N|At Navarros.|TOF|
@@ -402,8 +402,8 @@ A Steward at Work|QID|59197|M|52.83,47.88|Z|Bastion!The Shadowlands|N|From Kalis
 C Steward at Work|QID|59197|M|PLAYER|Z|Bastion!The Shadowlands|QO|1|NC|N|Use the new summon steward spell you just received.|MS|
 C Steward at Work|QID|59197|M|PLAYER|Z|Bastion!The Shadowlands|QO|2|CHAT|N|Talk to the Steward you summoned and ask him to fix the beacon.|MS|
 h Hero's Rest|ACTIVE|59197^62723^62729|M|53.15,46.88|Z|Bastion!The Shadowlands|N|To shorten the run later, set your Hearth at Inkiep.|
-T You'll Never Walk Alone|QID|62170|M|53.15,46.88|Z|Bastion!The Shadowlands|N|To Inkiep|IZ|Hero's Rest|
-T Functioning Anima Core|QID|62200|M|51.12,46.79|Z|Bastion!The Shadowlands|N|To Kalisthene|IZ|Hero's Rest|
+T You'll Never Walk Alone|QID|62170|M|53.15,46.88|Z|Bastion!The Shadowlands|N|To Inkiep|IZ|11381|
+T Functioning Anima Core|QID|62200|M|51.12,46.79|Z|Bastion!The Shadowlands|N|To Kalisthene|IZ|11381|
 C Steward at Work|QID|59197|M|53.24,46.82|Z|Bastion!The Shadowlands|QO|3|NC|N|Click to activate the Beacon of Invocation.|MS|
 
 A WANTED: Gorgebeak|QID|60315|M|53.27,46.43|Z|Bastion!The Shadowlands|ELITE|N|[color=ff8000]Elite: [/color]From the scroll on the wall.|RANK|2|
@@ -558,7 +558,7 @@ C Pride or Unit|QID|60296|M|55.79,39.49|Z|Bastion!The Shadowlands|QO|2|CHAT|N|Ta
 C Pride or Unit|QID|60296|M|55.79,39.49|Z|Bastion!The Shadowlands|QO|3|CHAT|N|Talk to Nemea.|
 C Pride or Unit|QID|60296|M|55.79,39.49|Z|Bastion!The Shadowlands|QO|4|CHAT|N|Choose Phalynx or Larion.|
 T Pride or Unit|QID|60296|M|55.79,39.49|Z|Bastion!The Shadowlands|N|To Nemea.|
-H Hero's Rest|ACTIVE|60056^62723^62729|M|52.99,37.84|Z|Bastion!The Shadowlands|N|Hearth or otherwise make your way back to Hero's Rest.|IZ|Forgefire Outpost|
+H Hero's Rest|ACTIVE|60056^62723^62729|M|52.99,37.84|Z|Bastion!The Shadowlands|N|Hearth or otherwise make your way back to Hero's Rest.|IZ|12793|
 T WANTED: Darkwing|QID|60366|M|52.43,48.00|Z|Bastion!The Shadowlands|ELITE|N|To Eumelia.|
 T Functioning Anima Core|QID|62200|M|51.12,46.79|Z|Bastion!The Shadowlands|N|To Kalisthene.|
 

--- a/WoWPro_Leveling/Neutral/SL_Chains_of_Domination.lua
+++ b/WoWPro_Leveling/Neutral/SL_Chains_of_Domination.lua
@@ -281,12 +281,12 @@ T The Nathrezim|QID|63654|M|23.07,45.86|Z|Revendreth|N|To Prince Renathal.|
 
 ; The Power of Night
 A A Cry From the Heart|QID|63672|PRE|63654|M|64.40,24.27|Z|Korthia|N|From Urgent Message from Ardenweald.|
-P Ring of Transference|ACTIVE|63672|M|64.47,24.04|Z|Korthia|IZ|Korthia|N|Take the portal to Ring of Transference.|
-F Heart of the Forest|ACTIVE|63672|M|60.96,68.81|Z|Ring of Transference@Oribos|IZ|-Heart of the Forest|N|Head to the flightmaster and take a flight to Heart of the Forest.|
+P Ring of Transference|ACTIVE|63672|M|64.47,24.04|Z|Korthia|IZ|1961|N|Take the portal to Ring of Transference.|
+F Heart of the Forest|ACTIVE|63672|M|60.96,68.81|Z|Ring of Transference@Oribos|IZ|-12858|N|Head to the flightmaster and take a flight to Heart of the Forest.|
 T A Cry From the Heart|QID|63672|M|71.55,45.89|Z|The Trunk@Heart of the Forest!Dungeon|N|To Ysera.|
 A Hunting Amid Houses|QID|63728|PRE|63672|M|71.55,45.89|Z|The Trunk@Heart of the Forest!Dungeon|N|From Ysera.|
 C Hunting Amid Houses|QID|63728|M|71.55,45.89|Z|The Trunk@Heart of the Forest!Dungeon|QO|1|CHAT|N|Speak to Ysera.|
-F Spider's Watch|ACTIVE|63728|M|49.35,51.84|Z|Ardenweald!The Shadowlands|IZ|-Maldraxxus|N|Head to the flightmaster and take a flight to Spider's Watch.|
+F Spider's Watch|ACTIVE|63728|M|49.35,51.84|Z|Ardenweald!The Shadowlands|IZ|-1536|N|Head to the flightmaster and take a flight to Spider's Watch.|
 C Hunting Amid Houses|QID|63728|M|42.79,25.12|Z|Maldraxxus|QO|2|NC|N|Huln Found in Maldraxxus.|
 T Hunting Amid Houses|QID|63728|M|42.79,25.12|Z|Maldraxxus|N|To Huln Highmountain.|
 A The Blade in the Night|QID|63990|PRE|63728|M|42.79,25.12|Z|Maldraxxus|N|From Huln Highmountain.|

--- a/WoWPro_Leveling/Neutral/SL_Covenant.lua
+++ b/WoWPro_Leveling/Neutral/SL_Covenant.lua
@@ -173,8 +173,8 @@ P Oribos|ACTIVE|62837|M|42.37,42.15|Z|The Maw|NC|N|Take the Waygate back to Orib
 C Hopeful News|QID|62837|M|42.37,42.15|Z|The Maw|NC|N|Take the Waygate back to Oribos.|COV|Night Fae|
 T Hopeful News|QID|62837|M|39.94,68.61|Z|Ring of Fates@Oribos|N|To Highlord Bolvar Fordragon.|COV|Night Fae|
 A Flutterback|QID|62894|M|40.31,68.69|Z|Ring of Fates@Oribos|N|From Highlord Bolvar Fordragon.|PRE|62837|COV|Night Fae|
-P Ring of Transference|ACTIVE|62894|M|49.55,60.83|Z|Ring of Transference@Oribos|IZ|-Heart of the Forest|N|Take the Teleporation Pad up to the Ring of Transference.|COV|Night Fae|
-F Heart of the Forest|ACTIVE|62894|M|60.59,68.98|Z|Ring of Transference@Oribos|N|Pathscribe Roh-Avonavi.|IZ|Ring of Transference|COV|Night Fae|
+P Ring of Transference|ACTIVE|62894|M|49.55,60.83|Z|Ring of Transference@Oribos|IZ|-12858|N|Take the Teleporation Pad up to the Ring of Transference.|COV|Night Fae|
+F Heart of the Forest|ACTIVE|62894|M|60.59,68.98|Z|Ring of Transference@Oribos|N|Pathscribe Roh-Avonavi.|IZ|1671|COV|Night Fae|
 T Flutterback|QID|62894|M|34.14,43.99|Z|The Trunk@Heart of the Forest!Dungeon|N|To Flutterby.|COV|Night Fae|
 A Recovered Souls|QID|62897|M|33.92,43.52|Z|The Trunk@Heart of the Forest!Dungeon|N|From Flutterby.|PRE|62894|COV|Night Fae|
 T Recovered Souls|QID|62897|M|39.84,55.64|Z|The Roots@Heart of the Forest!Dungeon|N|To Zayhad, The Builder.|COV|Night Fae|
@@ -506,9 +506,9 @@ C Rezan, Loa of Kings|QID|59856|M|45.80,85.03|Z|The Maw|QO|1|CHAT|N|Talk with Vo
 C Rezan, Loa of Kings|QID|59856|M|47.02,86.35|Z|The Maw|QO|2|N|Step into the barrier and kill Exhaurbius, once he dies there is a lot of dialog, you will continue to take damage so step out of the barrier while you wait and watch.|COV|Night Fae|
 T Rezan, Loa of Kings|QID|59856|M|45.80,85.03|Z|The Maw|N|To Spirit of Vol'jin.|COV|Night Fae|
 A Parting Ways|QID|59866|PRE|59856|M|45.80,85.03|Z|The Maw|N|From Spirit of Vol'jin.|COV|Night Fae|REN|20|
-P Oribos|ACTIVE|59866|M|42.37,42.15|Z|The Maw|IZ|The Maw|NC|N|Hearth or Take the Waygate back to Oribos.|
-P Ring of Transference|ACTIVE|59866|M|52.07,57.86|Z|Ring of Fates@Oribos|IZ|Oribos|N|Take the portal to Ring of Transference.|COV|Night Fae|
-F Heart of the Forest|ACTIVE|59866|M|60.23,68.72|Z|Ring of Transference@Oribos|IZ|Oribos|N|Head to the flightmaster and take a flight to Heart of the Forest.|COV|Night Fae|
+P Oribos|ACTIVE|59866|M|42.37,42.15|Z|The Maw|IZ|1960|NC|N|Hearth or Take the Waygate back to Oribos.|
+P Ring of Transference|ACTIVE|59866|M|52.07,57.86|Z|Ring of Fates@Oribos|IZ|10565|N|Take the portal to Ring of Transference.|COV|Night Fae|
+F Heart of the Forest|ACTIVE|59866|M|60.23,68.72|Z|Ring of Transference@Oribos|IZ|10565|N|Head to the flightmaster and take a flight to Heart of the Forest.|COV|Night Fae|
 P The Canopy|ACTIVE|59866|M|53.96,38.73|Z|The Trunk@Heart of the Forest!Dungeon|QO|1|IZ|-1703|N|Talk to Sparkledew to go see the Queen.|COV|Night Fae|
 C Parting Ways|QID|59866|M|51.04,30.60|Z|The Canopy@Heart of the Forest!Dungeon|CHAT|N|Speak with the Winter Queen and deliver the Loa to her.|COV|Night Fae|
 P The Trunk|ACTIVE|59866|M|36.21,63.74|Z|The Canopy@Heart of the Forest!Dungeon|IZ|1703|N|Talk to Shimmerwing to return to teh main foyer.|COV|Night Fae|
@@ -955,8 +955,8 @@ C I Dreamed A Dream|QID|58995|M|45.22,65.31|Z|Ardenweald!The Shadowlands|QO|1|CH
 C I Dreamed A Dream|QID|58995|M|45.28,65.62|Z|Ardenweald!The Shadowlands|QO|2|NC|N|Click on the Vessel of Ardenweald.|COV|Kyrian|
 T I Dreamed A Dream|QID|58995|M|45.20,65.38|Z|Ardenweald!The Shadowlands|N|To Pelagos.|COV|Kyrian|
 A A Bittersweet Prize|QID|58997|PRE|58995|M|45.20,65.38|Z|Ardenweald!The Shadowlands|N|From Pelagos.|COV|Kyrian|
-R Heart of the Forest|ACTIVE|58997|M|49.25,52.02|Z|Ardenweald!The Shadowlands|N|Make your way to the Refugee Camp or Hearth back to Elysian Hold if you are bound there.|IZ|-Elysian Hold|COV|Kyrian|
-F Elysian Hold|ACTIVE|58997|M|49.25,52.02|Z|Ardenweald!The Shadowlands|N|Head to the flightmaster and take a flight to Elysian Hold.|IZ|-Elysian Hold|COV|Kyrian|
+R Heart of the Forest|ACTIVE|58997|M|49.25,52.02|Z|Ardenweald!The Shadowlands|N|Make your way to the Refugee Camp or Hearth back to Elysian Hold if you are bound there.|IZ|-1707|COV|Kyrian|
+F Elysian Hold|ACTIVE|58997|M|49.25,52.02|Z|Ardenweald!The Shadowlands|N|Head to the flightmaster and take a flight to Elysian Hold.|IZ|-1707|COV|Kyrian|
 T A Bittersweet Prize|QID|58997|M|55.36,42.31|Z|Archon's Rise@Elysian Hold!Dungeon|N|To Polemarch Adrestes.|COV|Kyrian|
 A Heart of the Crest|QID|61135|PRE|58997|M|55.36,42.31|Z|Archon's Rise@Elysian Hold!Dungeon|N|From Polemarch Adrestes.|COV|Kyrian|
 T Heart of the Crest|QID|61135|M|43.54,64.61|Z|Archon's Rise@Elysian Hold!Dungeon|N|To Vessel at the Crest.|COV|Kyrian|
@@ -1018,8 +1018,8 @@ T Her Will, Inflicted|QID|57124|M|25.66,65.29|Z|The Maw|N|To Uther, just outside
 A Time to Reflect|QID|57125|PRE|57124|M|25.66,65.29|Z|The Maw|N|From Uther.|COV|Kyrian|
 C Time to Reflect|QID|57125|M|25.66,65.29|Z|The Maw|QO|1|CHAT|N|Speak to Kleia, to Fly to the Waystone.|COV|Kyrian|
 C Oribos|QID|57125|M|42.39,42.19|Z|The Maw|QO|2|NC|N|Use the Waystone to Oribos.|COV|Kyrian|
-P Ring of Transference|ACTIVE|57125|M|51.98,58.39|Z|Ring of Fates@Oribos|IZ|-Elysian Hold|N|Take the portal to Ring of Transference.|COV|Kyrian|
-F Elysian Hold|ACTIVE|57125|M|60.26,68.26|Z|Ring of Transference@Oribos|IZ|-Elysian Hold|N|Head to the flightmaster and take a flight to Elysian Hold.|COV|Kyrian|
+P Ring of Transference|ACTIVE|57125|M|51.98,58.39|Z|Ring of Fates@Oribos|IZ|-1707|N|Take the portal to Ring of Transference.|COV|Kyrian|
+F Elysian Hold|ACTIVE|57125|M|60.26,68.26|Z|Ring of Transference@Oribos|IZ|-1707|N|Head to the flightmaster and take a flight to Elysian Hold.|COV|Kyrian|
 T Time to Reflect|QID|57125|M|55.48,42.49|Z|Archon's Rise@Elysian Hold!Dungeon|N|To Polemarch Adrestes.|COV|Kyrian|
 A A Touch of Humility|QID|62555|PRE|57125|M|55.48,42.49|Z|Archon's Rise@Elysian Hold!Dungeon|N|From Polemarch Adrestes.|COV|Kyrian|
 C A Touch of Humility|QID|62555|M|45.16,56.85|Z|Archon's Rise@Elysian Hold!Dungeon|CHAT|N|Tell Polemarch Adrestes, you are Ready to witness the empowering of the Crest of Ascension.|COV|Kyrian|
@@ -1032,8 +1032,8 @@ C Convene the Paragons|QID|58854|M|56.02,41.27|Z|Archon's Rise@Elysian Hold!Dung
 C Convene the Paragons|QID|58854|M|58.15,40.37|Z|Archon's Rise@Elysian Hold!Dungeon|QO|2;3|NC|N|Enter Archon's Rise, as the Paragons arrive, to plan an Assualt.|COV|Kyrian|
 T Convene the Paragons|QID|58854|M|55.51,42.47|Z|Archon's Rise@Elysian Hold!Dungeon|N|To Polemarch Adrestes.|COV|Kyrian|
 A Before the Dawn|QID|58844|PRE|58854|M|55.51,42.47|Z|Archon's Rise@Elysian Hold!Dungeon|N|From Polemarch Adrestes.|COV|Kyrian|
-F Aspirant's Rest|ACTIVE|58844|M|51.31,48.72|Z|Archon's Rise@Elysian Hold!Dungeon|QO|1|IZ|-The Temple of Purity|N|Head to the flightmaster and take a flight to Aspirant's Rest.\n\n Or you can use your gateway to go directly to the Temple of Purity if you have it unlocked.|COV|Kyrian|
-R Temple of Purity|ACTIVE|58844|M|60.04,73.49|Z|Bastion!The Shadowlands|QO|1|IZ|-The Temple of Purity|N|Run to the Temple of Purity.|COV|Kyrian|
+F Aspirant's Rest|ACTIVE|58844|M|51.31,48.72|Z|Archon's Rise@Elysian Hold!Dungeon|QO|1|IZ|-11014|N|Head to the flightmaster and take a flight to Aspirant's Rest.\n\n Or you can use your gateway to go directly to the Temple of Purity if you have it unlocked.|COV|Kyrian|
+R Temple of Purity|ACTIVE|58844|M|60.04,73.49|Z|Bastion!The Shadowlands|QO|1|IZ|-11014|N|Run to the Temple of Purity.|COV|Kyrian|
 C Before the Dawn|QID|58844|M|60.04,73.49|Z|Bastion!The Shadowlands|QO|1|CHAT|N|Click on the bells, to restore the vespers then talk to Eridia, the Watchers' are needed for Battle.|COV|Kyrian|
 P Xandria's Vigil|ACTIVE|58844|M|59.43,77.12|Z|Bastion!The Shadowlands|QO|2|N|Take the Gateway to Xandria's Vigil if you have it unlocked, otherwise skip this step, mount up and proceed.|COV|Kyrian|
 C Before the Dawn|QID|58844|M|41.25,56.25|Z|Bastion!The Shadowlands|QO|2|NC|N|Talk to Apolon, the Bearers are needed for Battle.|COV|Kyrian|
@@ -1401,8 +1401,8 @@ C Face Your Fears|QID|60996|M|20.48,22.88|Z|Bastion!The Shadowlands|QO|3|N|Kill 
 T Face Your Fears|QID|60996|M|21.11,22.86|Z|Bastion!The Shadowlands|N|To General Draven.|COV|Venthyr|
 A The Prince's New Crown|QID|59233|PRE|60996|M|21.11,22.86|Z|Bastion!The Shadowlands|N|From General Draven.|COV|Venthyr|REN|13|
 H Sinfall|ACTIVE|59233|M|PLAYER|Z|Bastion!The Shadowlands|N|Hearth back to Sinfall or get back there by any other means you have.|COV|Venthyr|
-C The Prince's New Crown|QID|59233|M|21.12,22.87|Z|Bastion!The Shadowlands|QO|1|CHAT|N|Speak to General Draven for a ride back down.|IZ|Bastion|COV|Venthyr|
-F Sinfall|ACTIVE|59233|M|44.07,32.45|Z|Bastion!The Shadowlands|N|Head to the flightmaster and take a flight to Sinfall.|IZ|Bastion|COV|Venthyr|
+C The Prince's New Crown|QID|59233|M|21.12,22.87|Z|Bastion!The Shadowlands|QO|1|CHAT|N|Speak to General Draven for a ride back down.|IZ|1533|COV|Venthyr|
+F Sinfall|ACTIVE|59233|M|44.07,32.45|Z|Bastion!The Shadowlands|N|Head to the flightmaster and take a flight to Sinfall.|IZ|1533|COV|Venthyr|
 T The Prince's New Crown|QID|59233|M|51.82,37.71|Z|Sinfall Reaches@Sinfall!Dungeon|N|To Prince Renathal.|COV|Venthyr|
 
 ; Chapter 7
@@ -1506,7 +1506,7 @@ A To the Estate|QID|57729|PRE|60183|M|61.60,69.65|Z|Revendreth|N|From Prince Ren
 T To the Estate|QID|57729|M|71.93,68.86|Z|Revendreth|N|To Prince Renathal.|COV|Venthyr|
 A The Tithelord|QID|57646|PRE|57729|M|71.93,68.86|Z|Revendreth|N|From Prince Renathal.|COV|Venthyr|REN|20|
 C The Tithelord|QID|57646|M|77.79,70.18|Z|Revendreth|QO|1|N|Fight the Tithelord, this is a 3 phase battle.\n\nRoughly every 1/3 of his health he will shield and run the toward his manor.\n\nOnce he's been killed, look the Medallion of Envy.|COV|Venthyr|
-N The Tithelord|ACTIVE|57646|M|77.38,70.32|Z|Revendreth|IZ|-Sinfall|QO|2|V|N|Hop on Clemency Enforcer Traal for a free ride back to Sinfall. This is quick and will basically teleport you back to your Sanctum.|COV|Venthyr|
+N The Tithelord|ACTIVE|57646|M|77.38,70.32|Z|Revendreth|IZ|-1699|QO|2|V|N|Hop on Clemency Enforcer Traal for a free ride back to Sinfall. This is quick and will basically teleport you back to your Sanctum.|COV|Venthyr|
 T The Tithelord|QID|57646|M|51.87,37.70|Z|Sinfall Reaches@Sinfall!Dungeon|N|To Prince Renathal.|COV|Venthyr|
 
 ; Sidequest Storyline - Mirror Maker of the Master - From Revendreth guide (this is a PRE for chapter 8 and is available to everyone regardless of covenant.)
@@ -1550,20 +1550,20 @@ N Renown Level 22|AVAILABLE|58406|N|You must reach Renown level 22 to continue t
 A Mirror to Maldraxxus|QID|58406|M|51.73,37.59|Z|Sinfall Reaches@Sinfall!Dungeon|N|From Prince Renathal.|PRE|57536|COV|Venthyr|REN|22|
 T Mirror to Maldraxxus|QID|58406|M|27.27,40.39|Z|Revendreth|N|Take the ramp and portal outside to the surface and make your way to Laurent.|COV|Venthyr|
 A The Medallion of Dominion|QID|58407|PRE|58406|M|27.42,40.34|Z|Revendreth|N|From General Draven.|COV|Venthyr|REN|22|
-P Maldraxxus|ACTIVE|58407|M|27.24,40.28|Z|Revendreth|IZ|Revendreth|N|Take the Portal to Maldraxxus.|COV|Venthyr|REN|22|
+P Maldraxxus|ACTIVE|58407|M|27.24,40.28|Z|Revendreth|IZ|1525|N|Take the Portal to Maldraxxus.|COV|Venthyr|REN|22|
 C Taking the Necropolis|ACTIVE|58407|M|74.10,34.84|Z|Maldraxxus!Instance1689|SO|1|N|Kill Necromancers until one discloses the location of Kel'Thuzad.|COV|Venthyr|
 C To the Skies!|ACTIVE|58407|M|73.62,33.80|Z|Maldraxxus!Instance1689|SO|2|N|Hop onto General Draven to assist him in clearing the skies of enemies.|COV|Venthyr|
 C Reanimating Your Allies|ACTIVE|58407|Z|Maldraxxus!Instance1689|SO|4|NC|N|Click on the giant crystals to reanimate your allies.|COV|Venthyr|
 C United in Battle|ACTIVE|58407|Z|Maldraxxus!Instance1689|SO|5|N|Use Action Ability "[color=40C7EB]Call General Draven[/color]" to help kill Maw Infernous.|EAB|COV|Venthyr|
-N Maldraxxus|ACTIVE|58407|M|68.52,30.02|Z|Maldraxxus!Instance1689|IZ|House of Rituals|SO|6;1|V|N|Jump onto the Stoneborn Legionnaire for a ride to the Necropolis.|COV|Venthyr|REN|22|
+N Maldraxxus|ACTIVE|58407|M|68.52,30.02|Z|Maldraxxus!Instance1689|IZ|13316|SO|6;1|V|N|Jump onto the Stoneborn Legionnaire for a ride to the Necropolis.|COV|Venthyr|REN|22|
 C The Medallion of Dominion|ACTIVE|58407|M|74.56,33.64|Z|Maldraxxus!Instance1689|SO|6;1|N|Fight Kel'Thuzad and recover the Medallion of Dominion.|COV|Venthyr|
 T The Medallion of Dominion|QID|58407|M|51.69,37.47|Z|Sinfall Reaches@Sinfall!Dungeon|N|To Prince Renathal.|COV|Venthyr|
 
 ;N Necrolord Campaign|QID|99999|M|PLAYER|N|Guide is currently in development please report any bugs or changes found to the Retail-Bug_reports channel in discord.|COV|Necrolord|
 ; Chapter 1
 A Taking The Seat|QID|58609|M|42.97,74.24|Z|Ring of Fates@Oribos|N|From Secutor Mevix.|COV|Necrolord|
-P Ring of Transference|ACTIVE|58609|M|52.08,57.83|Z|Ring of Fates@Oribos|N|Take the portal to Ring of Transference.|IZ|Oribos|COV|Necrolord|
-F Bleak Redoubt|ACTIVE|58609|M|60.91,68.62|Z|Ring of Transference@Oribos|N|Head to the flightmaster and take a flight to Bleak Redoubt.|IZ|Oribos|COV|Necrolord|
+P Ring of Transference|ACTIVE|58609|M|52.08,57.83|Z|Ring of Fates@Oribos|N|Take the portal to Ring of Transference.|IZ|10565|COV|Necrolord|
+F Bleak Redoubt|ACTIVE|58609|M|60.91,68.62|Z|Ring of Transference@Oribos|N|Head to the flightmaster and take a flight to Bleak Redoubt.|IZ|10565|COV|Necrolord|
 C Taking The Seat|QID|58609|M|60.91,68.62|Z|Ring of Transference@Oribos|QO|1|NC|N|Fly to the Bleak Redoubt in Maldraxxus.|COV|Necrolord|
 C Taking The Seat|QID|58609|M|51.28,20.15|Z|Seat of the Primus!Dungeon|QO|2|NC|N|Report to Baroness Draka in the Seat of the Primus.|COV|Necrolord|
 T Taking The Seat|QID|58609|M|49.52,21.86|Z|Seat of the Primus!Dungeon|N|To Baroness Draka.|COV|Necrolord|
@@ -1809,7 +1809,7 @@ T The Golden Dawn|QID|59894|M|50.39,70.56|Z|Maldraxxus|N|To Baroness Draka.|COV|
 
 ; Chapter 6
 A Machinations of War|QID|61586|PRE|59894|M|50.39,70.56|Z|Maldraxxus|N|From Baroness Draka.|COV|Necrolord|
-P Seat of the Primus|ACTIVE|61586|M|50.39,73.99|Z|Maldraxxus|IZ|Bleak Redoubt|N|Take the gate to Seat of the Primus.|COV|Necrolord|REN|-13|
+P Seat of the Primus|ACTIVE|61586|M|50.39,73.99|Z|Maldraxxus|IZ|11466|N|Take the gate to Seat of the Primus.|COV|Necrolord|REN|-13|
 C Renown Level 13|QID|61586|NC|N|You must reach Renown level 13 to continue to the next chapter.|COV|Necrolord|
 T Machinations of War|QID|61586|M|49.73,50.70|Z|Seat of the Primus!Dungeon|N|To Baroness Draka.|COV|Necrolord|
 A Take The Fight To Them|QID|61145|PRE|61586|M|49.73,50.70|Z|Seat of the Primus!Dungeon|N|From Baroness Draka.|COV|Necrolord|REN|13|

--- a/WoWPro_Leveling/Neutral/SL_Maldraxxus.lua
+++ b/WoWPro_Leveling/Neutral/SL_Maldraxxus.lua
@@ -39,13 +39,13 @@ T A Fresh Blade|QID|62738^63035|M|52.85,68.33|N|To Secutor Mevix.|TOF|
 A Rallying Maldraxxus|QID|62748|PRE|62738^63035|M|49.70,44.13|Z|Seat of the Primus!Dungeon|N|From Secutor Menvix.|TOF|COV|Necrolord|
 A Rallying Maldraxxus|QID|62748|PRE|62738^63035|N|From Secutor Menvix.|TOF|
 l Rallying Maldraxxus|QID|62748|QO|1|S!US|N|Literally everything you do in Maldraxxus counts towards this quest. You may [color=40C7EB]return[/color] to [color=40C7EB]Bleak Redoubt[/color] to turn in and be done with the zone anytime after this step closes.|TOF|
-t Rallying Maldraxxus|QID|62748|IZ|Seat of the Primus!Dungeon|M|49.70,44.13|Z|Seat of the Primus!Dungeon|N|To Secutor Mevix.|TOF|COV|Necrolord|
-t Rallying Maldraxxus|QID|62748|IZ|Bleak Redoubt|M|52.85,68.28|Z|Maldraxxus|N|To Secutor Mevix.|
+t Rallying Maldraxxus|QID|62748|IZ|1698|M|49.70,44.13|Z|Seat of the Primus!Dungeon|N|To Secutor Mevix.|TOF|COV|Necrolord|
+t Rallying Maldraxxus|QID|62748|IZ|11466|M|52.85,68.28|Z|Maldraxxus|N|To Secutor Mevix.|
 A Return to Oribos|QID|62761|M|52.85,68.28|Z|Maldraxxus|N|From Secutor Mevix.|PRE|62748|TOF|
 F Oribos|ACTIVE|62761|M|52.46,67.64|Z|Maldraxxus|N|At Wing Guard Buurkin|TOF|
-t Return to Oribos|QID|62761|M|38.93,69.97|Z|Ring of Fates@Oribos|N|To Tal-Inara.|IZ|Oribos|TOF|
+t Return to Oribos|QID|62761|M|38.93,69.97|Z|Ring of Fates@Oribos|N|To Tal-Inara.|IZ|10565|TOF|
 A The Next Step|QID|63208|M|38.93,69.97|Z|Ring of Fates@Oribos|PRE|62761|CCOUNT|1;62729;62761;62776;62779|N|From Tal-Inara.|TOF|
-C Tal-Inara|QID|63208|M|38.93,69.97|Z|Ring of Fates@Oribos|CHAT|N|Talk to Tal-Inara to choose your next zone and then turn that quest back into her.|IZ|Oribos|TOF|
+C Tal-Inara|QID|63208|M|38.93,69.97|Z|Ring of Fates@Oribos|CHAT|N|Talk to Tal-Inara to choose your next zone and then turn that quest back into her.|IZ|10565|TOF|
 T The Next Step|QID|63208|M|38.93,69.97|Z|Ring of Fates@Oribos|N|To Tal-Inara.|TOF|
 A Furthering the Purpose|QID|63209|M|38.93,69.97|Z|Ring of Fates@Oribos|PRE|62761&63208|CCOUNT|2;62729;62761;62776;62779|N|From Tal-Inara.|TOF|;after finishing 2nd zone
 C Tal-Inara|QID|63209|M|61.03,36.71|Z|Ring of Fates@Oribos|CHAT|N|Talk to Tal-Inara to choose your next zone.|TOF|
@@ -315,8 +315,8 @@ C A Deadly Distraction|QID|57987|M|31.04,25.95|Z|Maldraxxus|N|Kill Warstitched f
 R The Stitchyard|QID|57245|M|25.75,40.61|Z|Maldraxxus|N|We are leaving the area briefly for 3 quests, if you aren't finished, don't worry, we will be back.|RANK|2|LVL|60|;moving this to lvl 60, because run thru 11/21 showed these mobs not scaling. quest available at 54. but VERY difficult. leaving in, because that may change again.
 A Ani-Matter Animator|QID|57245|M|26.29,42.67|Z|Maldraxxus|N|From Snyder Sixfold.|RANK|2|LVL|60|
 C Ani-Matter Animator|QID|57245|M|25.87,45.94|Z|Maldraxxus|U|175827|S!US|N|Use the provided orb to animate the piles of bone remains scattered around the Ossein Foundry. You will find 4 types:\nLoyal-will fight with along beside you for about a minute.\nRecruitable - Chat with them to recruit them.\nStubborn - may offer one or more daily repeatable quests. They also may be recruitable.\nEnraged - hostile, will fight you for about 15 seconds then despawn.|
-;A Blade of Blades|QID|57284|M|PLAYER|Z|Maldraxxus|IZ|Ossein Foundry|N|From Stubborn Animate.|ACTIVE|57245|;commenting out, it appears its not always the same quests.
-;A Bring Me Their Heads|QID|57278|M|PLAYER|Z|Maldraxxus|IZ|Ossein Foundry|N|From Stubborn Animate. Don't worry if you didn't have time to accept all quests, you will get another chance on the next Stubborn Animate you find.|ACTIVE|57245|
+;A Blade of Blades|QID|57284|M|PLAYER|Z|Maldraxxus|IZ|12777|N|From Stubborn Animate.|ACTIVE|57245|;commenting out, it appears its not always the same quests.
+;A Bring Me Their Heads|QID|57278|M|PLAYER|Z|Maldraxxus|IZ|12777|N|From Stubborn Animate. Don't worry if you didn't have time to accept all quests, you will get another chance on the next Stubborn Animate you find.|ACTIVE|57245|
 C Blade of Blades|QID|57284|M|PLAYER|Z|Maldraxxus|S|NC|N|Pick up forgotten blades lying around.|ACTIVE|57245|
 C Bring Me Their Heads|QID|57278|M|31.27,45.27|Z|Maldraxxus|N|The Violent Animates have the best drop rate and can be found in the northwest part of the quest area.|ACTIVE|57245|
 K Zargox the Reborn|PRE|57245|M|28.95,51.33|Z|Maldraxxus|T|Zargox the Reborn|N|Ask Synder for Ani-Matter Orb, go to the bone at these coord.\nUse orb on pile of bones in center of platform.|RARE|ACH|14308;3|U|175827|LVL|60|

--- a/WoWPro_Leveling/Neutral/SL_Maw_Intro.lua
+++ b/WoWPro_Leveling/Neutral/SL_Maw_Intro.lua
@@ -6,7 +6,7 @@ WoWPro:GuideName(guide,"Shadowlands Intro - The Maw")
 WoWPro:GuideNextGuide(guide, 'Bastion')
 WoWPro:GuideSteps(guide, function()
 return [[
-R Orgrimmar|AVAILABLE|61874|IZ|-Orgrimmar|N|If you aren't in Orgrimmar, go there to get the starting quest.|FACTION|Horde|
+R Orgrimmar|AVAILABLE|61874|IZ|-85|N|If you aren't in Orgrimmar, go there to get the starting quest.|FACTION|Horde|
 A A Chilling Summons|QID|61874|Z|Orgrimmar|N|From Highlord Darion Mograine. Auto Accepted.|FACTION|Horde|LVL|48|
 C A Chilling Summons|QID|61874|M|50.38,76.58|Z|Orgrimmar|QO|1|CHAT|N|Speak with Nazgrim outside Grommash Hold and he will open a gate.|FACTION|Horde|
 C A Chilling Summons|QID|61874|M|49.16,78.13|Z|Orgrimmar|QO|2|NC|N|Enter the Death gate to Acherus.|FACTION|Horde|

--- a/WoWPro_Leveling/Neutral/SL_Revendreth.lua
+++ b/WoWPro_Leveling/Neutral/SL_Revendreth.lua
@@ -45,8 +45,8 @@ T Dark Aspirations|QID|62740|CS|M|61.12,59.05;61.4,60.4|Z|Revendreth|N|To Prince
 A Reinforcing Revendreth|QID|62778|PRE|62740^63037|M|PLAYER|Z|Revendreth|N|From Prince Renathal.|TOF|
 l Reinforcing Revendreth|QID|62778|QO|1|S!US|N|Literally everything you do in Revendreth counts towards this quest. You may [color=40C7EB]return[/color] to [color=40C7EB]Darkhaven[/color], or [color=40C7EB]Sinfall[/color] if you are a member of the Venthyr, to turn in and be done with the zone anytime after this step closes.|TOF|
 F Darkhaven|QID|60176|ACTIVE|62778|M|67.31,21.48|Z|Sinfall Reaches@Sinfall!Dungeon|N|Courier Snaggle (Flight Master) can be found in the room behind Prince Renathal.|TOF|COV|Venthyr|
-t Reinforcing Revendreth|QID|62778|CS|M|51.65,37.56|Z|Sinfall Reaches@Sinfall!Dungeon|IZ|Sinfall|N|To Prince Renathal.|TOF|COV|Venthyr|
-t Reinforcing Revendreth|QID|62778|CS|M|61.11,58.97;61.4,60.4|Z|Revendreth|IZ|Darkhaven|N|To Prince Renathal.|TOF|
+t Reinforcing Revendreth|QID|62778|CS|M|51.65,37.56|Z|Sinfall Reaches@Sinfall!Dungeon|IZ|10986|N|To Prince Renathal.|TOF|COV|Venthyr|
+t Reinforcing Revendreth|QID|62778|CS|M|61.11,58.97;61.4,60.4|Z|Revendreth|IZ|10979|N|To Prince Renathal.|TOF|
 A Return to Oribos|QID|62779|PRE|62778|M|PLAYER|Z|Revendreth|N|From Prince Renathal.|TOF|
 F Oribos|ACTIVE|62779|M|67.37,21.44|Z|Revendreth|N|At Courier Snaggle.|TOF|COV|Venthyr|
 F Oribos|ACTIVE|62779|M|60.50,60.64|Z|Revendreth|N|At Courier Rokalai|TOF|
@@ -162,7 +162,7 @@ T The Stoneborn|QID|57174|M|61.34,63.8|Z|Revendreth|N|To Mistress Mihaela.|MS|
 T The Toll of the Road|QID|60517|M|61.34,63.8|Z|Revendreth|N|To Mistress Mihaela.|
 A A Plea to the Harvesters|QID|58654|M|61.34,63.8|Z|Revendreth|N|From Mistress Mihaela.|LVL|57|PRE|57174|MS|
 A Bring Out Your Tithe|QID|60176|M|61.34,63.8|Z|Revendreth|N|From Mistress Mihaela.|RANK|2|
-A WANTED: The Pale Doom|QID|60279|M|62.20,63.45|Z|Revendreth|LVL|60|IZ|The Sinposium|N|From WANTED Poster.|ELITE|RANK|2|
+A WANTED: The Pale Doom|QID|60279|M|62.20,63.45|Z|Revendreth|LVL|60|IZ|13414|N|From WANTED Poster.|ELITE|RANK|2|
 C Bring Out Your Tithe|QID|60176|M|61.04,60.57|Z|Revendreth|NC|N|Collect the tithes of anima by interacting with villagers, and clicking on droplets on the ground.|S|
 A Reason for the Treason|QID|60177|M|62.26,61.33|Z|Revendreth|N|From Lajos.|RANK|2|
 f Darkhaven|ACTIVE|60177^58654|M|60.55,60.65|Z|Revendreth|N|Get flightpath from Courier Rokalai.|
@@ -560,7 +560,7 @@ C Mirror Making, Not Breaking|QID|57536|M|24.80,50.27|Z|Revendreth|QO|1|NC|N|Fol
 C Mirror Making, Not Breaking|QID|57536|M|24.80,50.27|Z|Revendreth|QO|2|CHAT|N|Speak to Laurent to let him begin.|
 C Mirror Making, Not Breaking|QID|57536|M|24.80,50.27|Z|Revendreth|QO|3|N|Kill waves of enemies, defending Laurent and Simone.|
 T Mirror Making, Not Breaking|QID|57536|M|24.80,50.27|Z|Revendreth|N|To Laurent.|
-P Sanctuary of the Mad|ACTIVE|60275^60276|M|24.80,50.27|Z|Revendreth|N|Walk thru the mirror for a quick trip to Sanctuary of the Mad.|IZ|The Shrouded Asylum|
+P Sanctuary of the Mad|ACTIVE|60275^60276|M|24.80,50.27|Z|Revendreth|N|Walk thru the mirror for a quick trip to Sanctuary of the Mad.|IZ|10987|
 T WANTED: Enforcer Kristof|QID|60275|M|30.71,49.12|Z|Revendreth|N|To Dispatcher Raluca. Up the stairs, outside.|
 T WANTED: Summoner Marcelis|QID|60276|M|30.81,49.12|Z|Revendreth|N|To Dispatcher Raluca. Up the stairs, outside.|
 $ Makeshift Muckpool|QID|62198|CS|M|28.2,38.0;29.7,37.2|Z|Revendreth|LVL|60|N|Up path to get to upper floor of Ruins at Ember Ward, need 30 Infused Ruby to loot.|ACH|14314;6|


### PR DESCRIPTION
With the code change to accept subzone IDs, converted all existing guides that used text names to use IDs.