### PR TITLE
Update VAN_BCC_30_40_HordeChapter2.lua

### DIFF
--- a/WoWPro_Leveling/Classic_BC/Horde/VAN_BCC_30_40_HordeChapter2.lua
+++ b/WoWPro_Leveling/Classic_BC/Horde/VAN_BCC_30_40_HordeChapter2.lua
@@ -8,13 +8,11 @@ WoWPro:GuideNextGuide(guide, 'CLASSIC_BC_HordeChapter3')
 WoWPro:GuideSteps(guide, function()
 return [[
 
-N Welcome!|QID|5881|N|This is a new guide written by TheRealHendo. It is currently a work-in-progress.\nIf you find a problem, please report it on Discord in #classic-bug-reports .  Enjoy and thanks!|
-
-F Thunder Bluff|QID|1195|M|45.50,63.84|Z|Orgrimmar|
-T The Sacred Flame|QID|1195|M|54.74,51.41|Z|Thunder Bluff|N|To Zangen Stonehoof.|
-A The Sacred Flame|QID|1195|M|54.74,51.41|Z|Thunder Bluff|N|To Zangen Stonehoof.|
-F Camp Taurajo|QID|5881|M|47.02,49.83|Z|Thunder Bluff|
-A A New Ore Sample|QID|1153|M|45.10,57.73|Z|The Barrens|N|From Tatternack Steelforge.|
+F Thunder Bluff|ACTIVE|1195|M|45.50,63.84|Z|Orgrimmar|
+T The Sacred Flame|QID|1195|M|54.94,51.42|Z|Thunder Bluff|N|To Zangen Stonehoof.|
+A The Sacred Flame|QID|1196|M|54.94,51.42|Z|Thunder Bluff|N|From Zangen Stonehoof.|PRE|1195|
+F Camp Taurajo|AVAILABLE|1153|M|47.02,49.83|Z|Thunder Bluff|
+A A New Ore Sample|QID|1153|M|45.10,57.73|Z|The Barrens|N|From Tatternack Steelforge.|PRE|893|
 R The Great Lift|ACTIVE|5881|M|32.23,20.46|Z|Thousand Needles|N|Leave Camp Taurajo through the east gate and follow the Southern Gold Road south to the bottom of The Barrens.|
 T Calling in the Reserves|QID|5881|M|31.87,21.65|N|To Grish Longrunner.|
 A Message to Freewind Post|QID|4542|M|32.22,22.11|N|From Brave Moonhorn.|


### PR DESCRIPTION
- removed Welcome note
- `A The Sacred Flame|QID|1195|` is wrong. Corrected C&P error.
-  `A A New Ore Sample|QID|1153|` step missing PRE