### PR TITLE
Updated Argent Tournament guide for Horde

### DIFF
--- a/WoWPro_Dailies/Horde/WotLK_ArgTour_H.lua
+++ b/WoWPro_Dailies/Horde/WotLK_ArgTour_H.lua
@@ -199,21 +199,36 @@ A Among the Champions|QID|13814|PRE|13795|C|Death Knight|M|73.59,20.09|N|From Il
 A Taking Battle To The Enemy|QID|13813|PRE|13795|C|Death Knight|M|73.80,19.45|N|From Zor'be the Bloodletter.|FACTION|Horde|
 
 ; Crusader Quests
-A Deathspeaker Kharos|QID|14105|M|69.96,23.44|CC|N|From High Crusader Adelard|
-A The Fate of the Fallen|QID|14107|M|69.96,23.44|CC|N|From Crusader Silverdawn|
+; A Deathspeaker Kharos|QID|14105|M|69.96,23.44|CC|N|From High Crusader Adelard|
+; A Drottinn Hrothgar|QID|14101|M|69.96,23.44|CC|N|From High Crusader Adelard|
+; A Mistcaller Yngvar|QID|14102|M|69.96,23.44|CC|N|From High Crusader Adelard|
+; A Ornolf the Scarred|QID|14104|M|69.96,23.44|CC|N|From High Crusader Adelard|
+A Adelard gives 1 of 4|QID|14105^14104^14102^14101|M|76.10,24.10|N|From High Crusader Adelard|
+;A The Fate of the Fallen|QID|14107|M|69.96,23.44|CC|N|From Crusader Silverdawn|
+;A Get Kraken!|QID|14108|M|69.96,23.44|CC|N|From Crusader Silverdawn|
+A Silverdawn gives 1 of 2|QID|14107^14108|M|76.10,24.10|N|From Crusader Silverdawn|
 
 
 ; Generic Completions for Valiants and Champions
 C The Grand Melee|QID|13782^13767^13756|M|75.28,18.42|N|Mount on your new race specific ride, stack up on your shields, and then talk to an Horde Valiant from behind to start.  Break shield and charge as they move away!|U|46069|
 C Among the Champions|QID|13811^13814|M|71.54,23.74|N|Go challenge some champions. Avoid getting charged by your opponnent and try to get a charge and sheild break and thrust while they are low.|
+C Get Kraken!|QID|14108|M|69.80,22.20|N|Mount one of the Stabled Argent Hippogryphs outside the tent. While flying over the ships, use the Flaming Spears you were given to kill 6 Kvaldirs on the ship. Throw 8 spears at the Kraken as well. If you kill the Kraken, you will get a quest item for extra gold.|
+; A Identifying the Remains|QID|14095|M|69.80,22.20|CC|N|From Kraken Tooth|
 
 C What Do You Feed a Yeti, Anyway?|QID|14145|M|74.35,10.10|N|Go to the Horde Boat and get some chum|L|47036 6|
 C What Do You Feed a Yeti, Anyway?|QID|14145|M|74.35,10.10|CN|N|Jump into the water around these points, use the chum and get the meat.|U|47036|
 
 C Rescue at Sea|QID|14136|M|49.8,49.6;50.10,49.20;43.20,53.70|Z|Hrothgar's Landing|CN|N|Kill Vrykul Berserkers and Harpooners.|
-C A Leg Up|QID|14143|M|43.80,24.10;51.90,28.20;53.90,19.10;43.45,33.90;53.45,17.15;50.51,15.35;43.38,27.16;55.58,15.23;46.98,33.97;42.95,30.55;56.21,18.30;47.45,3.25;52.84,26.35;55.42,25.02;55.46,21.09;45.18,4.28;50.19,31.18|Z|Hrothgar's Landing|CN|N|Loot tallstrider legs.|
-C Stop The Aggressors|QID|14140|M|54.20,21.60;55.20,15.20;52.40,15.55;43.45,33.75;43.42,26.98;56.20,17.80;48.59,33.11;49.45,30.43;54.60,24.93;52.75,26.20;56.70,21.73;42.92,30.90;54.88,19.59;45.53,33.48|Z|Hrothgar's Landing|CN|N|Kill Kvaldir.|
-C The Light's Mercy|QID|14144|M|53.20,17.40;55.20,16.00;57.00,20.60;55.50,25.20;44.90,31.50;43.60,29.65;50.60,15.30;43.15,27.60;54.85,18.67;44.30,34.40;52.67,26.92;54.35,23.08;50.26,29.29;57.10,23.70;42.60,32.32;47.77,32.54|Z|Hrothgar's Landing|CN|N|Administer last rites by using your book near slain Tualiq Villagers.|U|46870|
+C A Leg Up|QID|14143|M|43.80,24.10;51.90,28.20;53.90,19.10;43.45,33.90;53.45,17.15;50.51,15.35;43.38,27.16;55.58,15.23;46.98,33.97;42.95,30.55;56.21,18.30;47.45,3.25;52.84,26.35;55.42,25.02;55.46,21.09;45.18,4.28;50.19,31.18|Z|Hrothgar's Landing|CN|N|Loot tallstrider legs.|S|
+C Stop The Aggressors|QID|14140|M|54.20,21.60;55.20,15.20;52.40,15.55;43.45,33.75;43.42,26.98;56.20,17.80;48.59,33.11;49.45,30.43;54.60,24.93;52.75,26.20;56.70,21.73;42.92,30.90;54.88,19.59;45.53,33.48|Z|Hrothgar's Landing|CN|N|Kill Kvaldir.|S|
+C The Light's Mercy|QID|14144|M|53.20,17.40;55.20,16.00;57.00,20.60;55.50,25.20;44.90,31.50;43.60,29.65;50.60,15.30;43.15,27.60;54.85,18.67;44.30,34.40;52.67,26.92;54.35,23.08;50.26,29.29;57.10,23.70;42.60,32.32;47.77,32.54|Z|Hrothgar's Landing|CN|N|Administer last rites by using your book near slain Tualiq Villagers.|S|U|46870|
+C Ornolf the Scarred|QID|14104|M|58.55,31.75|Z|Hrothgar's Landing|CC|N|Use the quest item on the deck of the ship and kill Ornolf the Scarred.|U|47029|
+C Drottin Hrothgar|QID|14101|M|50.10,15.35|Z|Hrothgar's Landing|CC|N|Use the quest item in front of the Tuskarr statue and kill Drottinn Hrothgar.|U|47006|
+C Mistcaller Yngvar|QID|14102|M|43.90,24.40|Z|Hrothgar's Landing|CC|N|Use the quest item next to the brazier in the cave and kill Mistcaller Yngvar.|U|47009|
+C A Leg Up|QID|14143|M|43.80,24.10;51.90,28.20;53.90,19.10;43.45,33.90;53.45,17.15;50.51,15.35;43.38,27.16;55.58,15.23;46.98,33.97;42.95,30.55;56.21,18.30;47.45,3.25;52.84,26.35;55.42,25.02;55.46,21.09;45.18,4.28;50.19,31.18|Z|Hrothgar's Landing|CN|N|Loot tallstrider legs.|US|
+C Stop The Aggressors|QID|14140|M|54.20,21.60;55.20,15.20;52.40,15.55;43.45,33.75;43.42,26.98;56.20,17.80;48.59,33.11;49.45,30.43;54.60,24.93;52.75,26.20;56.70,21.73;42.92,30.90;54.88,19.59;45.53,33.48|Z|Hrothgar's Landing|CN|N|Kill Kvaldir.|US|
+C The Light's Mercy|QID|14144|M|53.20,17.40;55.20,16.00;57.00,20.60;55.50,25.20;44.90,31.50;43.60,29.65;50.60,15.30;43.15,27.60;54.85,18.67;44.30,34.40;52.67,26.92;54.35,23.08;50.26,29.29;57.10,23.70;42.60,32.32;47.77,32.54|Z|Hrothgar's Landing|CN|N|Administer last rites by using your book near slain Tualiq Villagers.|US|U|46870|
+
 
 C Deathspeaker Kharos|QID|14105|M|64.30,21.50|CC|N|Kill Deathspeaker Kharos|
 
@@ -299,7 +314,12 @@ T Taking Battle To The Enemy|QID|13810|M|69.92,23.53|N|To Cellian Daybreak|
 
 ; Crusader Turnins
 T Deathspeaker Kharos|QID|14105|M|69.96,23.44|CC|N|To High Crusader Adelard|
+T Drottinn Hrothgar|QID|14101|M|69.96,23.44|CC|N|To High Crusader Adelard|
+T Mistcaller Yngvar|QID|14102|M|69.96,23.44|CC|N|To High Crusader Adelard|
+T Ornolf the Scarred|QID|14104|M|69.96,23.44|CC|N|To High Crusader Adelard|
 T The Fate of the Fallen|QID|14107|M|69.96,23.44|CC|N|To Crusader Silverdawn|
+T Get Kraken!|QID|14108|M|69.96,23.44|CC|N|To Crusader Silverdawn|
+T Identifying the Remains|QID|14095|M|69.96,23.44|CC|N|To Crusader Silverdawn|
 
 
 T Threat From Above|QID|13812|M|73.80,20.06|N|To Crok Scourgebane. Get the Purse.|

--- a/WoWPro_Dailies/Horde/WotLK_ArgTour_H.lua
+++ b/WoWPro_Dailies/Horde/WotLK_ArgTour_H.lua
@@ -14,7 +14,9 @@ return [[
 
 ; Quick and dirty adding of Horde to the old Alliance guide, and moved to Neutral.  I know Nzall was asking about this, and was also trying himself to make a guide. This is here incase he doesn't and or to 'merge' that one here.
 ; this has been done by Blanckaert 4/Jan/2021
-; Can't move to neutral, as different Guide Factions 1094 for alliance, 1124 for horde
+; Changes made by Nzall 2021/12/16 and 2021/12/24
+; Known issues: some Valiant quests may have wrong Quest IDs, especially for Troll and Tauren quests since the corresponding Alliance steps were missing from the guide
+; Can't move to neutral, as different Guide Factions 1124 for alliance, 1124 for horde
 
 N The Argent Tournament|N|Quests for the The Argent Tournament, for your faction, and MAYBE for the others too!|
 
@@ -47,7 +49,6 @@ A Up To The Challenge|QID|13678|M|76.4,19.4|PRE|13829&13839&13839|N|From Magiste
 ; Black Knight Quest Chain
 
 A The Black Knight of Silverpine?|QID|13634|M|69.43,23.02|N|From Crusader Rhydalla.|FACTION|Horde|	; Need Pre?
-C The Black Knight of Westfall?|ACTIVE|13633|M|42.10,69.66|Z|Westfall|N|Get to Moonbrook in Westfall and look at the Dusty Journal.|FACTION|Alliance|
 C The Black Knight of Silverpine?|ACTIVE|13634|M|53.1,28.1|Z|Silverpine Forest|N|Get to just past the Forsaken Rear Guard in Silverpine Forest and read the Dusty Journal.|FACTION|Horde|
 T The Black Knight of Silverpine?|QID|13634|M|69.43,23.02|N|To Crusader Rhydalla.|FACTION|Horde|
 A The Seer's Crystal|QID|13641|PRE|13633^13634|M|69.43,23.02|N|From Crusader Rhydalla.|
@@ -80,9 +81,9 @@ T The Black Knight's Fate|QID|14017|M|69.43,23.02|N|To Crusader Rhydalla.|
 
 ; Aspirant Quests
 
-A One of Three|QID|13673^13674^13675|LEAD|13679|M|76.2,24.2|N|From Magister Edien Sunhollow, one of three quests.|FACTION|Horde|
-A Learning The Reins|QID|13677|M|76.2,24.2|N|From Galathia Brightdawn.|FACTION|Horde|
-A Training In The Field|QID|13676|M|76.2,24.2|N|From Amariel Sunsworn.|FACTION|Horde|
+A One of Three|QID|13673^13674^13675|ACTIVE|13680|M|76.2,24.2|N|From Magister Edien Sunhollow, one of three quests.|FACTION|Horde|
+A Learning The Reins|QID|13677|ACTIVE|13680|M|76.2,24.2|N|From Galathia Brightdawn.|FACTION|Horde|
+A Training In The Field|QID|13676|ACTIVE|13680|M|76.2,24.2|N|From Amariel Sunsworn.|FACTION|Horde|
 
 C Learning The Reins|QID|13625|N|Mount up and go practice on the fields.|U|46069|
 C Training In The Field|QID|13676|QO|1|M|PLAYER|N|Equip your regular weapon(s) and go kill any Scourge with Icecrown.|
@@ -108,107 +109,126 @@ T Up To The Challenge|QID|13678|M|76.2,24.2|N|To Magister Edien Sunhollow.|FACTI
 ; Merge / rework with Horde done to this point, ALL based on Wowhead info.
 ; all the below need changing to Horde.
 
-A The Aspirant's Challenge|QID|13679|PRE|13672|M|76.47,19.40|N|From Arcanist Taelis.|FACTION|Alliance|
-C The Aspirant's Challenge|QID|13679|PRE|13672|M|71.43,19.56|N|Mount up and stack up on your shields BEFORE talking to the Squire.  Favor charging your opponjent.|U|46069|
-T The Aspirant's Challenge|QID|13679|PRE|13672|M|76.47,19.40|N|From Arcanist Taelis.|
+A The Aspirant's Challenge|QID|13680|PRE|13678|M|76.2,24.2|N|From Magister Edien Sunhollow.|FACTION|Horde|
+C The Aspirant's Challenge|QID|13680|PRE|13678|M|71.43,19.56|N|Mount up and stack up on your shields BEFORE talking to the Squire.  Favor charging your opponent.|U|46069|
+T The Aspirant's Challenge|QID|13680|PRE|13678|M|76.2,24.2|N|From Magister Edien Sunhollow.|
 
 ; These kick off the race specific initial quests.
-A A Valiant Of The Exodar|QID|13690|PRE|13679|R|Draenei|M|76.47,19.40|N|From Arcanist Taelis.|FACTION|Alliance|
-T A Valiant Of The Exodar|QID|13690|PRE|13679|M|76.10,19.10|N|To Colosos.|
-A A Valiant Of Ironforge|QID|13685|PRE|13679|R|Dwarf|M|76.47,19.40|N|From Arcanist Taelis.|FACTION|Alliance|
-T A Valiant Of Ironforge|QID|13685|PRE|13679|M|76.64,19.49|N|To Lana Stouthammer.|
-A A Valiant Of Stormwind|QID|13684|PRE|13679|R|Human|M|76.47,19.40|N|From Arcanist Taelis.|FACTION|Alliance|
-T A Valiant Of Stormwind|QID|13684|PRE|13679|M|76.60,19.12|N|To Marshal Jacob Alerius.|
-A A Valiant Of Darnassus|QID|13689|PRE|13679|R|Night Elf;Worgen|M|76.47,19.40|N|From Arcanist Taelis.|FACTION|Alliance|
-T A Valiant Of Darnassus|QID|13689|PRE|13679|M|76.34,19.03|N|To Jaelyne Evensong.|
-A A Valiant Of Gnomeregan|QID|13688|PRE|13679|R|Gnome|M|76.47,19.40|N|From Arcanist Taelis.|FACTION|Alliance|
-T A Valiant Of Gnomeregan|QID|13688|PRE|13679|M|76.55,19.83|N|To Ambrose Boltspark.|
+A A Valiant Of Silvermoon|QID|13696|PRE|13680|R|Blood Elf|M|76.2,24.2|N|From Magister Edien Sunhollow.|FACTION|Horde|
+T A Valiant Of Silvermoon|QID|13696|PRE|13680|M|76.40,23.90|N|To Eressea Dawnsinger.|
+A A Valiant Of Thunder Bluff|QID|13694|PRE|13680|R|Tauren|M|76.2,24.2|N|From Magister Edien Sunhollow.|FACTION|Horde|
+T A Valiant Of Thunder Bluff|QID|13694|PRE|13680|M|76.40,24.55|N|To Runok Wildmane.|
+A A Valiant Of Orgrimmar|QID|13691|PRE|13680|R|Orc|M|76.2,24.2|N|From Magister Edien Sunhollow.|FACTION|Horde|
+T A Valiant Of Orgrimmar|QID|13691|PRE|13680|M|76.40,24.50|N|To Mokra the Skullcrusher.|
+A A Valiant Of Undercity|QID|13695|PRE|13680|R|Undead|M|76.2,24.2|N|From Magister Edien Sunhollow.|FACTION|Horde|
+T A Valiant Of Undercity|QID|13695|PRE|13680|M|76.50,24.20|N|To Deathstalker Visceri.|
+A A Valiant Of Sen'jin|QID|13693|PRE|13680|R|Troll|M|76.2,24.2|N|From Magister Edien Sunhollow.|FACTION|Horde|
+T A Valiant Of Sen'jin|QID|13693|PRE|13680|M|76.00,24.45|N|To Zul'tore.|
 
 ; Champion level kick-offs
-A Pick Your New Faction|QID|13593^13703^13704^13705^13706|PRE|6|M|65.38,19.43|N|Talk to one of the NPCs for your new faction!|FACTION|Alliance|
-T Valiant Of The Exodar|QID|13705|M|76.10,19.10|N|To Colosos.|
-T Valiant Of Ironforge|QID|13703|M|76.64,19.49|N|To Lana Stouthammer.|
-T Valiant Of Stormwind|QID|13593|M|76.60,19.12|N|To Marshal Jacob Alerius.|
-T Valiant Of Darnassus|QID|13706|M|76.34,19.03|N|To Jaelyne Evensong.|
-T Valiant Of Gnomeregan|QID|13704|M|76.55,19.83|N|To Ambrose Boltspark.|
+A Pick Your New Faction|QID|13707^13709^13708^13711^13710|PRE|6|M|65.38,19.43|N|Talk to one of the NPCs for your new faction!|FACTION|Horde|
+T Valiant Of Silvermoon|QID|13711|M|76.40,23.90|N|To Eressea Dawnsinger.|
+T Valiant Of Thunder Bluff|QID|13709|M|76.40,24.55|N|To Runok Wildmane.|
+T Valiant Of Orgrimmar|QID|13707|M|76.40,24.50|N|To Mokra the Skullcrusher.|
+T Valiant Of Undercity|QID|13710|M|76.50,24.20|N|To Deathstalker Visceri.|
+T Valiant Of Gnomeregan|QID|13708|M|76.00,24.45|N|To Zul'tore.|
 
 ; The PRE clause selects allows either the race specific or the generic Valiant of * quest
-A The Valiant's Charge|QID|13718|PRE|13684^13593|M|76.60,19.12|N|From Marshal Jacob Alerius.|FACTION|Alliance|
-A The Valiant's Charge|QID|13716|PRE|13690^13705|M|76.10,19.10|N|From Colosos.|FACTION|Alliance|
-A The Valiant's Charge|QID|13714|PRE|13685^13703|M|76.64,19.49|N|From Lana Stouthammer.|FACTION|Alliance|
-A The Valiant's Charge|QID|13715|PRE|13688^13704|M|76.55,19.83|N|From Ambrose Boltspark.|FACTION|Alliance|
-A The Valiant's Charge|QID|13717|PRE|13689^13706|M|76.34,19.03|N|From Jaelyne Evensong.|FACTION|Alliance|
+A The Valiant's Charge|QID|13697|PRE|13691^13707|M|76.40,24.50|N|From Mokra the Skullcrusher.|FACTION|Horde|
+A The Valiant's Charge|QID|13722|PRE|13696^13711|M|76.40,23.90|N|From Eressea Dawnsinger.|FACTION|Horde|
+A The Valiant's Charge|QID|13720|PRE|13694^13709|M|76.40,24.55|N|From Runok Wildmane.|FACTION|Horde|
+A The Valiant's Charge|QID|13719|PRE|13693^13708|M|76.00,24.45|N|From Zul'tore.|FACTION|Horde|
+A The Valiant's Charge|QID|13721|PRE|13695^13710|M|76.50,24.20|N|From Deathstalker Visceri.|FACTION|Horde|
 
-; Valiant Quests (Night Elf/Worgen Primary)
-A One of Three|QID|13757^13758^13759|ACTIVE|13717|M|76.34,19.03|N|From Jaelyne Evensong, one of 3.|FACTION|Alliance|
-A A Valiant's Field Training|QID|13760|ACTIVE|13717|M|76.30,18.99|N|From Illestria Bladesinger.|FACTION|Alliance|
-A The Grand Melee|QID|13761|ACTIVE|13717|M|76.40,19.00|N|From Airae Starseeker.|FACTION|Alliance|
-A At The Enemy's Gates|QID|13855|ACTIVE|13717|M|76.40,19.00|N|From Airae Starseeker.|FACTION|Alliance|
+; Valiant Quests (Undead Primary)
+A One of Three|QID|13757^13758^13759|ACTIVE|13721|M|76.50,24.20|N|From Deathstalker Visceri, one of 3.|FACTION|Horde|
+A A Valiant's Field Training|QID|13781|ACTIVE|13721|M|76.50,24.20|N|From Sarah Chalke.|FACTION|Horde|
+A The Grand Melee|QID|13782|ACTIVE|13721|M|76.50,24.20|N|From Handler Dretch.|FACTION|Horde|
+A At The Enemy's Gates|QID|13860|ACTIVE|13721|M|76.50,24.20|N|From Handler Dretch.|FACTION|Horde|
 
-; Valiant Quests (Human Primary)
-A One of Three|QID|13600^13603^13616|ACTIVE|13718|M|76.60,19.12|N|From Marshal Jacob Alerius.|FACTION|Alliance|
-A A Valiant's Field Training|QID|13592|ACTIVE|13718|M|76.53,19.08|N|Sir Marcus Barlowe.|FACTION|Alliance|
-A The Grand Melee|QID|13665|ACTIVE|13718|M|76.62,19.21|N|From Captain Joseph Holley.|FACTION|Alliance|
-A At The Enemy's Gates|QID|13847|ACTIVE|13718|M|76.62,19.21|N|From Captain Joseph Holley.|FACTION|Alliance|
+; Valiant Quests (Orc Primary)
+A One of Three|QID|13600^13603^13616|ACTIVE|13697|M|76.40,24.50|N|From Mokra the Skullcrusher.|FACTION|Horde|
+A A Valiant's Field Training|QID|13765|ACTIVE|13697|M|76.50,24.20|N|From Akinos.|FACTION|Horde|
+A The Grand Melee|QID|13767|ACTIVE|13697|M|76.50,24.20|N|From Morah Worgsister.|FACTION|Horde|
+A At The Enemy's Gates|QID|13856|ACTIVE|13697|M|76.50,24.20|N|From Morah Worgsister.|FACTION|Horde|
 
-; Valiant Quests (Draenei Primary)
-A One of Three|QID|13752^13753^13754|ACTIVE|13716|M|76.10,19.10|N|From Colosos.|FACTION|Alliance|
-A A Valiant's Field Training|QID|13755|ACTIVE|13716|M|76.08,19.19|N|Saandos.|FACTION|Alliance|
-A The Grand Melee|QID|13756|ACTIVE|13716|M|76.15,19.07|N|From Ranii.|FACTION|Alliance|
-A At The Enemy's Gates|QID|13854|ACTIVE|13716|M|76.15,19.07|N|From Ranii.|FACTION|Alliance|
-; Valiant Quests (Dwarf Primary)
+; Valiant Quests (Blood Elf Primary)
+A One of Three|QID|13752^13753^13754|ACTIVE|13722|M|76.40,23.90|N|From Eressea Dawnsinger.|FACTION|Horde|
+A A Valiant's Field Training|QID|13786|ACTIVE|13722|M|76.40,23.90|N|From Kethiel Sunlance.|FACTION|Horde|
+A The Grand Melee|QID|13756|ACTIVE|13722|M|76.40,23.90|N|From Aneera Thuron.|FACTION|Horde|
+A At The Enemy's Gates|QID|13854|ACTIVE|13722|M|76.40,23.90|N|From Aneera Thuron.|FACTION|Horde|
 
-; Valiant Quests (Gnome Primary)
+; Valiant Quests (Tauren Primary)
+A One of Three|QID|13757^13758^13759|ACTIVE|13720|M|76.40,24.55|N|From Runok Wildmane, one of 3.|FACTION|Horde|
+A A Valiant's Field Training|QID|13766|ACTIVE|13720|M|76.40,24.55|N|From Dern Ragetotem.|FACTION|Horde|
+A The Grand Melee|QID|13777|ACTIVE|13720|M|76.40,24.55|N|From Anka Clawhoof.|FACTION|Horde|
+A At The Enemy's Gates|QID|13858|ACTIVE|13720|M|76.40,24.55|N|From Anka Clawhoof.|FACTION|Horde|
+
+; Valiant Quests (Troll Primary)
+A One of Three|QID|13757^13758^13759|ACTIVE|13719|M|76.00,24.20|N|From Zul'tore, one of 3.|FACTION|Horde|
+A A Valiant's Field Training|QID|13771|ACTIVE|13719|M|76.00,24.20|N|From Shadow Hunter Mezil'Kree.|FACTION|Horde|
+A The Grand Melee|QID|13772|ACTIVE|13719|M|76.00,24.20|N|From Gahju.|FACTION|Horde|
+A At The Enemy's Gates|QID|13857|ACTIVE|13719|M|76.00,24.20|N|From Gahju.|FACTION|Horde|
 
 ; Quests once you are exalted
-; Narasi gives 2 of 5
-; A You've Really Done It This Time, Kul|QID|14096|REP|The Silver Covenant;1094;exalted|M|76.26,19.63|N|From Narasi Snowdawn.|FACTION|Alliance|
-; A Rescue at Sea|QID|14152|REP|The Silver Covenant;1094;exalted|M|76.26,19.63|N|From Narasi Snowdawn.|FACTION|Alliance|
-; A A Leg Up|QID|14074|REP|The Silver Covenant;1094;exalted|M|76.26,19.63|N|From Narasi Snowdawn.|FACTION|Alliance|
-; A Stop The Aggressors|QID|14080|REP|The Silver Covenant;1094;exalted|M|76.26,19.63|N|From Narasi Snowdawn.|FACTION|Alliance|
-; A The Light's Mercy|QID|14077|REP|The Silver Covenant;1094;exalted|M|76.26,19.63|N|From Narasi Snowdawn.|FACTION|Alliance|
-N Narasi gives 2 of 5|REP|The Silver Covenant;1094;exalted|M|76.26,19.63|N|Accept both quests from Narasi Snowdawn and click to continue.|FACTION|Alliance|
+; Girana gives 2 of 5
+; A Rescue at Sea|QID|14136|REP|The Sunreavers;1124;exalted|M|76.10,24.10|N|From Girana the Blooded.|FACTION|Horde|
+; A A Leg Up|QID|14143|REP|The Sunreavers;1124;exalted|M|76.10,24.10|N|From Girana the Blooded.|FACTION|Horde|
+; A Stop The Aggressors|QID|14140|REP|The Sunreavers;1124;exalted|M|76.10,24.10|N|From Girana the Blooded.|FACTION|Horde|
+; A The Light's Mercy|QID|14144|REP|The Sunreavers;1124;exalted|M|76.10,24.10|N|From Girana the Blooded.|FACTION|Horde|
+A Girana gives 1 of 4|QID|14136^14143^14140^14144|REP|The Sunreavers;1124;exalted|M|76.10,24.10|N|Accept both quests from Girana the Blooded and click to continue.|FACTION|Horde|
+A You've Really Done It This Time, Kul|QID|14142|REP|The Sunreavers;1124;exalted|M|76.10,24.10|N|From Girana the Blooded.|FACTION|Horde|
 
-; Savinia gives 1 of 3
-; A Gormok Wants His Snobolds|QID|14090|REP|The Silver Covenant;1094;exalted|M|76.20,19.56|N|From Savinia Loresong|FACTION|Alliance|
-; A What Do You Feed a Yeti, Anyway?|QID|14112|REP|The Silver Covenant;1094;exalted|M|76.20,19.56|N|From Savinia Loresong|FACTION|Alliance|
-; A Breakfast Of Champions|QID|14076|REP|The Silver Covenant;1094;exalted|M|76.20,19.56|N|From Savinia Loresong|FACTION|Alliance|
-A Savinia gives 1 of 3|QID|14076^14090^14112|REP|The Silver Covenant;1094;exalted|M|76.20,19.56|N|From Savinia Loresong|FACTION|Alliance|
+; Tylos gives 1 of 3
+; A Gormok Wants His Snobolds|QID|14141|REP|The Sunreavers;1124;exalted|M|76.10,24.10|N|From Tylos Dawnrunner|FACTION|Horde|
+; A What Do You Feed a Yeti, Anyway?|QID|14145|REP|The Sunreavers;1124;exalted|M|76.10,24.10|N|From Tylos Dawnrunner|FACTION|Horde|
+; A Breakfast Of Champions|QID|14092|REP|The Sunreavers;1124;exalted|M|76.10,24.10|N|From Tylos Dawnrunner|FACTION|Horde|
+A Tylos gives 1 of 3|QID|14092^14141^14145|REP|The Sunreavers;1124;exalted|M|76.10,24.10|N|From Tylos Dawnrunner|FACTION|Horde|
 
 ; Now the Champion Dailies are open, the Class tag controls selection.
 ; Bizarely, both QID 13794 and 13795 show as complete.  Blizzard Bonus Bug!
 
-A Battle Before The Citadel|QID|13861|PRE|13794|C|Druid,Hunter,Mage,Paladin,Priest,Rogue,Shaman,Warlock,Warrior|M|69.96,23.44|N|From Eadric the Pure.|FACTION|Alliance|
-A Threat From Above|QID|13682|PRE|13794&14017|C|Druid,Hunter,Mage,Paladin,Priest,Rogue,Shaman,Warlock,Warrior|M|69.96,23.44|N|From Eadric the Pure.|FACTION|Alliance|
-A Among the Champions|QID|13790|PRE|13794|C|Druid,Hunter,Mage,Paladin,Priest,Rogue,Shaman,Warlock,Warrior|M|69.93,23.33|N|From Luuri.|FACTION|Alliance|
-A Taking Battle To The Enemy|QID|13789|PRE|13794|C|Druid,Hunter,Mage,Paladin,Priest,Rogue,Shaman,Warlock,Warrior|M|69.92,23.53|N|From Cellian Daybreak|FACTION|Alliance|
+A Battle Before The Citadel|QID|13862|PRE|13794|C|Druid,Hunter,Mage,Paladin,Priest,Rogue,Shaman,Warlock,Warrior,Monk,Demon Hunter|M|69.96,23.44|N|From Eadric the Pure.|FACTION|Horde|
+A Threat From Above|QID|13809|PRE|13794&14017|C|Druid,Hunter,Mage,Paladin,Priest,Rogue,Shaman,Warlock,Warrior,Monk,Demon Hunter|M|69.96,23.44|N|From Eadric the Pure.|FACTION|Horde|
+A Among the Champions|QID|13811|PRE|13794|C|Druid,Hunter,Mage,Paladin,Priest,Rogue,Shaman,Warlock,Warrior,Monk,Demon Hunter|M|69.93,23.33|N|From Luuri.|FACTION|Horde|
+A Taking Battle To The Enemy|QID|13810|PRE|13794|C|Druid,Hunter,Mage,Paladin,Priest,Rogue,Shaman,Warlock,Warrior,Monk,Demon Hunter|M|69.92,23.53|N|From Cellian Daybreak|FACTION|Horde|
 
-A Threat From Above|QID|13788|PRE|13795&14017|C|Death Knight|M|73.80,20.06|N|From Crok Scourgebane.|FACTION|Alliance|
-A Battle Before The Citadel|QID|13864|PRE|13795|C|Death Knight|M|73.80,20.06|N|From Crok Scourgebane.|FACTION|Alliance|
-A Among the Champions|QID|13793|PRE|13795|C|Death Knight|M|73.59,20.09|N|From Illyrie Nightfall.|FACTION|Alliance|
-A Taking Battle To The Enemy|QID|13791|PRE|13795|C|Death Knight|M|73.80,19.45|N|From Zor'be the Bloodletter.|FACTION|Alliance|
+A Threat From Above|QID|13812|PRE|13795&14017|C|Death Knight|M|73.80,20.06|N|From Crok Scourgebane.|FACTION|Horde|
+A Battle Before The Citadel|QID|13863|PRE|13795|C|Death Knight|M|73.80,20.06|N|From Crok Scourgebane.|FACTION|Horde|
+A Among the Champions|QID|13814|PRE|13795|C|Death Knight|M|73.59,20.09|N|From Illyrie Nightfall.|FACTION|Horde|
+A Taking Battle To The Enemy|QID|13813|PRE|13795|C|Death Knight|M|73.80,19.45|N|From Zor'be the Bloodletter.|FACTION|Horde|
+
+; Crusader Quests
+A Deathspeaker Kharos|QID|14105|M|69.96,23.44|CC|N|From High Crusader Adelard|
+A The Fate of the Fallen|QID|14107|M|69.96,23.44|CC|N|From Crusader Silverdawn|
+
 
 ; Generic Completions for Valiants and Champions
-C The Grand Melee|QID|13761^13665^13756|M|75.28,18.42|N|Mount on your new race specific ride, stack up on your shields, and then talk to an Alliance Valiant from behind to start.  Break shield and charge as they move away!|U|46069|
-C Among the Champions|QID|13790^13793|M|71.54,23.74|N|Go challenge some champions. Avoid getting charged by your opponnent and try to get a charge and sheild break and thrust while they are low.|
+C The Grand Melee|QID|13782^13767^13756|M|75.28,18.42|N|Mount on your new race specific ride, stack up on your shields, and then talk to an Horde Valiant from behind to start.  Break shield and charge as they move away!|U|46069|
+C Among the Champions|QID|13811^13814|M|71.54,23.74|N|Go challenge some champions. Avoid getting charged by your opponnent and try to get a charge and sheild break and thrust while they are low.|
 
-C What Do You Feed a Yeti, Anyway?|QID|14112|M|66.5,8.3|N|Go to the Alliance Boat and get some chum|L|47036 6|
-C What Do You Feed a Yeti, Anyway?|QID|14112|M|44.8,12.6;67.2,8.2;74.5,9.5|CN|N|Jump into the water around these points, use the chum and get the meat.|U|47036|
+C What Do You Feed a Yeti, Anyway?|QID|14145|M|74.35,10.10|N|Go to the Horde Boat and get some chum|L|47036 6|
+C What Do You Feed a Yeti, Anyway?|QID|14145|M|74.35,10.10|CN|N|Jump into the water around these points, use the chum and get the meat.|U|47036|
 
-C Rescue at Sea|QID|14152|M|49.8,49.6;50.10,49.20;43.20,53.70|Z|Hrothgar's Landing|CN|N|Kill Vrykul Berserkers and Harpooners.|
-C A Leg Up|QID|14074|M|43.80,24.10;51.90,28.20;53.90,19.10;43.45,33.90;53.45,17.15;50.51,15.35;43.38,27.16;55.58,15.23;46.98,33.97;42.95,30.55;56.21,18.30;47.45,3.25;52.84,26.35;55.42,25.02;55.46,21.09;45.18,4.28;50.19,31.18|Z|Hrothgar's Landing|CN|N|Loot tallstrider legs.|
-C Stop The Aggressors|QID|14080|M|54.20,21.60;55.20,15.20;52.40,15.55;43.45,33.75;43.42,26.98;56.20,17.80;48.59,33.11;49.45,30.43;54.60,24.93;52.75,26.20;56.70,21.73;42.92,30.90;54.88,19.59;45.53,33.48|Z|Hrothgar's Landing|CN|N|Kill Kvaldir.|
-C The Light's Mercy|QID|14077|M|53.20,17.40;55.20,16.00;57.00,20.60;55.50,25.20;44.90,31.50;43.60,29.65;50.60,15.30;43.15,27.60;54.85,18.67;44.30,34.40;52.67,26.92;54.35,23.08;50.26,29.29;57.10,23.70;42.60,32.32;47.77,32.54|Z|Hrothgar's Landing|CN|N|Administer last rites by using your book near slain Tualiq Villagers.|U|46870|
+C Rescue at Sea|QID|14136|M|49.8,49.6;50.10,49.20;43.20,53.70|Z|Hrothgar's Landing|CN|N|Kill Vrykul Berserkers and Harpooners.|
+C A Leg Up|QID|14143|M|43.80,24.10;51.90,28.20;53.90,19.10;43.45,33.90;53.45,17.15;50.51,15.35;43.38,27.16;55.58,15.23;46.98,33.97;42.95,30.55;56.21,18.30;47.45,3.25;52.84,26.35;55.42,25.02;55.46,21.09;45.18,4.28;50.19,31.18|Z|Hrothgar's Landing|CN|N|Loot tallstrider legs.|
+C Stop The Aggressors|QID|14140|M|54.20,21.60;55.20,15.20;52.40,15.55;43.45,33.75;43.42,26.98;56.20,17.80;48.59,33.11;49.45,30.43;54.60,24.93;52.75,26.20;56.70,21.73;42.92,30.90;54.88,19.59;45.53,33.48|Z|Hrothgar's Landing|CN|N|Kill Kvaldir.|
+C The Light's Mercy|QID|14144|M|53.20,17.40;55.20,16.00;57.00,20.60;55.50,25.20;44.90,31.50;43.60,29.65;50.60,15.30;43.15,27.60;54.85,18.67;44.30,34.40;52.67,26.92;54.35,23.08;50.26,29.29;57.10,23.70;42.60,32.32;47.77,32.54|Z|Hrothgar's Landing|CN|N|Administer last rites by using your book near slain Tualiq Villagers.|U|46870|
 
-C You've Really Done It This Time, Kul|QID|14096|M|64.40,21.60;61.71,21.16;60.8,23.0|CC|N|Kill the cultists, loot keys and rescue silly Kul and his buddies.|
+C Deathspeaker Kharos|QID|14105|M|64.30,21.50|CC|N|Kill Deathspeaker Kharos|
 
-C Threat From Above|QID|13788^13682|M|45.58,32.23;45.22,34.30|CN|N|Defeat Chillmaw and 3 Cultist Bombardiers.|
+C You've Really Done It This Time, Kul|QID|14142|M|64.40,21.60;61.71,21.16;60.8,23.0|CC|N|Kill the cultists, loot keys and rescue silly Kul and his buddies.|
 
-C A Valiant's Field Training|QID|13760^13592^13755|M|39.60,58.20;39.50,52.40;42.20,57.50;47.00,53.50;42.90,54.20;39.98,55.08;46.34,49.91;44.41,52.20;42.17,49.54;44.95,56.00;42.15,45.80|CN|N|Kill Converted Heroes.|
-C Taking Battle To The Enemy|QID|13789^13791|M|79.40,23.20;54.50,27.90;72.47,36.65;68.55,63.40;54.70,33.00;61.15,22.75;54.97,45.89;69.47,65.62;62.66,21.02;71.22,38.78;53.30,8.70;67.35,65.10;67.60,37.35;64.68,21.91;54.23,30.30;69.56,36.90;71.85,44.10;52.67,46.15;68.89,39.36;60.70,20.48;56.46,29.15;73.12,41.49;52.07,30.27;52.32,33.79;70.65,40.80;42.90,25.27;75.01,44.00;49.37,32.95|CN|N|Kill members of the Cult of the Damned.|
+C Threat From Above|QID|13812^13809|M|45.58,32.23;45.22,34.30|CN|N|Defeat Chillmaw and 3 Cultist Bombardiers.|
 
-C At The Enemy's Gates|QID|13855^13847^13854|M|49.00, 71.40|N|Mount up. Run over the footmen, lieutenants have red floating shields. Stay away from the commanders in green shields!|U|46069|
-C Battle Before The Citadel|QID|13864^13861|M|49.00,71.40|N|Mount up and now go after the commanders with the green shields. Go for the isolated commanders. |
+C The Fate of the Fallen|QID|14107|M|49,40|CC|N|Loot Crystals (small gems) around the area and use the quest item on 6 neutral mobs without chains.|
+
+
+C A Valiant's Field Training|QID|13781^13765^13786|M|39.60,58.20;39.50,52.40;42.20,57.50;47.00,53.50;42.90,54.20;39.98,55.08;46.34,49.91;44.41,52.20;42.17,49.54;44.95,56.00;42.15,45.80|CN|N|Kill Converted Heroes.|
+C Taking Battle To The Enemy|QID|13810^13813|M|79.40,23.20;54.50,27.90;72.47,36.65;68.55,63.40;54.70,33.00;61.15,22.75;54.97,45.89;69.47,65.62;62.66,21.02;71.22,38.78;53.30,8.70;67.35,65.10;67.60,37.35;64.68,21.91;54.23,30.30;69.56,36.90;71.85,44.10;52.67,46.15;68.89,39.36;60.70,20.48;56.46,29.15;73.12,41.49;52.07,30.27;52.32,33.79;70.65,40.80;42.90,25.27;75.01,44.00;49.37,32.95|CN|N|Kill members of the Cult of the Damned.|
+
+C At The Enemy's Gates|QID|13860^13856^13854^13858^13857|M|49.00, 71.40|N|Mount up. Run over the footmen, lieutenants have red floating shields. Stay away from the commanders in green shields!|U|46069|
+C Battle Before The Citadel|QID|13863^13862|M|49.00,71.40|N|Mount up and now go after the commanders with the green shields. Go for the isolated commanders. |
 
 C A Blade Fit For A Champion|QID|13757^13603^13752|M|60.4,52.0|Z|Grizzly Hills|T|Lake Frog|U|44986|L|44981|N|Kiss frogs till you get a princess.  Then ask for the blade.|
 C A Worthy Weapon|QID|13758^13600^13753|M|68.75,76.38;72.62,73.12;70.56,74.71|L|45000 4|CN|N|Pick flowers along the Ironwall Dam.|
@@ -216,90 +236,111 @@ C A Worthy Weapon|QID|13758^13600^13753|M|93,26|Z|Dragonblight|U|45000|N|Use the
 C The Edge Of Winter|QID|13759^13616^13754|M|55.5,74.9|Z|Crystalsong Forest|N|Kill Lord Everblaze and loot the everburning ember from his corpse.|L|45005|
 C The Edge Of Winter|QID|13759^13616^13754|M|42.19,19.66|Z|Howling Fjord|N|Find the maiden encased in ice and use the ember on her.|T|Maiden of Winter's Breath Lake|U|45005|L|45003|
 
-C Gormok Wants His Snobolds|QID|14090|M|44.05,81.68|Z|The Storm Peaks|T|Snowblind Follower|U|46855|N|Snag em!|
-C Breakfast Of Champions|QID|14076|M|42.70,54.40;43.40,56.75;46.20,61.80;40.67,52.56;43.16,60.16;38.58,61.11;38.12,55.58|Z|The Storm Peaks|T|Deep Jormungar|U|46893|CN|N|Find snow mounts and use the drums to get the Jormungar out. Kill and get the eggs.|
+C Gormok Wants His Snobolds|QID|14141|M|44.05,81.68|Z|The Storm Peaks|T|Snowblind Follower|U|46855|N|Snag em!|
+C Breakfast Of Champions|QID|14092|M|42.70,54.40;43.40,56.75;46.20,61.80;40.67,52.56;43.16,60.16;38.58,61.11;38.12,55.58|Z|The Storm Peaks|T|Deep Jormungar|U|46893|CN|N|Find snow mounts and use the drums to get the Jormungar out. Kill and get the eggs.|
 
-; NightElf/Worgen Valiant Turnins
-T A Valiant's Field Training|QID|13760|M|76.30,18.99|N|From Illestria Bladesinger.|
-T A Blade Fit For A Champion|QID|13757|M|76.34,19.03|N|From Jaelyne Evensong.|
-T A Worthy Weapon|QID|13758|M|76.34,19.03|N|From Jaelyne Evensong.|
-T The Edge Of Winter|QID|13759|M|76.34,19.03|N|From Jaelyne Evensong.|
-T The Grand Melee|QID|13761|M|76.40,19.00|N|From Airae Starseeker.|
-T At The Enemy's Gates|QID|13855|M|76.40,19.00|N|From Airae Starseeker.|
+; Undead Valiant Turnins
+T A Valiant's Field Training|QID|13781|M|76.50,24.20|N|From Sarah Chalke.|
+T A Blade Fit For A Champion|QID|13757|M|76.50,24.20|N|From Deathstalker Visceri.|
+T A Worthy Weapon|QID|13758|M|76.50,24.20|N|From Deathstalker Visceri.|
+T The Edge Of Winter|QID|13759|M|76.50,24.20|N|From Deathstalker Visceri.|
+T The Grand Melee|QID|13782|M|76.50,24.20|N|From Handler Dretch.|
+T At The Enemy's Gates|QID|13860|M|76.50,24.20|N|From Handler Dretch.|
 
-; Human Valiant Turnins
-T A Valiant's Field Training|QID|13592|M|76.53,19.08|N|To Sir Marcus Barlowe.|
-T A Blade Fit For A Champion|QID|13603|M|76.60,19.12|N|To Marshal Jacob Alerius.|
-T A Worthy Weapon|QID|13600|M|76.60,19.12|N|To Marshal Jacob Alerius.|
-T The Edge Of Winter|QID|13616|M|76.60,19.12|N|To Marshal Jacob Alerius.|
-T The Grand Melee|QID|13665|M|76.62,19.21|N|To Captain Joseph Holley.|
-T At The Enemy's Gates|QID|13847|M|76.62,19.21|N|To Captain Joseph Holley.|
+; Orc Valiant Turnins
+T A Valiant's Field Training|QID|13765|M|76.50,24.20|N|To Akinos.|
+T A Blade Fit For A Champion|QID|13603|M|76.40,24.50|N|To Mokra the Skullcrusher.|
+T A Worthy Weapon|QID|13600|M|76.40,24.50|N|To Mokra the Skullcrusher.|
+T The Edge Of Winter|QID|13616|M|76.40,24.50|N|To Mokra the Skullcrusher.|
+T The Grand Melee|QID|13767|M|76.50,24.20|N|To Morah Worgsister.|
+T At The Enemy's Gates|QID|13856|M|76.50,24.20|N|To Morah Worgsister.|
 
-; Draenei Valiant Turnins
-T A Valiant's Field Training|QID|13755|M|76.08,19.19|N|Saandos.|
-T A Blade Fit For A Champion|QID|13752|M|76.10,19.10|N|From Colosos.|
-T A Worthy Weapon|QID|13753|M|76.10,19.10|N|From Colosos.|
-T The Edge Of Winter|QID|13754|M|76.10,19.10|N|From Colosos.|
-T The Grand Melee|QID|13756|M|76.15,19.07|N|From Ranii.|
-T At The Enemy's Gates|QID|13854|M|76.15,19.07|N|From Ranii.|
+; Blood Elf Valiant Turnins
+T A Valiant's Field Training|QID|13786|M|76.40,23.90|N|Kethiel Sunlance.|
+T A Blade Fit For A Champion|QID|13752|M|76.40,23.90|N|From Eressea Dawnsinger.|
+T A Worthy Weapon|QID|13753|M|76.40,23.90|N|From Eressea Dawnsinger.|
+T The Edge Of Winter|QID|13754|M|76.40,23.90|N|From Eressea Dawnsinger.|
+T The Grand Melee|QID|13756|M|76.40,23.90|N|From Aneera Thuron.|
+T At The Enemy's Gates|QID|13854|M|76.40,23.90|N|From Aneera Thuron.|
+
+; Tauren Valiant Turnins
+T A Valiant's Field Training|QID|13776|M|76.40,23.90|N|Dern Ragetotem.|
+T A Blade Fit For A Champion|QID|13752|M|76.40,23.90|N|From Runok Wildmane.|
+T A Worthy Weapon|QID|13753|M|76.40,23.90|N|From Runok Wildmane.|
+T The Edge Of Winter|QID|13754|M|76.40,23.90|N|From Runok Wildmane.|
+T The Grand Melee|QID|13756|M|76.40,23.90|N|From Anka Clawhoof.|
+T At The Enemy's Gates|QID|13854|M|76.40,23.90|N|From Anka Clawhoof.|
+
+; Troll Valiant Turnins
+T A Valiant's Field Training|QID|13771|M|76.40,23.90|N|Shadow Hunter Mezil-kree.|
+T A Blade Fit For A Champion|QID|13752|M|76.40,23.90|N|From Zul'tore.|
+T A Worthy Weapon|QID|13753|M|76.40,23.90|N|From Zul'tore.|
+T The Edge Of Winter|QID|13754|M|76.40,23.90|N|From Zul'tore.|
+T The Grand Melee|QID|13756|M|76.40,23.90|N|From Gahju.|
+T At The Enemy's Gates|QID|13854|M|76.40,23.90|N|From Gahju.|
 
 ; Exalted Turnins
-T You've Really Done It This Time, Kul|QID|14096|M|76.26,19.63|N|To Narasi Snowdawn.|
-T Rescue at Sea|QID|14152|M|76.26,19.63|N|To Narasi Snowdawn.|
-T A Leg Up|QID|14074|M|76.26,19.63|N|To Narasi Snowdawn.|
-T Stop The Aggressors|QID|14080|M|76.26,19.63|N|To Narasi Snowdawn.|
-T The Light's Mercy|QID|14077|M|76.26,19.63|N|To Narasi Snowdawn.|
+T You've Really Done It This Time, Kul|QID|14142|M|76.10,24.10|N|To Girana the Blooded.|
+T Rescue at Sea|QID|14136|M|76.10,24.10|N|To Girana the Blooded.|
+T A Leg Up|QID|14143|M|76.10,24.10|N|To Girana the Blooded.|
+T Stop The Aggressors|QID|14140|M|76.10,24.10|N|To Girana the Blooded.|
+T The Light's Mercy|QID|14144|M|76.10,24.10|N|To Girana the Blooded.|
 
-T Gormok Wants His Snobolds|QID|14090|M|76.20,19.56|N|To Savinia Loresong|
-T What Do You Feed a Yeti, Anyway?|QID|14112|M|76.20,19.56|N|From Savinia Loresong|
-T Breakfast Of Champions|QID|14076|M|76.20,19.56|N|From Savinia Loresong|
+T Gormok Wants His Snobolds|QID|14141|M|76.10,24.10|N|To Tylos Dawnrunner|
+T What Do You Feed a Yeti, Anyway?|QID|14145|M|76.10,24.10|N|From Tylos Dawnrunner|
+T Breakfast Of Champions|QID|14092|M|76.10,24.10|N|From Tylos Dawnrunner|
 
 ; Champion Turnins
 ; Battle plans of Kilvadir ...
-T Threat From Above|QID|13682|M|69.96,23.44|N|To Eadric the Pure. Get the Purse.|
-T Battle Before The Citadel|QID|13861|M|69.96,23.44|N|To Eadric the Pure.|
-T Among the Champions|QID|13790|M|69.93,23.33|N|To Luuri.|
-T Taking Battle To The Enemy|QID|13789|M|69.92,23.53|N|To Cellian Daybreak|
+T Threat From Above|QID|13809|M|69.96,23.44|N|To Eadric the Pure. Get the Purse.|
+T Battle Before The Citadel|QID|13862|M|69.96,23.44|N|To Eadric the Pure.|
+T Among the Champions|QID|13811|M|69.93,23.33|N|To Luuri.|
+T Taking Battle To The Enemy|QID|13810|M|69.92,23.53|N|To Cellian Daybreak|
 
-T Threat From Above|QID|13788|M|73.80,20.06|N|To Crok Scourgebane. Get the Purse.|
-T Battle Before The Citadel|QID|13864|M|73.80,20.06|N|To Crok Scourgebane.|
-T Among the Champions|QID|13793|M|73.59,20.09|N|To Illyrie Nightfall.|
-T Taking Battle To The Enemy|QID|13791|M|73.80,19.45|N|To Zor'be the Bloodletter.|
+; Crusader Turnins
+T Deathspeaker Kharos|QID|14105|M|69.96,23.44|CC|N|To High Crusader Adelard|
+T The Fate of the Fallen|QID|14107|M|69.96,23.44|CC|N|To Crusader Silverdawn|
+
+
+T Threat From Above|QID|13812|M|73.80,20.06|N|To Crok Scourgebane. Get the Purse.|
+T Battle Before The Citadel|QID|13863|M|73.80,20.06|N|To Crok Scourgebane.|
+T Among the Champions|QID|13814|M|73.59,20.09|N|To Illyrie Nightfall.|
+T Taking Battle To The Enemy|QID|13813|M|73.80,19.45|N|To Zor'be the Bloodletter.|
 
 ; Finishing up being an Valiant
-C The Valiant's Charge|QID|13714^13715^13716^13717^13718|L|44987 25|N|You need 25 Valiant's Seals, come back another day. |
+C The Valiant's Charge|QID|13720^13719^13722^13721^13697|L|44987 25|N|You need 25 Valiant's Seals, come back another day. |
 
-T The Valiant's Charge|QID|13718|M|76.60,19.12|N|To Marshal Jacob Alerius.|
-T The Valiant's Charge|QID|13716|M|76.10,19.10|N|To Colosos.|
-T The Valiant's Charge|QID|13714|M|76.64,19.49|N|To Lana Stouthammer.|
-T The Valiant's Charge|QID|13715|M|76.55,19.83|N|To Ambrose Boltspark.|
-T The Valiant's Charge|QID|13717|M|76.34,19.03|N|To Jaelyne Evensong.|
+T The Valiant's Charge|QID|13697|M|76.40,24.50|N|To Mokra the Skullcrusher.|
+T The Valiant's Charge|QID|13722|M|76.40,23.90|N|To Eressea Dawnsinger.|
+T The Valiant's Charge|QID|13720|M|76.40,24.55|N|To Runok Wildmane.|
+T The Valiant's Charge|QID|13719|M|76.00,24.45|N|To Zul'tore.|
+T The Valiant's Charge|QID|13721|M|76.50,24.20|N|To Deathstalker Visceri.|
 
-A The Valiant's Challenge|QID|13725|PRE|13717|M|76.34,19.03|N|From Jaelyne Evensong.|FACTION|Alliance|
-A The Valiant's Challenge|QID|13713|PRE|13714|M|76.64,19.49|N|From Lana Stouthammer.|FACTION|Alliance|
-A The Valiant's Challenge|QID|13699|PRE|13718|M|76.60,19.12|N|From Marshal Jacob Alerius.|FACTION|Alliance|
-A The Valiant's Challenge|QID|13723|PRE|13715|M|76.55,19.83|N|From Ambrose Boltspark.|FACTION|Alliance|
-A The Valiant's Challenge|QID|13724|PRE|13716|M|76.10,19.10|N|From Colosos.|FACTION|Alliance|
+A The Valiant's Challenge|QID|13729|PRE|13721|M|76.50,24.20|N|From Deathstalker Visceri.|FACTION|Horde|
+A The Valiant's Challenge|QID|13728|PRE|13720|M|76.40,24.55|N|From Runok Wildmane.|FACTION|Horde|
+A The Valiant's Challenge|QID|13726|PRE|13697|M|76.40,24.50|N|From Mokra the Skullcrusher.|FACTION|Horde|
+A The Valiant's Challenge|QID|13727|PRE|13719|M|76.00,24.45|N|From Zul'tore.|FACTION|Horde|
+A The Valiant's Challenge|QID|13731|PRE|13722|M|76.40,23.90|N|From Eressea Dawnsinger.|FACTION|Horde|
 
-C The Valiant's Challenge|QID|13699^13713^13723^13724^13725|M|68.60,20.99|N|Mount up, get your shields going and talk to Squire Danny to get things started.|
+C The Valiant's Challenge|QID|13726^13728^13727^13731^13729|M|68.60,20.99|N|Mount up, get your shields going and talk to Squire Danny to get things started.|
 
-T The Valiant's Challenge|QID|13725|M|76.34,19.03|N|To Jaelyne Evensong.|
-T The Valiant's Challenge|QID|13713|M|76.64,19.49|N|To Lana Stouthammer.|
-T The Valiant's Challenge|QID|13699|M|76.60,19.12|N|To Marshal Jacob Alerius.|
-T The Valiant's Challenge|QID|13723|M|76.55,19.83|N|To Ambrose Boltspark.|
-T The Valiant's Challenge|QID|13724|M|76.10,19.10|N|To Colosos.|
+T The Valiant's Challenge|QID|13729|M|76.50,24.20|N|To Deathstalker Visceri.|
+T The Valiant's Challenge|QID|13728|M|76.40,24.55|N|To Runok Wildmane.|
+T The Valiant's Challenge|QID|13726|M|76.40,24.50|N|To Mokra the Skullcrusher.|
+T The Valiant's Challenge|QID|13727|M|76.00,24.45|N|To Zul'tore.|
+T The Valiant's Challenge|QID|13731|M|76.40,23.90|N|To Eressea Dawnsinger.|
 
-A A Champion Rises|QID|13735|PRE|13725|R|Night Elf;Worgen|M|76.34,19.03|N|From Jaelyne Evensong.|FACTION|Alliance|
-A A Champion Rises|QID|13732|PRE|13713|R|Dwarf|M|76.64,19.49|N|From Lana Stouthammer.|FACTION|Alliance|
-A A Champion Rises|QID|13702|PRE|13699|R|Human|M|76.60,19.12|N|From Marshal Jacob Alerius.|FACTION|Alliance|
-A A Champion Rises|QID|13733|PRE|13723|R|Gnome|M|76.55,19.83|N|From Ambrose Boltspark.|FACTION|Alliance|
-A A Champion Rises|QID|13734|PRE|13724|R|Draenei|M|76.10,19.10|N|From Colosos.|FACTION|Alliance|
-N A Champion Rises|QID|13702^13732^13733^13734^13735|N|At this point you can become a Valiant for another faction.  Walk up and take the quest and the guide should adjust.|FACTION|Alliance|
-T A Champion Rises|QID|13702^13732^13733^13734^13735|M|69.66,22.85|N|To Justicar Mariel Trueheart.|FACTION|Alliance|
+A A Champion Rises|QID|13739|PRE|13729|R|Undead|M|76.50,24.20|N|From Deathstalker Visceri.|FACTION|Horde|
+A A Champion Rises|QID|13738|PRE|13728|R|Tauren|M|76.40,24.55|N|From Runok Wildmane.|FACTION|Horde|
+A A Champion Rises|QID|13736|PRE|13726|R|Orc|M|76.40,24.50|N|From Mokra the Skullcrusher.|FACTION|Horde|
+A A Champion Rises|QID|13737|PRE|13727|R|Troll|M|76.00,24.45|N|From Zul'tore.|FACTION|Horde|
+A A Champion Rises|QID|13740|PRE|13731|R|Blood Elf|M|76.40,23.90|N|From Eressea Dawnsinger.|FACTION|Horde|
+N A Champion Rises|QID|13736^13738^13737^13740^13739|N|At this point you can become a Valiant for another faction.  Walk up and take the quest and the guide should adjust.|FACTION|Horde|
+T A Champion Rises|QID|13736^13738^13737^13740^13739|M|69.66,22.85|N|To Justicar Mariel Trueheart.|FACTION|Horde|
 
-A Eadric the Pure|QID|13794|PRE|13702^13732^13733^13734^13735^13736^13737^13738^13739^13740|M|69.66,22.85|C|Druid,Hunter,Mage,Paladin,Priest,Rogue,Shaman,Warlock,Warrior|N|From Justicar Mariel Trueheart, everybody but DKs|FACTION|Alliance|
+A Eadric the Pure|QID|13794|PRE|13736^13738^13737^13740^13739^13736^13737^13738^13739^13740|M|69.66,22.85|C|Druid,Hunter,Mage,Paladin,Priest,Rogue,Shaman,Warlock,Warrior,Monk,Demon Hunter|N|From Justicar Mariel Trueheart, everybody but DKs|FACTION|Horde|
 T Eadric the Pure|QID|13794|M|69.96,23.44|N|To Eadric the Pure.|
-A The Scourgebane|QID|13795|PRE|13702^13732^13733^13734^13735^13736^13737^13738^13739^13740|M|69.66,22.85|C|Death Knight|N|From Justicar Mariel Trueheart, for DKs|FACTION|Alliance|
+A The Scourgebane|QID|13795|PRE|13736^13738^13737^13740^13739^13736^13737^13738^13739^13740|M|69.66,22.85|C|Death Knight|N|From Justicar Mariel Trueheart, for DKs|FACTION|Horde|
 T The Scourgebane|QID|13795|M|73.80,20.06|N|From Crok Scourgebane.|
 
 ]]


### PR DESCRIPTION
Updated most of the Argent Tournament guide (WowPro_Dailies/Horde/WotLK_argTour_H.lua). This isn't entirely finished yet, and not everything is tested yet. I pretty much need someone to double check my work, because after 4 hours of looking up Wowhead quests, they tend to blur together.

things to verify:

- faction-specific coordinates for Valiant and Champion quest targets may still point towards the Alliance location;
- Not all Crusader quests are implemented yet, only those of 2021-12-24 (Deathspeaker Kharos and The Fate of the Fallen).
- Quest accept and turnin coordinates are "close enough" locations that are within a few feet in front of the group of NPCs associated with the quests, but not 100% matching the exact NPC locations;
- Quest IDs and NPC names for Valiant dailies might be wrong. I tried to directly convert the existing Alliance code in the guide 1-1 to Horde counterparts, but there were only 3 races done in the existing guide, so Troll and Tauren had to be written manually. I based the accepts of their dailies on Undead, but turnin on Blood Elf (which in hindsight might have been a confusing choice). Some of the quest IDs may additionally be missing from completion step QID lists. I was interrupted halfway through updating them and may have missed some;
- Quests that have racial requirements may be missing race listings from Cataclysm and later expansions;
- In general, this guide can benefit from additional testing by characters who aren't crusaders yet.