### PR TITLE
Allow comment to Z tag and zone in RegisterGuide

### DIFF
--- a/WoWPro/WoWPro.lua
+++ b/WoWPro/WoWPro.lua
@@ -1,5 +1,5 @@
 -- luacheck: globals _NPCScan
--- luacheck: globals pairs ipairs tinsert tremove sort
+-- luacheck: globals select pairs ipairs tinsert tremove sort
 -- luacheck: globals tostring tonumber
 -- luacheck: globals date type max min coroutine
 -- luacheck: globals debugstack debuglocals geterrorhandler seterrorhandler

--- a/WoWPro/WoWPro.lua
+++ b/WoWPro/WoWPro.lua
@@ -740,7 +740,7 @@ function WoWPro:RegisterGuide(GIDvalue, gtype, zonename, authorname, faction, re
 
     local guide = {
         guidetype = gtype,
-        zone = zonename,
+        zone = select(1, (";"):split(zonename)),
         author = authorname,
         faction = faction,
         name = name,

--- a/WoWPro/WoWPro_Parser.lua
+++ b/WoWPro/WoWPro_Parser.lua
@@ -573,6 +573,9 @@ function WoWPro.ParseQuestLine(faction, zone, i, text)
     if WoWPro.action[i] == "h" then
         WoWPro.step[i] = L[WoWPro.step[i]]
     end
+	if WoWPro.zone[i] then
+		WoWPro.zone[i] = select(1, (";"):split(WoWPro.zone[i]))
+	end
     WoWPro.zone[i] = WoWPro.zone[i] or (WoWPro.map[i] and zone)
     if WoWPro.zone[i] and WoWPro.map[i] and not WoWPro:ValidZone(WoWPro.zone[i]) then
         WoWPro:Error("Step %s [%s] has a bad ¦Z¦%s¦ tag.",WoWPro.action[i],WoWPro.step[i],WoWPro.zone[i])


### PR DESCRIPTION
Gave the Z tag and zone area of RegisterGuide the ability to add the ; to add a text based comment after an ID.

|Z|1455;Ironforge||