### PR TITLE
Update VAN_BCC_30_40_HordeChapter2.lua

### DIFF
--- a/WoWPro_Leveling/Classic_BC/Horde/VAN_BCC_30_40_HordeChapter2.lua
+++ b/WoWPro_Leveling/Classic_BC/Horde/VAN_BCC_30_40_HordeChapter2.lua
@@ -164,29 +164,30 @@ A Alliance Relations|QID|1432|M|22.28,53.92|Z|Orgrimmar|N|From Keldran.|PRE|1431
 
 ; --- Thousand Needles
 F Freewind Post|ACTIVE|1146|M|45.50,63.84|Z|Orgrimmar|
-T The Swarm Grows|QID|1146|M|67.59,63.93|N|To Moktar Krin in Ironstone Camp, on the edge of the Shimmering Flats. Just follow the road to the east and you'll find him. \nYou'll get to a point where the road veers left. Stick to the right and follow the canyon wall from here.|
+R Ironstone Camp|ACTIVE|1146|M|67.72,63.73|N|It's located on the edge of the Shimmering Flats. Follow the road to the east and you'll find it.\n[color=FF0000]NOTE: [/color]You'll get to a point where the road veers left. Stick to the right and follow the canyon wall from here.|
+T The Swarm Grows|QID|1146|M|67.59,63.93|N|To Moktar Krin.|
 A The Swarm Grows|QID|1147|M|67.59,63.93|N|From Moktar Krin.|
-R Mirage Raceway|AVAILABLE|1104^1105^1110^1111^1175^1176|N|Make your way across the Flats to the Mirage Raceway in the middle of it.|
-A Rocket Car Parts|QID|1110|M|77.76,77.25|N|From Kravel Koalbeard.|
-A Wharfmaster Dizzywig|QID|1111|M|77.76,77.25|N|From Kravel Koalbeard.|
-A Salt Flat Venom|QID|1104|M|78.01,77.14|N|From Fizzle Brassbolts.|
-A Hardened Shells|QID|1105|M|78.08,77.12|N|From Wizzle Brassbolts.|
-A Load Lightening|QID|1176|M|80.13,75.84|N|From Pozzik.|
-A A Bump in the Road|QID|1175|M|81.59,77.85|N|From Trackmaster Zherin.|
-r Repair/Restock|QID|1175|M|80.46,76.98|N|At Synge. You've just picked up a number of collection quests. It would be in your best interest to make as much bag space as feasible.|
-N Mob Location|ACTIVE|1104^1105^1110^1111^1175^1176|N|All of the mobs involved in the quests you just picked up are scattered around the outside of Mirage Raceway.\nThere is no real dividing line between levels. You'll find lv 30s mixed with lv 35s.|
-C Salt Flat Venom|QID|1104|N|Kill Scorpids to collect them.\nYou'll find the Reavers (lv 31-32) in the north and the Terrors (33-34) in the south.|S|
-C Hardened Tortoise Shell|QID|1105|N|Kill any variety of Sparkleshell tortoises to collect them.\nYou'll find the Tortoise (lv 30-31) in the NW quadrant, the Borer (32-33) in the SE quadrant and the Snapper (34-35) in the NE quadrant.|S|
-C Hollow Vulture Bone|QID|1176|N|Kill Salt Flats Vultures/Scavengers to collect them.\nYou'll find the lower level Scavengers (lv 30-32) in the north and the Vultures (32-34) in the south.|S|
-l Rocket Car Parts|ACTIVE|1110|L|5798 30|N|You'll find these scattered on the ground in Shimmering Flats.|S|
-K A Bump in the Road|ACTIVE|1175|QO|3;2;1|N|You'll find the Basilisks (lv 30-31) in the NW quadrant, the Crystalhides (32-33) all over, and the Gazers (34-35) in the SE quadrant.|
+R Mirage Raceway|AVAILABLE|1104^1105^1110^1111^1175^1176|M|80.34,77.10|N|Make your way east across the Shimmering Flats to the Mirage Raceway in the middle of it.\n[color=FF0000]NOTE: [/color]Avoid fighting if possible. Save the kills for when they count.|
+A Rocket Car Parts|QID|1110|M|77.79,77.27|N|From Kravel Koalbeard.|
+A Wharfmaster Dizzywig|QID|1111|M|77.79,77.27|N|From Kravel Koalbeard.|
+A Salt Flat Venom|QID|1104|M|78.06,77.13|N|From Fizzle Brassbolts.|
+A Hardened Shells|QID|1105|M|78.15,77.12|N|From Wizzle Brassbolts.|
+A Load Lightening|QID|1176|M|80.18,75.89|N|From Pozzik.|
+A A Bump in the Road|QID|1175|M|81.63,77.95|N|From Trackmaster Zherin.|
+r Repair/Restock|ACTIVE|1175|M|80.40,77.01|N|At Synge.\n[color=FF0000]NOTE: [/color]You've just picked up a number of collection quests. It would be in your best interest to free up as much bag space as feasible.|
+N Mob Location|ACTIVE|1104^1105^1110^1111^1175^1176|N|All of the mobs involved in the quests you just picked up are scattered around the outside of Mirage Raceway.\nThere is no real dividing line between levels. You'll find lv 30s mixed with lv 35s.\nAs they are spread out, there are no specific coordinates for each item and no arrow.\n[color=FF0000]NOTE: [/color]Manually check this step off to continue.|
+C Salt Flat Venom|QID|1104|L|5794 6|N|You'll find the Reavers (lv 31-32) in the north and the Terrors (33-34) in the south.|S|
+C Hollow Vulture Bone|QID|1176|L|5848 10|N|You'll find the Scavengers (30-32) in the north and the Vultures (32-34) in the south.|S|
+C Rocket Car Parts|QID|1110|L|5798 30|N|You'll find these scattered on the ground in Shimmering Flats.|S|
+K A Bump in the Road|ACTIVE|1175|QO|3;2;1|N|You'll find the Basilisks (lv 30-31) in the NW quadrant, the Crystalhides (32-33) all over, and the Gazers (34-35) in the SE quadrant.|S|
+C Hardened Tortoise Shell|QID|1105|M|82.37,54.62|L|5795 9|N|Kill any variety of Sparkleshell tortoises.|
 ;L Level 33|QID|1147|N|You should be around level 33 by this point.|LVL|33|
 A Parts of the Swarm|QID|1148|N|Click the Cracked Silithid Carapace to activate the quest.|U|5877|PRE|
 * Extra Cracked Silithid Carapace|AVAILABLE|-1148|N|Dispose of these if you pick up anymore.|U|5877|O|
 C Parts of the Swarm|QID|1148|L|5855 1|N|Kill Silithids to collect a Silithid Heart.|S|
 C Parts of the Swarm|QID|1148|L|5854 5|N|Kill Silithids to collect Silithid Talons.|S|
 C Parts of the Swarm|QID|1148|L|5853 3|N|Kill Silithids to collect Intact Silithid Carapaces.|S|
-K The Swarm Grows|ACTIVE|1147|M|71.33,83.15;66.52,86.15|CN|QO|1;2;3|N|At the Rustmaul Dig Site in the south, kill Silithid Searchers, Hive Drones, and Invaders.\nYou'll find the Drones spread out around the area. The Searchers can be around the outside edge of the pit. The Invaders are inside the hive. There are two entrances into the hive.\n[color=FF0000]NOTE: [/color]The drones are non-aggressive as long as you don't attack them or any mobs around them. Do not leave them roaming inside the hive; you will die from being overwhelmed.|
+K The Swarm Grows|ACTIVE|1147|M|71.33,83.15;66.52,86.15|CN|QO|1;2;3|N|At the Rustmaul Dig Site in the south, kill Silithid Searchers, Hive Drones, and Invaders.\n[color=FF0000]NOTE: [/color]You'll find the Drones spread out around the area. The Searchers can be around the outside edge of the pit. The Invaders are inside the hive. There are two entrances into the hive.\n[color=FF0000]NOTE: [/color]The drones are non-aggressive as long as you don't attack them or any mobs around them. Do not leave them roaming inside the hive; you will die from being overwhelmed.|
 C Parts of the Swarm|QID|1148|L|5855 1|N|Kill Silithids to collect a Silithid Heart.|US|
 C Parts of the Swarm|QID|1148|L|5854 5|N|Kill Silithids to collect Silithid Talons.|US|
 C Parts of the Swarm|QID|1148|L|5853 3|N|Kill Silithids to collect Intact Silithid Carapaces.|US|
@@ -271,7 +272,7 @@ A The Corrupter|QID|1480|N|Click on the Flayed Demon Skin to start the quest.\nT
 ; --- destroy excess quest starter item
 * Excess Flayed Demon Skin|AVAILABLE|-1480|N|Once you've accepted the quest, you no longer need to loot these items. If you loot any more, safely destroy them.|U|20310|
 ;L Level 34|QID|1107|N|You should be around level 34 by this point.|
-C Sceptre of Light|QID|5741|M|55.17,30.09|Z|Desolace|N|Head north into Thunder Axe Fortress and kill the Burning Blade Seer to loot the Sceptre of Light.\nYou'll find the Seer at the top of the Watchtower just inside the entrance. He has 2 Felsworn standing guard outside and an Augur inside with him. You can easily pull the outside guards one at a time.|
+C Sceptre of Light|QID|5741|M|55.17,30.09|Z|Desolace|N|Head north into Thunder Axe Fortress and kill the Burning Blade Seer to loot the Sceptre of Light.\n[color=FF0000]NOTE: [/color]You'll find the Seer at the top of the Watchtower just inside the entrance. He has 2 Felsworn standing guard outside and an Augur inside with him. You can easily pull the outside guards one at a time.|
 l The Burning of Spirits|QID|1435|L|6435 15|U|6436|N|Finish collecting the Infused Burning Gems.|US|
 T Sceptre of Light|QID|5741|M|38.89,27.19|Z|Desolace|N|Make your way west back to Azore Aldamort in Ethel Rethor.|
 A Book of the Ancients|QID|6027|M|38.89,27.19|Z|Desolace|N|From Azore Aldamort.|
@@ -582,7 +583,7 @@ R Circle of Outer Binding|ACTIVE|651|N|Head SW to the next ring of stones.\nYou'
 C Stone of Outer Binding|QID|651|M|52.00,50.74|Z|Arathi Highlands|L|4485|N|Go slow and try pulling 1 at a time. Once you have cleared the center stone, click on it to loot the Thundering Key.|
 C Guile of the Raptor|QID|701|L|4513 12|N|Loot 12 Raptor Hearts from Highland Fleshstalkers.|S|
 R Boulderfist Hall|ACTIVE|678|M|51.78,73.59|Z|Arathi Highlands|N|Head south to Boulderfist Hall.|
-C Call to Arms|QID|678|QO|1;2|N|Kill 10 Boulderfist Brutes and 4 Boulderfist Magi.\nYou'll find more inside the first cave. The second cave (the one set further back) is empty right now.|
+C Call to Arms|QID|678|QO|1;2|N|Kill 10 Boulderfist Brutes and 4 Boulderfist Magi.\n[color=FF0000]NOTE: [/color]You'll find more inside the first cave. The second cave (the one set further back) is empty right now.|
 C Guile of the Raptor|QID|701|L|4513 12|N|Finish looting 12 Raptor Hearts from Highland Fleshstalkers.\nWith a drop rate of 33%, this could take some time.|US|
 R Hammerfall|ACTIVE|701|M|71.23,42.77|Z|Arathi Highlands|N|Head back to Hammerfall.|
 T Guile of the Raptor|QID|701|M|74.72,36.28|Z|Arathi Highlands|N|To Tor'gan.|
@@ -652,7 +653,7 @@ R Main Road|ACTIVE|1202|M|39.14,37.96|Z|Dustwallow Marsh|CC|N|Exit Brackenwall f
 R North Point Tower|AVAILABLE|1218|M|46.43,22.88|Z|Dustwallow Marsh|N|Follow the main road north/east to the North Point Tower.\n[color=FF0000]NOTE: [/color]Sticking to the road is your best bet. You'll find several mobs to kill along the way.|
 R Witch Hill|AVAILABLE|1218|M|50.88,25.01|Z|Dustwallow Marsh|N|Continue along the road to the Witch Hill.|
 R Swamplight Manor|AVAILABLE|1218|M|55.17,26.96|Z|Dustwallow Marsh|N|Continue east to the Swamplight Manor. There is a road leading north from the main road to the house.|
-A Soothing Spices|QID|1218|M|55.43,26.26|Z|Dustwallow Marsh|N|From "Swamp Eye" Jarl.|
+A Marsh Frog Legs|QID|1218|M|55.43,26.26|Z|Dustwallow Marsh|N|From "Swamp Eye" Jarl.|
 A The Lost Report|QID|1238|M|55.44,25.92|Z|Dustwallow Marsh|N|From the dirt pile beside the house.|
 C Hungry!|QID|1177|M|57.27,22.46|Z|Dustwallow Marsh|N|Kill Mirefin Murlocs to collect the Mirefin Heads.|S|
 R Dreadmurk Shore|ACTIVE|1202|M|57.85,19.01|Z|Dustwallow Marsh|N|Make your way to the Dreadmurk Shore.|

--- a/WoWPro_Leveling/Classic_BC/Horde/VAN_BCC_30_40_HordeChapter2.lua
+++ b/WoWPro_Leveling/Classic_BC/Horde/VAN_BCC_30_40_HordeChapter2.lua
@@ -8,12 +8,17 @@ WoWPro:GuideNextGuide(guide, 'CLASSIC_BC_HordeChapter3')
 WoWPro:GuideSteps(guide, function()
 return [[
 
+; --- Thunder Bluff
 F Thunder Bluff|ACTIVE|1195|M|45.50,63.84|Z|Orgrimmar|
 T The Sacred Flame|QID|1195|M|54.94,51.42|Z|Thunder Bluff|N|To Zangen Stonehoof.|
 A The Sacred Flame|QID|1196|M|54.94,51.42|Z|Thunder Bluff|N|From Zangen Stonehoof.|PRE|1195|
 l Maggran's Reserve Letter|ACTIVE|5881|L|16189|N|You need this to turn in the quest.\n[color=FF0000]NOTE: [/color]Go grab it or you'll have to get a replacement from Maggran Earthbinder in Thunder Bluff.|
+
+; --- The Barrens
 F Camp Taurajo|AVAILABLE|1153|M|47.02,49.83|Z|Thunder Bluff|
 A A New Ore Sample|QID|1153|M|45.10,57.69|Z|The Barrens|N|From Tatternack Steelforge.|PRE|893|
+
+; --- Thousand Needles
 R The Great Lift|ACTIVE|5881|M|32.23,20.46|Z|Thousand Needles|N|Leave Camp Taurajo and follow the Southern Gold Road south to the bottom of The Barrens.|
 T Calling in the Reserves|QID|5881|M|31.87,21.65|N|To Grish Longrunner.|
 A Message to Freewind Post|QID|4542|M|32.24,22.17|N|From Brave Moonhorn.\n[color=FF0000]NOTE: [/color]If he's not here, check the bottom of The Great Lift or wait for him to respawn because he's dead.|
@@ -144,10 +149,10 @@ A Test of Lore|QID|6627|M|78.79,45.67|Z|Stonetalon Mountains|N|From Braug Dimspi
 C Test of Lore|QID|6627|M|78.79,45.67|Z|Stonetalon Mountains|N|Answer Braug Dimspirit's question with #2 Neltharion.|CHAT|
 T Test of Lore|QID|6627|M|78.79,45.67|Z|Stonetalon Mountains|N|To Braug Dimspirit.|
 A Test of Lore|QID|1159|M|78.79,45.67|Z|Stonetalon Mountains|N|From Braug Dimspirit.|PRE|6627|
-H Freewind Post|AVAILABLE|1145|N|This is much faster than running back to Sun Rock Retreat.\n[color=FF0000]NOTE: [/color]If your hearth is on CD, skip this step.|
-R Sun Rock Retreat|AVAILABLE|1145|M|49.58,60.99|Z|Stonetalon Mountains|N|Unfortunately, you have no choice but to foot it to Sun Rock Retreat.|IZ|1442;Stonetalon Mountains|
 
 ; --- The Barrens/Orgrimmar
+H Freewind Post|AVAILABLE|1145|N|This is much faster than running back to Sun Rock Retreat.\n[color=FF0000]NOTE: [/color]If your hearth is on CD, skip this step.|
+R Sun Rock Retreat|AVAILABLE|1145|M|49.58,60.99|Z|Stonetalon Mountains|N|Unfortunately, you have no choice but to foot it to Sun Rock Retreat.|IZ|1442;Stonetalon Mountains|
 F Crossroads|AVAILABLE|1145|M|45.12,59.84|Z|Stonetalon Mountains|IZ|1442;Stonetalon Mountains|
 F Crossroads|AVAILABLE|1145|M|45.14,49.10|IZ|1441;Thousand Needles|
 A The Swarm Grows|QID|1145|M|51.07,29.63|Z|The Barrens|N|From Korran.|
@@ -175,85 +180,109 @@ A Hardened Shells|QID|1105|M|78.15,77.12|N|From Wizzle Brassbolts.|
 A Load Lightening|QID|1176|M|80.18,75.89|N|From Pozzik.|
 A A Bump in the Road|QID|1175|M|81.63,77.95|N|From Trackmaster Zherin.|
 r Repair/Restock|ACTIVE|1175|M|80.40,77.01|N|At Synge.\n[color=FF0000]NOTE: [/color]You've just picked up a number of collection quests. It would be in your best interest to free up as much bag space as feasible.|
-N Mob Location|ACTIVE|1104^1105^1110^1111^1175^1176|N|All of the mobs involved in the quests you just picked up are scattered around the outside of Mirage Raceway.\nThere is no real dividing line between levels. You'll find lv 30s mixed with lv 35s.\nAs they are spread out, there are no specific coordinates for each item and no arrow.\n[color=FF0000]NOTE: [/color]Manually check this step off to continue.|
-C Salt Flat Venom|QID|1104|L|5794 6|N|You'll find the Reavers (lv 31-32) in the north and the Terrors (33-34) in the south.|S|
-C Hollow Vulture Bone|QID|1176|L|5848 10|N|You'll find the Scavengers (30-32) in the north and the Vultures (32-34) in the south.|S|
-C Rocket Car Parts|QID|1110|L|5798 30|N|You'll find these scattered on the ground in Shimmering Flats.|S|
-K A Bump in the Road|ACTIVE|1175|QO|3;2;1|N|You'll find the Basilisks (lv 30-31) in the NW quadrant, the Crystalhides (32-33) all over, and the Gazers (34-35) in the SE quadrant.|S|
+N Mob Location|ACTIVE|1104^1105^1110^1175^1176|N|All of the mobs involved in the quests you just picked up are scattered around the Shimmering Flats.\nThere is no real dividing line between levels. You'll find lv 30s mixed with lv 35s.\n[color=FF0000]NOTE: [/color]Manually check this step off to continue.|
+C Salt Flat Venom|QID|1104|L|5794 6|N|The Reavers (lv 31-32) are in the north and the Terrors (33-34) in the south.|S|
+C Rocket Car Parts|QID|1110|L|5798 30|N|Pick these up as you see them.|S|
+K A Bump in the Road|ACTIVE|1175|QO|3;2;1|N|The Basilisks (lv 30-31) are in the NW quadrant, the Crystalhides (32-33) all over, and the Gazers (34-35) in the SE quadrant.|S|
+C Hollow Vulture Bone|QID|1176|M|87.82,65.57|L|5848 10|N|Kill Scavengers (30-32) Vultures (32-34) to loot these.\n[color=FF0000]NOTE: [/color]The 6 Scavengers at this location have a respawn timer of 10 minutes.|
+l Turtle Meat|AVAILABLE|7321|L|3712 10|N|Kill turtles to loot the Turtle Meat for a quest later.|S|
 C Hardened Tortoise Shell|QID|1105|M|82.37,54.62|L|5795 9|N|Kill any variety of Sparkleshell tortoises.|
+l Turtle Meat|AVAILABLE|7321|M|82.37,54.62|L|3712 10|N|Finish collecting the Turtle Meat.\n[color=FF0000]NOTE: [/color]The drop rate is @30% or 1 in 3 kills.|US|
+K A Bump in the Road|ACTIVE|1175|M|73.85,57.34|QO|1|N|Kill the Basilisks. Kill any Crystalhides you come across.|US|
+K A Bump in the Road|ACTIVE|1175|M|77.54,67.81|QO|2|N|Kill the Crystalhides.|
+r Repair/Restock|ACTIVE|1175|M|80.40,77.01|N|While you're in the area, visit Synge.|
+K A Bump in the Road|ACTIVE|1175|M|78.94,87.57|QO|3|N|Kill the Gazers.|
 ;L Level 33|QID|1147|N|You should be around level 33 by this point.|LVL|33|
 A Parts of the Swarm|QID|1148|N|Click the Cracked Silithid Carapace to activate the quest.|U|5877|PRE|
 * Extra Cracked Silithid Carapace|AVAILABLE|-1148|N|Dispose of these if you pick up anymore.|U|5877|O|
-C Parts of the Swarm|QID|1148|L|5855 1|N|Kill Silithids to collect a Silithid Heart.|S|
-C Parts of the Swarm|QID|1148|L|5854 5|N|Kill Silithids to collect Silithid Talons.|S|
-C Parts of the Swarm|QID|1148|L|5853 3|N|Kill Silithids to collect Intact Silithid Carapaces.|S|
-K The Swarm Grows|ACTIVE|1147|M|71.33,83.15;66.52,86.15|CN|QO|1;2;3|N|At the Rustmaul Dig Site in the south, kill Silithid Searchers, Hive Drones, and Invaders.\n[color=FF0000]NOTE: [/color]You'll find the Drones spread out around the area. The Searchers can be around the outside edge of the pit. The Invaders are inside the hive. There are two entrances into the hive.\n[color=FF0000]NOTE: [/color]The drones are non-aggressive as long as you don't attack them or any mobs around them. Do not leave them roaming inside the hive; you will die from being overwhelmed.|
-C Parts of the Swarm|QID|1148|L|5855 1|N|Kill Silithids to collect a Silithid Heart.|US|
-C Parts of the Swarm|QID|1148|L|5854 5|N|Kill Silithids to collect Silithid Talons.|US|
-C Parts of the Swarm|QID|1148|L|5853 3|N|Kill Silithids to collect Intact Silithid Carapaces.|US|
-l Turtle Meat|QID|1105|L|3712 10|N|Keep 10 pieces of Turtle Meat. You will need these for a quest much later in this guide.|
-T A Bump in the Road|QID|1175|M|81.63,78.08|N|To Trackmaster Zherin.|
-T Load Lightening|QID|1176|M|80.11,75.83|N|To Pozzik.|
-A Goblin Sponsorship|QID|1178|M|80.11,75.83|N|From Pozzik.|PRE|1176|
-T Salt Flat Venom|QID|1104|M|78.08,77.04|N|To Fizzle Brassbolts\nNOTE: Do not accept 'Martek the Exiled' (Breadcrumb to the Badlands)|
-T Hardened Shells|QID|1105|M|78.14,77.08|N|To Wizzle Brassbolts.|
-A Encrusted Tail Fins|QID|1107|M|78.14,77.08|ELITE|N|[color=FF8000]Elite: [/color]\nFrom Wizzle Brassbolts.|PRE|1104&1105|
-T Rocket Car Parts|QID|1110|M|77.8,77.2|Z|Thousand Needles|N|To Kravel Koalbeard.|
-A Hemet Nesingwary Jr.|QID|5762|M|77.84,77.22|N|From Kravel Koalbeard.|
-T The Swarm Grows|QID|1147|M|67.59,63.93|N|To Moktar Krin.|
+l Parts of the Swarm|ACTIVE|1148|QO|1;2;3|N|Kill Silithids to collect the items.|S|
+N The Swarm Grows|ACTIVE|1147|N|The Searchers are around the outside edge of the pit. The Invaders are inside the hive. The Drones are spread around the area and non-aggressive as long as you don't attack them or any mobs around them. If you leave them roaming inside the hive; you will die from being overwhelmed.\n[color=FF0000]NOTE: [/color]Manually check this step off to continue.|
+K The Swarm Grows|ACTIVE|1147|M|71.33,83.15;66.52,86.15|CN|QO|1;2;3|N|At the Rustmaul Dig Site in the south, kill Silithid Searchers, Hive Drones, and Invaders.|
+C Parts of the Swarm|QID|1148|QO|1;2;3|N|Kill Silithids to collect the items.|US|
+C Rocket Car Parts|QID|1110|L|5798 30|N|Leave Rustmaul Dig Site heading north and begin a clockwise circle around Shimmering Flats looking for the vultures.\n[color=FF0000]NOTE: [/color]This shouldn't take long to complete.|US|
+T A Bump in the Road|QID|1175|M|81.63,77.95|N|To Trackmaster Zherin.|
+T Load Lightening|QID|1176|M|80.18,75.89|N|To Pozzik.|
+A Goblin Sponsorship|QID|1178|M|80.18,75.89|N|From Pozzik.|PRE|1176|
+T Salt Flat Venom|QID|1104|M|78.06,77.13|N|To Fizzle Brassbolts\nNOTE: Do not accept 'Martek the Exiled' (Breadcrumb to the Badlands)|
+T Hardened Shells|QID|1105|M|78.15,77.12|N|To Wizzle Brassbolts.|
+A Encrusted Tail Fins|QID|1107|M|78.15,77.12|ELITE|N|[color=FF8000]Elite: [/color]\nFrom Wizzle Brassbolts.|PRE|1104&1105|
+T Rocket Car Parts|QID|1110|M|77.79,77.27|Z|Thousand Needles|N|To Kravel Koalbeard.|
+A Hemet Nesingwary Jr.|QID|5762|M|77.79,77.27|N|From Kravel Koalbeard.|
+T The Swarm Grows|QID|1147|M|67.59,63.93|N|To Moktar Krin in Ironstone Camp.|
 R Freewind Post|AVAILABLE|5361|M|47.63,49.04|N|Run back to Freewind and take the lift up.|
 A Family Tree|QID|5361|M|45.66,50.79|N|From Cliffwatcher Longhorn.|
 
 ; --- The Barrens/Orgrimmar
-F The Crossroads|ACTIVE|1148|M|45.14,49.09|Z|The Barrens|N|Fly to the Crossroads.|
-T Parts of the Swarm|QID|1148|M|51.09,29.62|Z|The Barrens|N|To Korran.|
-A Parts of the Swarm|QID|1184|M|51.09,29.62|Z|The Barrens|N|From Korran.|
+F Crossroads|ACTIVE|1148|M|45.14,49.10|TZ|The Crossroads|
+T Parts of the Swarm|QID|1148|M|51.07,29.63|Z|The Barrens|N|To Korran.|
+A Parts of the Swarm|QID|1184|M|51.07,29.63|Z|The Barrens|N|From Korran.|
 T Regthar Deathgate|QID|1361|M|45.34,28.40|Z|The Barrens|N|To Regthar Deathgate.|
 A The Kolkar of Desolace|QID|1362|M|45.34,28.40|Z|The Barrens|N|From Regthar Deathgate.|
-R The Crossroads|ACTIVE|1184|M|50.61,29.01|Z|The Barrens|N|Run to the Crossroads.|
-F Orgrimmar|ACTIVE|1184|M|51.50,30.33|Z|The Barrens|N|Fly to Orgrimmar.|
+R The Crossroads|ACTIVE|1184|M|50.81,29.07|Z|The Barrens|
+F Orgrimmar|ACTIVE|1184|M|51.50,30.33|Z|The Barrens|
+R Valley of Honor|ACTIVE|1184|M|67.41,39.39|Z|Orgrimmar|
 T Parts of the Swarm|QID|1184|M|75.21,34.23|Z|Orgrimmar|N|To Belgrom Rockmaul.|
 
 ; --- Undercity
-N Test of Lore|ACTIVE|1159|N|Making a side trip to unload a quest while we are in the area.|
-b Tirisfal Glades|ACTIVE|1159|M|50.88,13.83|Z|Durotar|N|Take the Zeppelin to Tirisfal Glades.|
-R Undercity|ACTIVE|1159|M|61.86,65.04|Z|Tirisfal Glades|N|Enter Undercity.|
-T Test of Lore|QID|1159|M|57.67,65.35|Z|Undercity|N|To Parqual Fintallas.|
-A Test of Lore|QID|1160|M|57.67,65.35|Z|Undercity|ELITE|N|[color=E6CC80]Dungeon: Scarlet Monastery[/color]\nFrom Parqual Fintallas.\nAccept this quest if you plan on running the dungeon.|PRE|1159|O|
-b Orgrimmar|ACTIVE|1181|M|60.71,58.78|Z|Tirisfal Glades|N|Take the Zeppelin to Orgrimmar.|
+N Test of Lore|ACTIVE|1159|N|Making a side trip to unload a quest while we are in the area.\n[color=FF0000]NOTE: [/color]Manually check this step off to continue.|
+b Tirisfal Glades|ACTIVE|1159|M|50.88,13.83|Z|Durotar|N|Exit Orgrimmar and take the zeppelin to Tirisfal Glades.|
+R Undercity|ACTIVE|1159|M|61.86,65.04|Z|Tirisfal Glades|
+R The Apothecarium|ACTIVE|1159|M|56.35,58.33|Z|Undercity|N|Make your way inside and head to the Apothecarium.|
+T Test of Lore|QID|1159|M|57.78,65.41|Z|Undercity|N|To Parqual Fintallas.|
+A Test of Lore|QID|1160|M|57.78,65.41|Z|Undercity|ELITE|N|[color=E6CC80]Dungeon: Scarlet Monastery[/color]\nFrom Parqual Fintallas.\nAccept this quest if you plan on running the dungeon.|PRE|1159|O|
+
+; --- The Barrens/Orgrimmar
+b Durotar|ACTIVE|1178|M|60.71,58.78|Z|Tirisfal Glades|N|Exit Undercity and take the Zeppelin back to Durotar.|
+R Orgrimmar|ACTIVE|1178|M|49.15,95.09|Z|Orgrimmar|N|Enter Orgrimmar by the front gate.|
+= Level 34 training|ACTIVE|1178|C|-Druid|
+F Thunder Bluff|ACTIVE|1178|M|45.13,63.90|Z|Orgrimmar|C|Druid|
+= Level 34 training|ACTIVE|1178|C|Druid|
+F Ratchet|ACTIVE|1178|M|45.13,63.90|Z|Orgrimmar|IZ|1454;Orgrimmar|
+F Ratchet|ACTIVE|1178|M|47.02,49.83|Z|Thunder Bluff|IZ|1456;Thunder Bluff|
+T Goblin Sponsorship|QID|1178|M|62.68,36.23|Z|The Barrens|N|To Gazlowe.|
+A Goblin Sponsorship|QID|1180|M|62.68,36.23|Z|The Barrens|N|From Gazlowe.|PRE|1178|
+T Wharfmaster Dizzywig|QID|1111|M|63.35,38.45|Z|The Barrens|N|To Wharfmaster Dizzywig.|
+A Parts for Kravel|QID|1112|M|63.35,38.45|Z|The Barrens|N|From Wharfmaster Dizzywig.|PRE|1111|
 
 ; --- Booty Bay
-F Ratchet|ACTIVE|1181|M|45.50,63.84|Z|Orgrimmar|
-T Goblin Sponsorship|QID|1178|M|62.6,36.2|Z|The Barrens|N|To Gazlowe.|
-A Goblin Sponsorship|QID|1180|M|62.6,36.2|Z|The Barrens|N|From Gazlowe.|PRE|1178|
 b Booty Bay|ACTIVE|1180|M|63.70,38.63|Z|The Barrens|N|Take the boat to Booty Bay.|
-T Goblin Sponsorship|QID|1180|M|26.4,73.6|Z|Stranglethorn Vale|N|To Wharfmaster Lozgil.|
-A Goblin Sponsorship|QID|1181|M|26.4,73.6|Z|Stranglethorn Vale|N|From Wharfmaster Lozgil.|PRE|1180|
-T Goblin Sponsorship|QID|1181|M|27.06,77.59;27.04,77.14;27.23,76.88|Z|Stranglethorn Vale|CC|N|To Baron Revilgaz. Work your way through the Salty Sailor Tavern up to the deck.|
+T Goblin Sponsorship|QID|1180|M|26.35,73.56|Z|Stranglethorn Vale|N|To Wharfmaster Lozgil.|
+A Goblin Sponsorship|QID|1181|M|26.35,73.56|Z|Stranglethorn Vale|N|From Wharfmaster Lozgil.|PRE|1180|
+R The Salty Sailor Tavern|ACTIVE|1181|M|27.07,77.60|Z|Stranglethorn Vale|N|Make your way around the dock to the Inn on the opposite side.|
+T Goblin Sponsorship|QID|1181|M|27.23,76.88|Z|Stranglethorn Vale|N|To Baron Revilgaz.\n[color=FF0000]NOTE: [/color]Work your way through the Salty Sailor Tavern up to the deck.|
 A Goblin Sponsorship|QID|1182|M|27.23,76.88|Z|Stranglethorn Vale|N|From Baron Revilgaz.|
-f Booty Bay|ACTIVE|1112|M|26.87,77.09|Z|Stranglethorn Vale|N|At Gringer.|TAXI|-Booty Bay|
-b Ratchet|ACTIVE|1112|M|25.80,73.10|Z|Stranglethorn Vale|N|Take the boat to Ratchet.|
-F Freewind Post|ACTIVE|1112|M|63.11,37.10|Z|The Barrens|
-T Parts for Kravel|QID|1112|M|77.79,77.25|N|To Kravel Koalbeard at Mirage Raceway.|
-A Delivery to the Gnomes|QID|1114|M|77.79,77.26|N|From Kravel Koalbeard.|PRE|1112|
-T Delivery to the Gnomes|QID|1114|M|78.06,77.13|N|To Fizzle Brassbolts.|
+f Booty Bay|ACTIVE|1112|M|26.87,77.09|Z|Stranglethorn Vale|N|At Gringer.\n[color=FF0000]NOTE: [/color]Manually check this step off to continue if it doesn't auto-complete.|TAXI|-Booty Bay|
 
-; --- Desolace
-N Desolace|AVAILABLE|5501|N|We are now going to make our run to Desolace via Stonetalon Mountains.|
-R Freewind Post|AVAILABLE|5501^5561|M|47.63,49.04|N|Run back to Freewind and take the lift up.|
-F Orgrimmar|AVAILABLE|5501^5561|M|45.05,49.16|N|We are making a detour to Orgrimmar to change our hearthstone to Orgrimmar.|
-h Orgrimmar|AVAILABLE|5501^5561|M|54.03,68.77|Z|Orgrimmar|N|At Innkeeper Gryshka.|
-F Sun Rock Retreats|AVAILABLE|5501^5561|M|45.13,63.88|Z|Orgrimmar|
-R The Charred Vale|AVAILABLE|5501^5561|M|44.55,63.01;37.99,68.08;30.19,76.00|Z|Stonetalon Mountains|CC|N|Head back to the main trail. Follow the torch-marked path south over the mountain to the bottom. Make your way through the Charred Vale to the Desolace border in the south.|
-A Bone Collector|QID|5501|M|62.06,32.41;62.34,38.99|Z|Desolace|CC|N|From Bibbly F'utzbuckle.|
+; --- Thousand Needles
+b Ratchet|ACTIVE|1112|M|25.80,73.10|Z|Stranglethorn Vale|N|Take the boat to Ratchet.|
+F Freewind Post|ACTIVE|1112|M|63.09,37.16|Z|The Barrens|
+R Ironstone Camp|ACTIVE|1112|M|67.72,63.73|N|Exit Freewind Post and follow the road to the east.\n[color=FF0000]NOTE: [/color]You'll get to a point where the road veers left. Stick to the right and follow the canyon wall from here.|
+R Mirage Raceway|ACTIVE|1112|M|80.34,77.10|N|Make your way east across the Shimmering Flats to the Mirage Raceway in the middle of it.|
+T Parts for Kravel|QID|1112|M|77.79,77.25|N|To Kravel Koalbeard at Mirage Raceway.|
+A Delivery to the Gnomes|QID|1114|M|77.79,77.26|N|From Kravel Koalbeard.\n[color=FF0000]NOTE: [/color]This one takes a few to show up. Not really sure what he's waiting for.|PRE|1112|
+T Delivery to the Gnomes|QID|1114|M|78.06,77.13|N|To Fizzle Brassbolts.|
+N Desolace|AVAILABLE|5501^5561|N|We're now going to make our way to Desolace via Stonetalon Mountains.\n[color=FF0000]NOTE: [/color]Manually check this step off to continue.|
+
+; --- Orgrimmar
+R Freewind Post|AVAILABLE|5501^5561|M|47.63,49.04|
+F Orgrimmar|AVAILABLE|5501^5561|M|45.05,49.16|N|A pit stop in Orgrimmar to change our hearthstone.|
+h Orgrimmar|AVAILABLE|5501^5561|M|54.10,68.38|Z|Orgrimmar|N|At Innkeeper Gryshka.|
+
+; --- Desolace/Stonetalon Mountains
+F Sun Rock Retreat|AVAILABLE|5501^5561|M|45.13,63.88|Z|Orgrimmar|
+R The Charred Vale|AVAILABLE|5501^5561|M|44.4,63.6;39.84,70.02|Z|Stonetalon Mountains|CC|N|Follow the torch-marked path south over the mountain.|
+R Desolace|AVAILABLE|5501^5561|M|54.16,2.87|Z|Desolace|N|Continue to the bottom and make your way through the Charred Vale to the Desolace border in the south.|
+R Kormek's Hut|AVAILABLE|5501^5561|M|62.0,32.4;62.02,39.38|Z|Desolace|CC|
+A Bone Collector|QID|5501|M|62.34,38.99|Z|Desolace|N|From Bibbly F'utzbuckle.|
 A Kodo Roundup|QID|5561|M|60.86,61.86|Z|Desolace|N|From Smeed Scrabblescrew at Scrabblescrew's Camp.\n[color=FF0000]NOTE: [/color]If you are feeling adventurous, you can try and make the run straight down through some higher level mobs. I'd suggest taking the road east and coming in that way.|
-R Ghost Walker Post|ACTIVE|1362|M|58.58,56.93|Z|Desolace|
+R Ghost Walker Post|ACTIVE|1362|M|57.49,56.38|Z|Desolace|
 T The Kolkar of Desolace|QID|1362|M|56.19,59.57|Z|Desolace|N|To Felgur Twocuts.|
 A Khan Dez'hepah|QID|1365|M|56.19,59.57|Z|Desolace|N|From Felgur Twocuts.|
-N Gelkis or Magram|AVAILABLE|1367&1368|N|At this point in time, you need to decide which clan are you going to earn rep for.\nTo earn rep for the Gelkis Clan, you need to kill Magram Clan Centaurs and vice-versa.\n[color=FF0000]NOTE: [/color]Unless you are going after a specific reward item, Gelkis Clan is much easier to do.\nIt is possible to do both chains.|
-; --- Space intentionally added to break auto-accept.
-A Magram Alliance |QID|1367|ACTIVE|-1368|AVAILABLE|1368|M|56.29,59.68|Z|Desolace|N|From Gurda Wildmane.\n[color=FF0000]NOTE: [/color]If you are choosing the Gelkis Clan, skip this step and accept the Gelkis quest.|
-A Gelkis Alliance|QID|1368|ACTIVE|-1367|M|56.29,59.68|Z|Desolace|N|From Gurda Wildmane.|
+N Gelkis or Magram|AVAILABLE|1367&1368|N|At this point in time, you need to decide which clan are you going to earn rep for.\nTo earn rep for the Gelkis Clan, you need to kill Magram Clan Centaurs and vice-versa.\n[color=FF0000]NOTE: [/color]Unless you are going after a specific reward item, Gelkis Clan is much easier to do.\nIt's possible to do both chains.\nManually check this step off to continue.|
+; --- 'space' and '.' intentionally added to break auto-accept.
+;A Magram Alliance |QID|1367|ACTIVE|-1368|AVAILABLE|1368|M|56.29,59.68|Z|Desolace|N|From Gurda Wildmane.\n[color=FF0000]NOTE: [/color]If you are choosing the Gelkis Clan, skip this step and accept the Gelkis quest.|
+;A Gelkis Alliance.|QID|1368|ACTIVE|-1367|M|56.29,59.68|Z|Desolace|N|From Gurda Wildmane.|
+A Magram Alliance or Gelkis Alliance|QID|1367^1368|M|56.29,59.68|Z|Desolace|N|From Gurda Wildmane.|
 T Family Tree|QID|5361|M|55.41,55.80|Z|Desolace|N|To Nataka Longhorn.|
 A Catch of the Day|QID|5386|M|55.41,55.80|Z|Desolace|N|From Nataka Longhorn.|
 T Alliance Relations|QID|1432|M|52.57,54.39|Z|Desolace|N|To Takata Steelblade.|
@@ -261,11 +290,13 @@ A Alliance Relations|QID|1433|M|52.57,54.39|Z|Desolace|N|From Takata Steelblade.
 A Befouled by Satyr|QID|1434|M|52.57,54.39|Z|Desolace|N|From Takata Steelblade.|
 T Alliance Relations|QID|1433|M|52.25,53.44|Z|Desolace|N|To Maurin Bonesplitter.|
 A The Burning of Spirits|QID|1435|M|52.25,53.44|Z|Desolace|N|From Maurin Bonesplitter.|
-l Bone Collector|ACTIVE|5501|L|13703 10|N|While you are in the Kodo Graveyard, collect any Kodo Bones you come across.\n[color=FF0000]NOTE: [/color]Be aware, there is a chance of a lv 37-38 Kodo Apparation appearing and attacking you. You can stand and fight or run. If you run, the Kodo will return to its spawn point and despawn after a couple minutes.\nUnless you want the added challenge, make sure you clear any Vultures in the area before looting the bones.|S|
+C Bone Collector|ACTIVE|5501|L|13703 10|N|While you are in the Kodo Graveyard, collect any Kodo Bones you come across.\n[color=FF0000]NOTE: [/color]Be aware, there is a chance of a lv 37-38 Kodo Apparation appearing and attacking you. You can stand and fight or run. If you run, the Kodo will return to its spawn point and despawn after a couple minutes.\nUnless you want the added challenge, make sure you clear any Vultures in the area before looting the bones.|S|
 C Kodo Roundup|QID|5561|N|Go into the Kodo Graveyard and target one of the Kodos. Using the kombobulator, tame the kodo and have it follow you back to Scrabblescrew's Camp. After Scrabblescrew speaks with you, talk to the Kodo to get credit for it.\n[color=FF0000]NOTE: [/color]You can only do this one at a time and you have 5 minutes to bring the Kodo to Scrabblescrew.|U|13892|
 T Kodo Roundup|QID|5561|M|60.86,61.86|Z|Desolace|N|To Smeed Scrabblescrew.|
-l Bone Collector|ACTIVE|5501|L|13703 10|N|Go back into the Kodo Graveyard, finish collecting your Kodo Bones.|US|
-A Sceptre of Light|QID|5741|M|38.89,27.16|Z|Desolace|N|From Azore Aldamort at Ethel Rethot.\nTake the road north out of Kodo Graveyard and go west at the intersection. When you get to the ramp to the tower at the end of the road, go to the path along the right side of the ramp and follow it down.|
+C Bone Collector|ACTIVE|5501|L|13703 10|N|Go back into the Kodo Graveyard and finish collecting your Kodo Bones.|US|
+R Ethel Rethor|AVAILABLE|5741|M|42.71,35.91|Z|Desolace|N|Take the road north out of Kodo Graveyard and go west at the intersection.|
+A Sceptre of Light|QID|5741|M|38.89,27.16|Z|Desolace|N|From Azore Aldamort at Ethel Rethor.\n[color=FF0000]NOTE: [/color]Go up the hill to the bottom of the ramp, slowly drop off the side of the ramp, and follow the path around to the right.|
+R Kormek's Hut|ACTIVE|5501|M|44.1,34.4;62.02,39.38|Z|Desolace|CC|
 T Bone Collector|QID|5501|M|62.31,38.96|Z|Desolace|N|Head back to the road and follow it east to Bibbly F'utzbuckle at Kormek's Hut.|
 C The Burning of Spirits|QID|1435|N|Attack a Burning Blade mob. When they are almost dead (<300 hp), use the Burning Gem to capture them. If they die, you will collect an Infused Burning Gem.\nNOTE: Avoid using special attacks (DOT) when they are near death. This could disrupt the Burning Gem effect. The mob MUST die from the 'Capture Spirit' debuff to collect the gem. The debuff does 100 damage every 3 seconds for 9 seconds.\nA side note for Druids. You cannot use the gem while shapeshifted.|S|U|6436|
 A The Corrupter|QID|1480|N|Click on the Flayed Demon Skin to start the quest.\nThis item is dropped by Burning Blade mobs.|U|20310|O|
@@ -347,8 +378,8 @@ T Clam Bait|QID|6142|N|To Mai'Lahii.|
 
 ; --- Hillsbrad Foothills/Alterac
 F Orgrimmar|ACTIVE|1136|M|21.60,74.05|Z|Desolace|N|You're done with this area for now. You are now headed to Hillsbrad and Alterac.|
+N Turtle Meat|AVAILABLE|7321|L|3712 10|N|Make sure you grab the 10 pieces of Turtle Meat you were told to keep earlier. You'll need them now.|
 b Tirisfal Glades|ACTIVE|1136|M|50.8,13.6|Z|Durotar|N|Take the Zeppelin to Undercity.|
-N Turtle Meat|AVAILABLE|7321|L|3712 10|N|Make sure you have the 10 pieces of Turtle Meat you were told to keep earlier. You'll need them now.|
 F Tarren Mill|ACTIVE|1136|M|62.89,48.16|Z|Undercity|N|Enter Undercity and fly to Tarren Mill.|
 A Prison Break In|QID|544|M|61.59,20.83|Z|Hillsbrad Foothills|N|From Magus Wordeen Voidglare.|
 A Stone Tokens|QID|556|M|61.50,20.94|Z|Hillsbrad Foothills|N|From Keeper Bel'varil.|
@@ -624,7 +655,7 @@ T Bracers of Binding|QID|557|M|61.50,20.93|Z|Hillsbrad Foothills|N|To Keeper Bel
 
 ; -- Dustwallow Marsh
 F Undercity|AVAILABLE|1251^1268^1269|M|60.19,18.69|Z|Hillsbrad Foothills|N|Fly to Undercity.|
-b Orgrimmar|AVAILABLE|1251^1268^1269|M|31.37,30.15|Z|Stranglethorn Vale|N|Take the Zeppelin to Orgrimmar.|
+b Durotar|AVAILABLE|1251^1268^1269|M|31.37,30.15|Z|Stranglethorn Vale|N|Take the Zeppelin to Orgrimmar.|
 F Camp Taurajo|AVAILABLE|1251^1268^1269|M|45.50,63.84|Z|Orgrimmar|
 R Dustwallow Marsh|AVAILABLE|1251^1268^1269|M|28.53,47.18|N|Head east out Camp Taurajo to Southern Gold Road and follow the signs to Dustwallow Marsh.|
 

--- a/WoWPro_Leveling/Classic_BC/Horde/VAN_BCC_30_40_HordeChapter2.lua
+++ b/WoWPro_Leveling/Classic_BC/Horde/VAN_BCC_30_40_HordeChapter2.lua
@@ -297,20 +297,21 @@ C Bone Collector|ACTIVE|5501|L|13703 10|N|Go back into the Kodo Graveyard and fi
 R Ethel Rethor|AVAILABLE|5741|M|42.71,35.91|Z|Desolace|N|Take the road north out of Kodo Graveyard and go west at the intersection.|
 A Sceptre of Light|QID|5741|M|38.89,27.16|Z|Desolace|N|From Azore Aldamort at Ethel Rethor.\n[color=FF0000]NOTE: [/color]Go up the hill to the bottom of the ramp, slowly drop off the side of the ramp, and follow the path around to the right.|
 R Kormek's Hut|ACTIVE|5501|M|44.1,34.4;62.02,39.38|Z|Desolace|CC|
-T Bone Collector|QID|5501|M|62.31,38.96|Z|Desolace|N|Head back to the road and follow it east to Bibbly F'utzbuckle at Kormek's Hut.|
-C The Burning of Spirits|QID|1435|N|Attack a Burning Blade mob. When they are almost dead (<300 hp), use the Burning Gem to capture them. If they die, you will collect an Infused Burning Gem.\nNOTE: Avoid using special attacks (DOT) when they are near death. This could disrupt the Burning Gem effect. The mob MUST die from the 'Capture Spirit' debuff to collect the gem. The debuff does 100 damage every 3 seconds for 9 seconds.\nA side note for Druids. You cannot use the gem while shapeshifted.|S|U|6436|
+T Bone Collector|QID|5501|M|62.31,38.96|Z|Desolace|N|To Bibbly F'utzbuckle.|
+C The Burning of Spirits|QID|1435|L|6435 15|N|Attack a Burning Blade mob and when they are almost dead (<300 hp), use the Burning Gem on them. If they die, you will collect an Infused Burning Gem. They MUST die from the 'Capture Spirit' debuff to collect the gem. The debuff does 100 damage every 3 seconds for 9 seconds.\n[color=FF0000]NOTE: [/color]Using special attacks (DOT) when they are near death could disrupt the Burning Gem effect.\nA side note for Druids. You cannot use the gem while shapeshifted.|U|6436|S|
 A The Corrupter|QID|1480|N|Click on the Flayed Demon Skin to start the quest.\nThis item is dropped by Burning Blade mobs.|U|20310|O|
 ; --- destroy excess quest starter item
 * Excess Flayed Demon Skin|AVAILABLE|-1480|N|Once you've accepted the quest, you no longer need to loot these items. If you loot any more, safely destroy them.|U|20310|
 ;L Level 34|QID|1107|N|You should be around level 34 by this point.|
-C Sceptre of Light|QID|5741|M|55.17,30.09|Z|Desolace|N|Head north into Thunder Axe Fortress and kill the Burning Blade Seer to loot the Sceptre of Light.\n[color=FF0000]NOTE: [/color]You'll find the Seer at the top of the Watchtower just inside the entrance. He has 2 Felsworn standing guard outside and an Augur inside with him. You can easily pull the outside guards one at a time.|
+C Sceptre of Light|QID|5741|M|55.17,30.09|Z|Desolace|L|15750|N|Kill the Burning Blade Seer to loot the Sceptre of Light.\n[color=FF0000]NOTE: [/color]You'll find the Seer at the top of the Watchtower just inside the entrance. He has 2 Felsworn standing guard outside and an Augur inside with him. You can easily pull the outside guards one at a time.|
 l The Burning of Spirits|QID|1435|L|6435 15|U|6436|N|Finish collecting the Infused Burning Gems.|US|
-T Sceptre of Light|QID|5741|M|38.89,27.19|Z|Desolace|N|Make your way west back to Azore Aldamort in Ethel Rethor.|
-A Book of the Ancients|QID|6027|M|38.89,27.19|Z|Desolace|N|From Azore Aldamort.|
+T Sceptre of Light|QID|5741|M|38.89,27.16|Z|Desolace|N|Make your way west back to Azore Aldamort in Ethel Rethor.|
+A Book of the Ancients|QID|6027|M|38.89,27.16|Z|Desolace|N|From Azore Aldamort.|
 T The Burning of Spirits|QID|1435|M|52.24,53.44|Z|Desolace|N|Make your way back to Maurin Bonesplitter at Ghost Walker Post.|
 T The Corrupter|QID|1480|M|52.24,53.44|Z|Desolace|N|To Maurin Bonesplitter.|
 A The Corrupter|QID|1481|M|52.24,53.44|Z|Desolace|N|From Maurin Bonesplitter.|PRE|1480|
-R Sargeron|ACTIVE|1434^1481|M|50.39,52.91;53.82,37.12;62.39,32.43;65.82,33.19;70.76,22.93|Z|Desolace|CC|N|Head west out Ghost Walker Post and follow the road north to the intersection. Continue east along the road to the 2nd intersection and go north from that intersection into Sargeron.|
+r Repair|ACTIVE|1481|M|55.59,56.48|Z|Desolace|N|Visit Muuran before leaving.|
+R Sargeron|ACTIVE|1434^1481|M|49.7,46.8;53.8,37.2;65.8,33.2;70.76,22.93|Z|Desolace|CC|N|Head north out of Ghost Walker Post and follow the road north to the intersection. Continue east along the road to the 2nd intersection and head north from there into Sargeron.|
 C The Corrupter|QID|1481|N|Kill a Hatefury Shadowstalker to loot its scalp.|S|
 C Befouled by Satyr|QID|1434|QO|1;2;3|N|Kill Satyrs in the area.|
 C The Corrupter|QID|1481|N|Kill Hatefury Shadowstalkers until you loot a shadowstalker scalp.|US|

--- a/WoWPro_Leveling/Classic_BC/Horde/VAN_BCC_30_40_HordeChapter2.lua
+++ b/WoWPro_Leveling/Classic_BC/Horde/VAN_BCC_30_40_HordeChapter2.lua
@@ -121,38 +121,45 @@ F Camp Taurajo|ACTIVE|1153|M|46.14,51.70|
 T A New Ore Sample|QID|1153|M|45.10,57.69|Z|The Barrens|N|To Tatternack Steelforge.|
 
 ; --- Thunder Bluff
-F Thunder Bluff|QID|1131|M|44.46,59.14|Z|The Barrens|
+F Thunder Bluff|ACTIVE|1131|M|44.44,59.15|Z|The Barrens|
 T Steelsnap|QID|1131|M|61.53,80.89|Z|Thunder Bluff|N|To Melor Stonehoof.|
 A Frostmaw|QID|1136|M|61.53,80.89|Z|Thunder Bluff|N|From Melor Stonehoof.|PRE|1131|
 
 ; --- Stonetalon Mountains
 F Sun Rock Retreat|ACTIVE|1152|M|47.02,49.83|Z|Thunder Bluff|
 R Windshear Crag|ACTIVE|1152|M|49.51,61.02;53.15,61.61;59.97,71.14|Z|Stonetalon Mountains|CC|N|Head to the Sun Rock Retreat entrance and follow the road south to the Windshear Crag sign.|
-T Test of Lore|QID|1152|M|78.79,45.67|Z|Stonetalon Mountains|N|To Braug Dimspirit near the entrance to Talondeep Path in Stonetalon Mountains.|
+R The Talondeep Path|ACTIVE|1152|M|76.75,45.34|Z|Stonetalon Mountains|N|Head to the northeast corner of Windshear Crag.|
+T Test of Lore|QID|1152|M|78.79,45.67|Z|Stonetalon Mountains|N|To Braug Dimspirit.|
 A Test of Lore|QID|1154|M|78.79,45.67|Z|Stonetalon Mountains|N|From Braug Dimspirit.|PRE|1152|
 
 ; --- Ashenvale
-R The Dor'Danil Barrow Den|QID|1154|M|42.28,71.07;53.71,58.89;71.71,70.28;75.02,76.38;75.84,75.38|Z|Ashenvale|CC|N|Take the Talondeep Path to Ashenvale. Follow the path to the road and continue east until you get to the path leading to The Dor'Danil Barrow Den.|
-l Legacy of the Aspects|QID|1154|M|77.32,75.18;76.60,74.86;75.56,74.36|Z|Ashenvale|CC|L|5860|N|Find the Legacy of the Aspects.|
+R The Dor'Danil Barrow Den|ACTIVE|1154|M|42.3,71.1;42.7,57.1;71.7,70.2;72.51,71.32|Z|Ashenvale|CC|N|Enter the cave and take the Talondeep Path to Ashenvale. Head straight north to the road and continue east until you get to the path leading to The Dor'Danil Barrow Den. Follow the path into The Dor'Danil Barrow Den area.|
+C Legacy of the Aspects|QID|1154|M|75.9,75.4;76.8,74.9;75.57,74.38|Z|Ashenvale|CS|L|5860|N|Make your way to the Den entrance and work your way inside the Den. Locate the podium and loot the Legacy of the Aspects from it.\n[color=FF0000]NOTE: [/color]You will come across mobs that will attack you as you descend the path inside.|
 
 ; --- Stonetalon Mountains
-R The Talondeep Path|ACTIVE|1154|CC|N|Make your way out The Dor'Danil Barrow Den. Head to the Ashenvale entrance to The Talondeep Path and go through to Stonetalon Mountains.|
-T Test of Lore|QID|1154|M|78.75,45.62|Z|Stonetalon Mountains|N|To Braug Dimspirit.|
-A Test of Lore|QID|6627|M|78.75,45.62|Z|Stonetalon Mountains|N|From Braug Dimspirit.|PRE|1154|
-C Test of Lore|QID|6627|M|78.75,45.62|Z|Stonetalon Mountains|N|Answer Braug Dimspirit's question with #2 Neltharion.|CHAT|
-T Test of Lore|QID|6627|M|78.75,45.62|Z|Stonetalon Mountains|N|To Braug Dimspirit.|
-A Test of Lore|QID|1159|M|78.75,45.62|Z|Stonetalon Mountains|N|From Braug Dimspirit.|PRE|6627|
-R Sun Rock Retreat|AVAILABLE|1145|M|49.58,60.99|Z|Stonetalon Mountains|
+R The Talondeep Path|ACTIVE|1154|M|43.04,71.29|Z|Ashenvale|N|Make your way out The Dor'Danil Barrow Den and head back to The Talondeep Path.
+R Stonetalon Mountains|ACTIVE|1154|M|81.56,30.11|Z|Stonetalon Mountains|N|Enter the cave and follow the path through to Stonetalon Mountains.|
+T Test of Lore|QID|1154|M|78.79,45.67|Z|Stonetalon Mountains|N|To Braug Dimspirit.|
+A Test of Lore|QID|6627|M|78.79,45.67|Z|Stonetalon Mountains|N|From Braug Dimspirit.|PRE|1154|
+C Test of Lore|QID|6627|M|78.79,45.67|Z|Stonetalon Mountains|N|Answer Braug Dimspirit's question with #2 Neltharion.|CHAT|
+T Test of Lore|QID|6627|M|78.79,45.67|Z|Stonetalon Mountains|N|To Braug Dimspirit.|
+A Test of Lore|QID|1159|M|78.79,45.67|Z|Stonetalon Mountains|N|From Braug Dimspirit.|PRE|6627|
+H Freewind Post|AVAILABLE|1145|N|This is much faster than running back to Sun Rock Retreat.\n[color=FF0000]NOTE: [/color]If your hearth is on CD, skip this step.|
+R Sun Rock Retreat|AVAILABLE|1145|M|49.58,60.99|Z|Stonetalon Mountains|N|Unfortunately, you have no choice but to foot it to Sun Rock Retreat.|IZ|1442;Stonetalon Mountains|
 
 ; --- The Barrens/Orgrimmar
-F Crossroads|AVAILABLE|1145|M|45.12,59.84|Z|Stonetalon Mountains|
-A The Swarm Grows|QID|1145|M|51.09,29.61|Z|The Barrens|N|From Korran.|
+F Crossroads|AVAILABLE|1145|M|45.12,59.84|Z|Stonetalon Mountains|IZ|1442;Stonetalon Mountains|
+F Crossroads|AVAILABLE|1145|M|45.14,49.10|IZ|1441;Thousand Needles|
+A The Swarm Grows|QID|1145|M|51.07,29.63|Z|The Barrens|N|From Korran.|
 F Orgrimmar|ACTIVE|1145|M|51.50,30.34|Z|The Barrens|
-T The Swarm Grows|QID|1145|M|75.22,34.23|Z|Orgrimmar|N|To Belgrom Rockmaul.|
-A The Swarm Grows|QID|1146|M|75.22,34.23|Z|Orgrimmar|N|From Belgrom Rockmaul.|PRE|1145|
-A Regthar Deathgate|QID|1361|M|75.22,34.23|Z|Orgrimmar|N|From Belgrom Rockmaul.|
-A Alliance Relations|QID|1431|M|51.99,45.41|Z|Orgrimmar|N|From Craven Drok.|
-T Alliance Relations|QID|1431|M|22.28,53.92|Z|Orgrimmar|N|To Keldran.|
+R Valley of Honor|ACTIVE|1145|M|67.41,39.39|Z|Orgrimmar|
+T The Swarm Grows|QID|1145|M|75.23,34.23|Z|Orgrimmar|N|To Belgrom Rockmaul.|
+A The Swarm Grows|QID|1146|M|75.23,34.23|Z|Orgrimmar|N|From Belgrom Rockmaul.|PRE|1145|
+A Regthar Deathgate|QID|1361|M|75.23,34.23|Z|Orgrimmar|N|From Belgrom Rockmaul.|
+R Cleft of Shadow|AVAILABLE|1431|M|52.61,42.41|Z|Orgrimmar|
+A Alliance Relations|QID|1431|M|51.99,45.41|Z|Orgrimmar|N|From Craven Drok.\n[color=FF0000]NOTE: [/color]If he's not here, he circles around the buildings at the bottom and up the ramp on the opposite side before returning.|
+R Valley of Spirits|ACTIVE|1431|M|38.18,73.56|Z|Orgrimmar|N|Exit and make your way to the Valley of Spirits.|
+T Alliance Relations|QID|1431|M|22.28,53.92|Z|Orgrimmar|N|To Keldran, in the building just before the west entrance/exit.|
 A Alliance Relations|QID|1432|M|22.28,53.92|Z|Orgrimmar|N|From Keldran.|PRE|1431|
 
 ; --- Thousand Needles

--- a/WoWPro_Leveling/Classic_BC/Horde/VAN_BCC_30_40_HordeChapter2.lua
+++ b/WoWPro_Leveling/Classic_BC/Horde/VAN_BCC_30_40_HordeChapter2.lua
@@ -312,44 +312,52 @@ T The Corrupter|QID|1480|M|52.24,53.44|Z|Desolace|N|To Maurin Bonesplitter.|
 A The Corrupter|QID|1481|M|52.24,53.44|Z|Desolace|N|From Maurin Bonesplitter.|PRE|1480|
 r Repair|ACTIVE|1481|M|55.59,56.48|Z|Desolace|N|Visit Muuran before leaving.|
 R Sargeron|ACTIVE|1434^1481|M|49.7,46.8;53.8,37.2;65.8,33.2;70.76,22.93|Z|Desolace|CC|N|Head north out of Ghost Walker Post and follow the road north to the intersection. Continue east along the road to the 2nd intersection and head north from there into Sargeron.|
-C The Corrupter|QID|1481|N|Kill a Hatefury Shadowstalker to loot its scalp.|S|
-C Befouled by Satyr|QID|1434|QO|1;2;3|N|Kill Satyrs in the area.|
-C The Corrupter|QID|1481|N|Kill Hatefury Shadowstalkers until you loot a shadowstalker scalp.|US|
-C Khan Dez'hepah|ACTIVE|1365|M|72.95,46.68|Z|Desolace|QO|1|N|Head south from Sargeron to Kolkar Village. Clear any Kolkar in the immediate area around the ramp leading up to Khan Dez'hepah. Once that is done, pull Khan Dez'hepah and kill him to loot his head.|
-R Ghost Walker Post|ACTIVE|1365|M|58.59,56.97|Z|Desolace|N|Take the road back to Ghost Walker Post.|
+C The Corrupter|QID|1481|M|74.75,20.36|Z|Desolace|L|6441|N|Kill a Hatefury Shadowstalker to loot its scalp.|S|
+K Befouled by Satyr|ACTIVE|1434|M|74.75,20.36|Z|Desolace|QO|1;2;3;4|N|Kill Satyrs in the area.|
+C The Corrupter|QID|1481|M|74.75,20.36|Z|Desolace|L|6441|N|Kill Hatefury Shadowstalkers until you loot a shadowstalker scalp.|US|
+K Khan Dez'hepah|ACTIVE|1365|M|72.95,46.68;74.70,48.78;73.2,41.8|Z|Desolace|CN|QO|1|N|Head south from Sargeron to Kolkar Village. Locate Khan Dez'hepah and kill him to loot his head.\n[color=FF0000]NOTE: [/color]He has 3 different spawn locations.|
+R Ghost Walker Post|ACTIVE|1365|M|56.74,56.79|Z|Desolace|N|Take the road back to Ghost Walker Post.|
 T Khan Dez'hepah|QID|1365|M|56.19,59.57|Z|Desolace|N|To Felgur Twocuts.|
 A Centaur Bounty|QID|1366|M|56.19,59.57|Z|Desolace|N|From Felgur Twocuts.|PRE|1365|
+r Repair|ACTIVE|1434|M|55.59,56.48|Z|Desolace|N|Check in with Muuran as you go by.|
 T Befouled by Satyr|QID|1434|M|52.57,54.39|Z|Desolace|N|To Takata Steelblade.|
 A Alliance Relations|QID|1436|M|52.57,54.39|Z|Desolace|N|From Takata Steelblade.|PRE|1436|
-T The Corrupter|QID|1481|N|To Maurin Bonesplitter.|
-A The Corrupter|QID|1482|N|From Maurin Bonesplitter.|PRE|1481|
+T The Corrupter|QID|1481|M|52.24,53.44|Z|Desolace|N|To Maurin Bonesplitter.|
+A The Corrupter|QID|1482|M|52.24,53.44|Z|Desolace|N|From Maurin Bonesplitter.|PRE|1481|
 R Shadowprey Village|AVAILABLE|6142^6143|M|26.50,75.15|Z|Desolace|N|Leave Ghost Walker Post from the east and follow the road south all the way to the shore line at the end.|
 f Shadowprey Village|AVAILABLE|6142^6143|M|21.60,74.12|Z|Desolace|N|Thalon can be found at the end of the dock.|
-A Clam Bait|QID|6142|M|22.72,72.09|Z|Desolace|N|From Mai'Lahii.|
-A Other Fish to Fry|QID|6143|M|23.27,72.82|Z|Desolace|N|From Drulzegar Skraghook.|
-P Moonglade|ACTIVE|1436|N|Now that we have the FP in Desolace, use your Teleport: Moonglade to do your training.|C|Druid|
-H Orgrimmar|ACTIVE|1436|N|Hearth back to Orgrimmar. It's faster than flying; unless your hearth is on CD.|C|Druid|
-H Orgrimmar|ACTIVE|1436|N|Now that we have the FP in Desolace, you can hearth back to Orgrimmar to do your training or whatever else you need to do.|C|-Druid|
-N Advanced Target Dummy|ACTIVE|1367|N|Make sure you bring an 'Advanced Target Dummy' with you. You're going to need it for the quest chain.|
-T Alliance Relations|QID|1436|M|22.27,53.74|Z|Orgrimmar|N|To Keldran.|
-F Shadowprey Village|QID|1366|M|45.50,63.84|Z|Orgrimmar|N|Once you're done whatever you need to do, fly back to Desolace.|
-l Shellfish|AVAILABLE|5421|ACTIVE|5386|L|13545 10|N|Drop into the water and look for cages on the ocean floor. Open these to collect Shellfish. Jinar'Zillen will trade 5 of these Shellfish for 1 Bloodybelly fish.\n[color=FF0000]NOTE: [/color]If you do not have a means of breathing underwater, locate one of the small, bubbling fissures and use it to restore your breath.\nAlso, be aware that a Drysnap Crawler may spawn and attack you when you open the trap.|
-T Fish in a Bucket|QID|5421|M|22.46,73.11|Z|Desolace|N|To Jinar'Zillen on the pier.\nThis is a repeatable quest and you'll have to turn it in at least twice.|L|13546 2|NOCACHE|
-C Centaur Bounty|QID|1366|N|Kill Centaurs and loot their ears.|S|
-R Gelkis Village|ACTIVE|1368|M|36.64,77.13|Z|Desolace|N|Follow the road out of Shadowprey Village. The village is on the south side of the road.|
-K Gelkis Clan Centaurs|ACTIVE|1368|N|Kill Gelkis Clan Centaurs until have reached Friendly status (3,000 rep) with the Magram Clan.\nIt'll take about 50 kills to reach it.|REP|Magram Clan Centaur;93;neutral|
-R Magram Village|ACTIVE|1367|M|67.20,66.19|Z|Desolace|N|Follow the road out of Shadowprey Village as far east as it goes. The village is on the south side of the road.|
-K Magram Clan Centaurs|ACTIVE|1367|N|Kill Magram Clan Centaurs until have reached Friendly status (3,000 rep) with The Gelkis Clan.\nIt'll take about 50 kills to reach it.|REP|Gelkis Clan Centaur;92;friendly|
-C Centaur Bounty|QID|1366|N|Continue killing Centaurs and looting their ears until done.|US|
+A Clam Bait|QID|6142|M|22.64,71.97|Z|Desolace|N|From Mai'Lahii.|
+A Other Fish to Fry|QID|6143|M|23.32,72.88|Z|Desolace|N|From Drulzegar Skraghook.|
+l Shellfish|AVAILABLE|5421|ACTIVE|5386|M|20.10,79.10|Z|Desolace|L|13545 10|N|Drop into the water and look for cages on the ocean floor. Open these to collect Shellfish. Jinar'Zillen will trade 5 of these Shellfish for 1 Bloodybelly fish.\n[color=FF0000]NOTE: [/color]If you do not have a means of breathing underwater, locate one of the small, bubbling fissures and use it to restore your breath.\nAlso, be aware that a Drysnap Crawler may spawn and attack you when you open the trap.|
+A Fish in a Bucket|QID|5421|M|22.46,73.11|Z|Desolace|L|13546 2|N|From Jinar'Zillen on the pier.\n[color=FF0000]NOTE: [/color]This is a low level quest that you need to do.|
+T Fish in a Bucket|QID|5421|M|22.46,73.11|Z|Desolace|L|13546 2|N|To Jinar'Zillen on the pier.|NOCACHE|
+A Fish in a Bucket|QID|5421|M|22.46,73.11|Z|Desolace|L|13546 2|N|From Jinar'Zillen on the pier.\n[color=FF0000]NOTE: [/color]You have to do this a second time.|
+T Fish in a Bucket|QID|5421|M|22.46,73.11|Z|Desolace|L|13546 2|N|To Jinar'Zillen on the pier.|NOCACHE|
+C Centaur Bounty|QID|1366|ACTIVE|1367|M|37.21,81.78|Z|Desolace|N|Kill Centaurs and loot their ears.|S|
+C Centaur Bounty|QID|1366|ACTIVE|1368|M|70.76,75.30|Z|Desolace|N|Kill Centaurs and loot their ears.|S|
+N Reputation Monitoring|ACTIVE|1367^1368|N|Open the Reputation Tab (<U>) and locate the Faction you want to track. Check the box 'Show as Experience Bar' and it will appear above the Exp bar.\n[color=FF0000]NOTE: [/color]Results may vary dependant upon your UI layout and other Addons.\nManually check this step off to continue.|
+R Gelkis Village|ACTIVE|1367|M|36.60,77.54|Z|Desolace|N|Follow the road out of Shadowprey Village. The village is on the south side of the road.|
+K Gelkis Clan Centaurs|ACTIVE|1367|M|37.21,81.78|Z|Desolace|N|Kill Gelkis Clan Centaurs until reach Friendly status (3,000 rep) with the Magram Clan.\nIt'll take 75 kills to reach it.|REP|Magram Clan Centaur;93;neutral|
+R Magram Village|ACTIVE|1368|M|67.32,66.501|Z|Desolace|N|Follow the road out of Shadowprey Village as far east as it goes. The village is on the south side of the road.|
+K Magram Clan Centaurs|ACTIVE|1368|M|70.76,75.30|Z|Desolace|N|Kill Magram Clan Centaurs until have reached Friendly status (3,000 rep) with The Gelkis Clan.\nIt'll take 75 kills to reach it.|REP|Gelkis Clan Centaur;92;Neutral|
+C Centaur Bounty|QID|1366|ACTIVE|1367|M|37.21,81.78|Z|Desolace|N|Continue killing Centaurs and looting their ears until done.|US|
+C Centaur Bounty|QID|1366|ACTIVE|1368|M|70.76,75.30|Z|Desolace|N|Continue killing Centaurs and looting their ears until done.|US|
+R Ghost Walker Post|ACTIVE|1366|M|56.74,56.79|Z|Desolace|
 T Centaur Bounty|QID|1366|M|56.20,59.55|Z|Desolace|N|To Felgur Twocuts.|
+T Catch of the Day|QID|5386|M|55.41,55.80|Z|Desolace|N|To Nataka Longhorn.|
 R Gelkis Village|ACTIVE|1368|M|36.64,77.13|Z|Desolace|N|Follow the road out of Ghost Walker Post and go west at the intersection. The village is on the south side of the road.|REP|Gelkis Clan Centaur;92;friendly|
 T Gelkis Alliance|QID|1368|M|36.24,79.25|Z|Desolace|N|To Uthek the Wise.|REP|Gelkis Clan Centaur;92;friendly|
 A Stealing Supplies|QID|1370|M|36.24,79.25|Z|Desolace|N|From Uthek the Wise.|PRE|1368|REP|Gelkis Clan Centaur;92;friendly|
 R Magram Village|ACTIVE|1370|M|67.20,66.19|Z|Desolace|N|Return to Magram Village.|
 l Stealing Supplies|ACTIVE|1370|L|6069 6|N|Loot the yellow bags off the ground near the tents in Magram Village.\n[color=FF0000]NOTE: [/color]There are some bags that are not lootable.|
 T Stealing Supplies|QID|1370|M|36.24,79.24|Z|Desolace|N|To Uthek the Wise.|
+P Moonglade|ACTIVE|1436|N|Now that we have the FP in Desolace, use your Teleport: Moonglade to do your training.|C|Druid|
+H Orgrimmar|ACTIVE|1436|N|Hearth back to Orgrimmar. It's faster than flying; unless your hearth is on CD.|C|Druid|
+H Orgrimmar|ACTIVE|1436|N|Now that we have the FP in Desolace, you can hearth back to Orgrimmar to do your training or whatever else you need to do.|C|-Druid|
+N Advanced Target Dummy|ACTIVE|1367|N|Make sure you bring an 'Advanced Target Dummy' with you. You're going to need it for the quest chain.|
+T Alliance Relations|QID|1436|M|22.27,53.74|Z|Orgrimmar|N|To Keldran.|
+F Shadowprey Village|QID|6142|M|45.50,63.84|Z|Orgrimmar|N|Once you're done whatever you need to do, fly back to Desolace.|
 A Ongeku|QID|1373|M|36.24,79.20|Z|Desolace|N|From Uthek the Wise.|
-R Shadowprey Village|ACTIVE|6143|M|26.50,75.15|Z|Desolace|N|Return to Shadowprey Village.|
 N Shortcut|ACTIVE|6142|N|Instead of running all the way around to get to the shoreline in the north, you are going to swim up from Shadowprey Village.|
 l Clam Bait|ACTIVE|6142|M|45.2,63.8|Z|Desolace|L|15924 10|N|Open Soft-shelled clams to collect the meat.\nYou can get them from opening the Giant Soft Clams on the ocean floor and by killing Drysnap crawlers/pincers. You can also get them from killing the Reef Crawlers.|U|15874|S|
 R Ethel Rethor|ACTIVE|6143|M|30.55,34.26;35.66,30.67|Z|Desolace|CC|N|Walk into the water and swim north.|
@@ -374,8 +382,8 @@ A The Corrupter|QID|1484|M|52.25,53.50|Z|Desolace|N|After a brief cinematic, acc
 T The Corrupter|QID|1484|M|52.57,54.34|Z|Desolace|N|To Takata Steelblade.To Takata Steelblade.\n[color=FF0000]NOTE: [/color]Do not pick up the follow-up quest... yet.|
 R Shadowprey Village|ACTIVE|6142^6143|M|26.50,75.15|Z|Desolace|N|Return to Shadowprey Village.|
 A Hunting in Stranglethorn|QID|5763|M|25.05,72.26|Z|Desolace|N|From Roon Wildmane.|
-T Other Fish to Fry|QID|6143|N|To Drulzegar Skraghook.|
-T Clam Bait|QID|6142|N|To Mai'Lahii.|
+T Other Fish to Fry|QID|6143|M|23.32,72.88|N|To Drulzegar Skraghook.|
+T Clam Bait|QID|6142||M|22.64,71.97|N|To Mai'Lahii.|
 
 ; --- Hillsbrad Foothills/Alterac
 F Orgrimmar|ACTIVE|1136|M|21.60,74.05|Z|Desolace|N|You're done with this area for now. You are now headed to Hillsbrad and Alterac.|

--- a/WoWPro_Leveling/Classic_BC/Horde/VAN_BCC_30_40_HordeChapter2.lua
+++ b/WoWPro_Leveling/Classic_BC/Horde/VAN_BCC_30_40_HordeChapter2.lua
@@ -289,7 +289,7 @@ T Alliance Relations|QID|1432|M|52.57,54.39|Z|Desolace|N|To Takata Steelblade.|
 A Alliance Relations|QID|1433|M|52.57,54.39|Z|Desolace|N|From Takata Steelblade.|PRE|1432|
 A Befouled by Satyr|QID|1434|M|52.57,54.39|Z|Desolace|N|From Takata Steelblade.|
 T Alliance Relations|QID|1433|M|52.25,53.44|Z|Desolace|N|To Maurin Bonesplitter.|
-A The Burning of Spirits|QID|1435|M|52.25,53.44|Z|Desolace|N|From Maurin Bonesplitter.|
+A The Burning of Spirits|QID|1435|M|52.25,53.44|Z|Desolace|N|From Maurin Bonesplitter.|PRE|1433|
 C Bone Collector|ACTIVE|5501|L|13703 10|N|While you are in the Kodo Graveyard, collect any Kodo Bones you come across.\n[color=FF0000]NOTE: [/color]Be aware, there is a chance of a lv 37-38 Kodo Apparation appearing and attacking you. You can stand and fight or run. If you run, the Kodo will return to its spawn point and despawn after a couple minutes.\nUnless you want the added challenge, make sure you clear any Vultures in the area before looting the bones.|S|
 C Kodo Roundup|QID|5561|N|Go into the Kodo Graveyard and target one of the Kodos. Using the kombobulator, tame the kodo and have it follow you back to Scrabblescrew's Camp. After Scrabblescrew speaks with you, talk to the Kodo to get credit for it.\n[color=FF0000]NOTE: [/color]You can only do this one at a time and you have 5 minutes to bring the Kodo to Scrabblescrew.|U|13892|
 T Kodo Roundup|QID|5561|M|60.86,61.86|Z|Desolace|N|To Smeed Scrabblescrew.|
@@ -321,7 +321,7 @@ T Khan Dez'hepah|QID|1365|M|56.19,59.57|Z|Desolace|N|To Felgur Twocuts.|
 A Centaur Bounty|QID|1366|M|56.19,59.57|Z|Desolace|N|From Felgur Twocuts.|PRE|1365|
 r Repair|ACTIVE|1434|M|55.59,56.48|Z|Desolace|N|Check in with Muuran as you go by.|
 T Befouled by Satyr|QID|1434|M|52.57,54.39|Z|Desolace|N|To Takata Steelblade.|
-A Alliance Relations|QID|1436|M|52.57,54.39|Z|Desolace|N|From Takata Steelblade.|PRE|1436|
+A Alliance Relations|QID|1436|M|52.57,54.39|Z|Desolace|N|From Takata Steelblade.|PRE|1435|
 T The Corrupter|QID|1481|M|52.24,53.44|Z|Desolace|N|To Maurin Bonesplitter.|
 A The Corrupter|QID|1482|M|52.24,53.44|Z|Desolace|N|From Maurin Bonesplitter.|PRE|1481|
 R Shadowprey Village|AVAILABLE|6142^6143|M|26.50,75.15|Z|Desolace|N|Leave Ghost Walker Post from the east and follow the road south all the way to the shore line at the end.|
@@ -329,23 +329,44 @@ f Shadowprey Village|AVAILABLE|6142^6143|M|21.60,74.12|Z|Desolace|N|Thalon can b
 A Clam Bait|QID|6142|M|22.64,71.97|Z|Desolace|N|From Mai'Lahii.|
 A Other Fish to Fry|QID|6143|M|23.32,72.88|Z|Desolace|N|From Drulzegar Skraghook.|
 l Shellfish|AVAILABLE|5421|ACTIVE|5386|M|20.10,79.10|Z|Desolace|L|13545 10|N|Drop into the water and look for cages on the ocean floor. Open these to collect Shellfish. Jinar'Zillen will trade 5 of these Shellfish for 1 Bloodybelly fish.\n[color=FF0000]NOTE: [/color]If you do not have a means of breathing underwater, locate one of the small, bubbling fissures and use it to restore your breath.\nAlso, be aware that a Drysnap Crawler may spawn and attack you when you open the trap.|
-A Fish in a Bucket|QID|5421|M|22.46,73.11|Z|Desolace|L|13546 2|N|From Jinar'Zillen on the pier.\n[color=FF0000]NOTE: [/color]This is a low level quest that you need to do.|
+A Fish in a Bucket|QID|5421|ACTIVE|5386|M|22.46,73.11|Z|Desolace|L|13546 2|N|From Jinar'Zillen on the pier.\n[color=FF0000]NOTE: [/color]This is a low level quest that you need to do.|
 T Fish in a Bucket|QID|5421|M|22.46,73.11|Z|Desolace|L|13546 2|N|To Jinar'Zillen on the pier.|NOCACHE|
-A Fish in a Bucket|QID|5421|M|22.46,73.11|Z|Desolace|L|13546 2|N|From Jinar'Zillen on the pier.\n[color=FF0000]NOTE: [/color]You have to do this a second time.|
+A Fish in a Bucket|QID|5421|ACTIVE|5386|M|22.46,73.11|Z|Desolace|L|13546 2|N|From Jinar'Zillen on the pier.\n[color=FF0000]NOTE: [/color]You have to do this a second time.|
 T Fish in a Bucket|QID|5421|M|22.46,73.11|Z|Desolace|L|13546 2|N|To Jinar'Zillen on the pier.|NOCACHE|
 C Centaur Bounty|QID|1366|ACTIVE|1367|M|37.21,81.78|Z|Desolace|N|Kill Centaurs and loot their ears.|S|
 C Centaur Bounty|QID|1366|ACTIVE|1368|M|70.76,75.30|Z|Desolace|N|Kill Centaurs and loot their ears.|S|
 N Reputation Monitoring|ACTIVE|1367^1368|N|Open the Reputation Tab (<U>) and locate the Faction you want to track. Check the box 'Show as Experience Bar' and it will appear above the Exp bar.\n[color=FF0000]NOTE: [/color]Results may vary dependant upon your UI layout and other Addons.\nManually check this step off to continue.|
+; --- Magram Alliance chain
 R Gelkis Village|ACTIVE|1367|M|36.60,77.54|Z|Desolace|N|Follow the road out of Shadowprey Village. The village is on the south side of the road.|
 K Gelkis Clan Centaurs|ACTIVE|1367|M|37.21,81.78|Z|Desolace|N|Kill Gelkis Clan Centaurs until reach Friendly status (3,000 rep) with the Magram Clan.\nIt'll take 75 kills to reach it.|REP|Magram Clan Centaur;93;neutral|
-R Magram Village|ACTIVE|1368|M|67.32,66.501|Z|Desolace|N|Follow the road out of Shadowprey Village as far east as it goes. The village is on the south side of the road.|
-K Magram Clan Centaurs|ACTIVE|1368|M|70.76,75.30|Z|Desolace|N|Kill Magram Clan Centaurs until have reached Friendly status (3,000 rep) with The Gelkis Clan.\nIt'll take 75 kills to reach it.|REP|Gelkis Clan Centaur;92;Neutral|
 C Centaur Bounty|QID|1366|ACTIVE|1367|M|37.21,81.78|Z|Desolace|N|Continue killing Centaurs and looting their ears until done.|US|
+R Ghost Walker Post|ACTIVE|1366&1367|M|56.74,56.79|Z|Desolace|
+T Centaur Bounty|QID|1366|ACTIVE|1367|M|56.20,59.55|Z|Desolace|N|To Felgur Twocuts.|
+T Catch of the Day|QID|5386|ACTIVE|1367|M|55.41,55.80|Z|Desolace|N|To Nataka Longhorn.|
+R Magram Village|ACTIVE|1367|M|67.20,66.19|Z|Desolace|N|Follow the road out of Ghost Walker Post to the first intersection and continue as far east as it goes. The village is on the south side of the road.|
+T Magram Alliance|QID|1367|M|74.8,68.0|Z|Desolace|N|To Warug.|
+A Broken Tears|QID|1369|M|74.8,68.0|Z|Desolace|N|From Warug.|PRE|1368|
+R Bolgan's Hole|ACTIVE|1369|M|40.4,89.5;38.1,85.7,38.45,90.84|Z|Desolace|N|Take the road that leads south past the Gelkis Village into Feralas. Just before you enter the mountains hang a right and take the path leading down into the pit. Work your way around and up the ramp to the cave entrance.|
+C Broken Tears|QID|1369|L|6083 3|N|Loot the Broken Tears from the Tear of Theradras found on the ground in the cave.
+R Magram Village|ACTIVE|1369|M|67.32,66.51|Z|Desolace|
+T Broken Tears|QID|1369|M|74.8,68.0|Z|Desolace|N|To Warug.|
+A Gizmo for Warug|QID|1371|M|74.8,68.0|Z|Desolace|N|From Warug.|PRE|1369|
+T Gizmo for Warug|QID|1371|M|74.8,68.0|Z|Desolace|N|To Warug.|
+A Khan Shaka|QID|1375|M|74.8,68.0|Z|Desolace|N|From Warug.|PRE|1371|
+R Bolgan's Hole|ACTIVE|1375|M|40.4,89.5;38.1,85.7,38.45,90.84|Z|Desolace|
+K Khan Shaka|ACTIVE|1375|M|40.49,95.49|Z|Desolace|QO|1|N|Once inside the cave and jump up onto the slight ledge behind the tent in front of you.\n[color=FF0000]NOTE: [/color]In addition to all of the other mobs between you and Khan, he is flanked by 2 guards.|
+R Magram Village|ACTIVE|1369|M|67.32,66.51|Z|Desolace|
+T Khan Shaka|QID|1375|M|74.8,68.0|Z|Desolace|N|To Warug.|
+
+; --- Gelkis Alliance chain
+R Magram Village|ACTIVE|1368|M|67.32,66.51|Z|Desolace|N|Follow the main road as far east as it goes. The village is on the south side of the road.|
+K Magram Clan Centaurs|ACTIVE|1368|M|70.76,75.30|Z|Desolace|N|Kill Magram Clan Centaurs until have reached Friendly status (3,000 rep) with The Gelkis Clan.\nIt'll take 75 kills to reach it.|REP|Gelkis Clan Centaur;92;Neutral|
 C Centaur Bounty|QID|1366|ACTIVE|1368|M|70.76,75.30|Z|Desolace|N|Continue killing Centaurs and looting their ears until done.|US|
 R Ghost Walker Post|ACTIVE|1366|M|56.74,56.79|Z|Desolace|
 T Centaur Bounty|QID|1366|M|56.20,59.55|Z|Desolace|N|To Felgur Twocuts.|
 T Catch of the Day|QID|5386|M|55.41,55.80|Z|Desolace|N|To Nataka Longhorn.|
-R Gelkis Village|ACTIVE|1368|M|36.64,77.13|Z|Desolace|N|Follow the road out of Ghost Walker Post and go west at the intersection. The village is on the south side of the road.|REP|Gelkis Clan Centaur;92;friendly|
+; --- Gelkis Alliance chain
+R Gelkis Village|ACTIVE|1368|M|37.64,78.95|Z|Desolace|REP|Gelkis Clan Centaur;92;friendly|
 T Gelkis Alliance|QID|1368|M|36.24,79.25|Z|Desolace|N|To Uthek the Wise.|REP|Gelkis Clan Centaur;92;friendly|
 A Stealing Supplies|QID|1370|M|36.24,79.25|Z|Desolace|N|From Uthek the Wise.|PRE|1368|REP|Gelkis Clan Centaur;92;friendly|
 R Magram Village|ACTIVE|1370|M|67.20,66.19|Z|Desolace|N|Return to Magram Village.|


### PR DESCRIPTION
- QID to ACTIVE for travel steps
- added or improved upon travel steps where applicable
- added H step to avoid running from Windshear to Sun Rock to fly to Crossroads. Steps adjusted to show in the event that they can't use their hearth.
- F step to Crossroads duplicated to show depending upon player location.