### PR TITLE
Update VAN_BCC_30_40_HordeChapter2.lua

### DIFF
--- a/WoWPro_Leveling/Classic_BC/Horde/VAN_BCC_30_40_HordeChapter2.lua
+++ b/WoWPro_Leveling/Classic_BC/Horde/VAN_BCC_30_40_HordeChapter2.lua
@@ -567,63 +567,67 @@ T Tiger Mastery|QID|186|M|35.62,10.62|Z|1434|N|To Ajeck Rouack.|
 A Tiger Mastery|QID|187|M|35.62,10.62|Z|1434|N|From Ajeck Rouack.|PRE|186|
 T Panther Mastery|QID|191|M|35.56,10.54|Z|1434|N|To Sir S. J. Erlgadin.|
 A Panther Mastery|QID|192|M|35.56,10.54|Z|1434|N|From Sir S. J. Erlgadin.|PRE|191|
-R Venture Co. Base Camp|ACTIVE|570|M|36.8,13.6;40.0,14.9;40.8,14.7;42.61,16.70|CC|Z|1434|N|Make your way east under the bridge and head for the north side of the lake.|
-C Hostile Takeover|QID|213|L|4106 8|N|Kill Venture Co. Geologists to loot Tumbled Crystals.\n[color=FF0000]NOTE: [/color]They are spellcasters.|S|
-K Foreman Cozzle|ACTIVE|1182|M|42.72,18.37|Z|1434|L|5851|N|Head up to the top floor of the Venture Co. Operations Center, kill Foreman Cozzle inside the office, and loot his key to unlock his footlocker.\n[color=FF0000]NOTE: [/color]You'll need to pull each mob as there isn't much spacing between them and they will run. Try to avoid the ones out on the first level platform. They tend to pull as a group.|
-C Cozzle's Footlocker|QID|1182|M|43.33,20.33|Z|1434|QO|1|N|Once you have the key, drop down into the water and head for the little house beside the mill. Click on the chest to open it and loot the Fuel Regulator Blueprints.\n[color=FF0000]NOTE: [/color]There is no one inside.|NC|
-C Hostile Takeover|QID|213|M|43.91,22.90|Z|1434|L|4106 8|N|Kill Venture Co. Geologists to loot Tumbled Crystals.\n[color=FF0000]NOTE: [/color]They are spellcasters.|US|
+R Venture Co. Base Camp|ACTIVE|570|M|36.8,13.6;40.0,14.9;40.8,14.7;42.61,16.70|CC|Z|1434|QO|1;2|N|Make your way east under the bridge and head for the north side of the lake.|
+C Hostile Takeover|QID|213|L|4106 8|ITEM|4106|N|Venture Co. Geologists\n[color=FF0000]NOTE: [/color]They are spellcasters.|S|
+K Foreman Cozzle|ACTIVE|1182|M|42.72,18.37|Z|1434|L|5851|ITEM|5851|QO|1|N|Foreman Cozzle\nForeman Cozzle is inside the office on the top floor of the Venture Co. Operations Center.\n[color=FF0000]NOTE: [/color]You'll need to pull each mob as there isn't much spacing between them and they will run. Try to avoid the ones out on the first level platform. They tend to pull as a group.|
+C Cozzle's Footlocker|QID|1182|M|43.33,20.33|Z|1434|QO|1|N|Drop down into the water and head inside the little house beside the mill. Click on the chest to open it and loot the Fuel Regulator Blueprints.\n[color=FF0000]NOTE: [/color]There is no one inside.|NC|
+C Hostile Takeover|QID|213|M|43.91,22.90|Z|1434|L|4106 8|ITEM|4106|N|Venture Co. Geologists\n[color=FF0000]NOTE: [/color]They are spellcasters.|US|
 K Panther Mastery|ACTIVE|192|M|48.67,22.86|Z|1434|QO|1|N|Kill Shadowmaw Panthers.|S|
-C Mok'thardin's Enchantment|QID|570|M|48.67,22.86|Z|1434|QO|1|N|Kill Shadowmaw Panthers to loot Shadowmaw Claws.|S|
-C Mok'thardin's Enchantment|QID|570|M|48.67,22.86|Z|1434|QO|2|N|Head up into the hills on the east side of Venture Co, Base Camp. Kill Stranglethorn Tigresses until one drops a Pristine Tigress Fang.\n[color=FF0000]NOTE: [/color]Watch out for the Elite Mosh'Ogg south of the road.|
-C Mok'thardin's Enchantment|QID|570|M|48.67,22.86|Z|1434|QO|1|N|Finish collecting Shadowmaw Claws.\n[color=FF0000]NOTE: [/color]As they can cloak themselves, unless you can track them, you'll have to wander around the area until you find them.|US|
-K Panther Mastery|QID|192|M|48.67,22.86|Z|1434|QO|1|N|Kill Shadowmaw Panthers.\n[color=FF0000]NOTE: [/color]As they can cloak themselves, unless you can track them, you'll have to wander around the area until you find them.|US|
+C Mok'thardin's Enchantment|QID|570|M|48.67,22.86|Z|1434|L|3838 8|ITEM|3838|N|Shadowmaw Panthers|S|
+C Mok'thardin's Enchantment|QID|570|M|48.67,22.86|Z|1434|L|3839|ITEM|3839|N|Stranglethorn Tigresses\nHead up into the hills on the east side of Venture Co, Base Camp.\n[color=FF0000]NOTE: [/color]Watch out for the Mosh'Ogg south of the road.|
+C Mok'thardin's Enchantment|QID|570|M|48.67,22.86|Z|1434|L|3838 8|ITEM|3838|N|Shadowmaw Panthers|US|
+K Panther Mastery|QID|192|M|48.67,22.86|Z|1434|QO|1|N|Kill Shadowmaw Panthers.\n[color=FF0000]NOTE: [/color]As they can cloak themselves, unless you can track them, you'll have to wander around the area until you find them.|T|Shadowmaw Panther|US|
 R Nesingwary's Expedition|ACTIVE|192|M|35.65,10.66|Z|1434|N|Head back to Nesingwary's Expedition.\n[color=FF0000]NOTE: [/color]Following the road is probably the best route.|
 T Panther Mastery|QID|192|M|35.56,10.54|Z|1434|N|To Sir S. J. Erlgadin.|
 A Panther Mastery|QID|193|M|35.56,10.54|Z|1434|N|From Sir S. J. Erlgadin.|PRE|192|
 K Tiger Mastery|ACTIVE|187|M|33.23,19.03|Z|1434|QO|1|N|Kill Elder Stranglethorn Tigers.\n[color=FF0000]NOTE: [/color]Take the road or cut through Tkashi Ruins.|
-R The Hills of the Ruins of Zul'Kunda|ACTIVE|189^581^596|M|29.26,16.14|CC|Z|1434|N|Head to the hills below the Ruins of Zul'Kunda|
-R Ruins of Zul'Kunda|ACTIVE|189^581^596|M|27.98,11.25|Z|1434|N|Head into the Ruins of Zul'Kunda.|
-C Bloody Bone Necklaces|QID|596|M|25.70,11.30|Z|1434|L|3915 25|N|Kill any Bloodscalp troll to loot them.\n[color=FF0000]NOTE: [/color]Watch out for multiple pulls and patrollers. Take Hunters out quickly because they can root you for 10 seconds.|S|IZ|Ruins of Zul'Kunda^Zuuldaia Ruins^Tkashi Ruins|
-C Hunt for Yenniku|QID|581|M|25.70,11.30|Z|1434|L|3901 9|N|Kill any Bloodscalp troll to loot them.|S|
-C Bloodscalp Ears|QID|189|M|25.70,11.30|Z|1434|L|1519 15|N|Kill any Bloodscalp troll to loot them.|
-C Hunt for Yenniku|QID|581|M|25.70,11.30|Z|1434|L|3901 9|N|Finish collecting Bloodscalp Tusks.|US|
-R Nesingwary's Expedition|ACTIVE|581|M|35.65,10.66|Z|1434|N|Head back to Nesingwary's Expedition.|
+R Ruins of Zul'Kunda|ACTIVE|189^581^596|M|27.98,11.25|Z|1434|
+C Bloody Bone Necklaces|QID|596|M|25.70,11.30|Z|1434|L|3915 25|ITEM|3915|N|Any Bloodscalp Troll\n[color=FF0000]NOTE: [/color]Watch out for multiple pulls and patrollers. Take Hunters out quickly because they can root you for 10 seconds.|S|IZ|Ruins of Zul'Kunda^Zuuldaia Ruins^Tkashi Ruins|
+C Hunt for Yenniku|QID|581|M|25.70,11.30|Z|1434|L|3901 9|ITEM|3901|N|Any Bloodscalp Troll|S|
+C Bloodscalp Ears|QID|189|M|25.70,11.30|Z|1434|L|1519 15|ITEM|1519|N|Any Bloodscalp Troll|
+C Hunt for Yenniku|QID|581|M|25.70,11.30|Z|1434|L|3901 9|ITEM|3901|N|Any Bloodscalp Troll|US|
+R Nesingwary's Expedition|ACTIVE|187|M|35.65,10.66|Z|1434|
 T Tiger Mastery|QID|187|M|35.62,10.62|Z|1434|N|To Ajeck Rouack.|
 A Tiger Mastery|QID|188|M|35.62,10.62|Z|1434|N|From Ajeck Rouack.|
-K Sin'Dall|ACTIVE|188|M|31.8,17.0;32.05,17.47|CC|Z|1434|L|3879|N|Kill Sin'Dall and loot her paw. You'll find her on top of a flat hill near Tkashi Ruins.\n[color=FF0000]NOTE: [/color]There is only one way up the hill.\nIf she is not up here, she's either dead, or respawned at the base of the hill and on her way up.|T|Sin'Dall|
-R Bal'lal Ruins|ACTIVE|9436|M|29.35,18.01|Z|1434|
-C Bloodscalp Insight|QID|9436|M|29.89,20.68|Z|1434|L|23679|N|Kill Bloodscalp Shaman until ones drops the Bloodscalp Totem.|
+K Sin'Dall|ACTIVE|188|M|31.8,17.0;32.05,17.47|CC|Z|1434|L|3879|ITEM|3879|N|Sin'Dall\nYou'll find her on top of a flat hill near Tkashi Ruins.\n[color=FF0000]NOTE: [/color]There is only one way up the hill.\nIf she is not up here, she's either dead, or respawned at the base of the hill and on her way up.|T|Sin'Dall|
+R Bal'lal Ruins|ACTIVE|9436|M|29.35,18.01|Z|1434|QO|1|
+C Bloodscalp Insight|QID|9436|M|29.89,20.68|Z|1434|L|23679|ITEM|23679|N|Bloodscalp Shaman|T|Bloodscalp Shaman|
 K Raptor Mastery|ACTIVE|195|M|32.53,23.50|Z|1434|QO|1|N|Kill Lashtail Raptors.|S|
 K The Defense of Grom'gol|ACTIVE|568|M|32.53,23.50|Z|1434|QO|1|N|Kill Lashtail Raptors.\n[color=FF0000]NOTE: [/color]The Young Lashtail Raptors do not count.|
-T Hunt for Yenniku|QID|581|M|32.16,27.72|Z|1434|N|To Nimboya.|
+R Grom'gol Base Camp|ACTIVE|581|M|32.87,28.73|Z|1434|N|Grind as you return to Grom'gol.|S|
+L Level 38|ACTIVE|581|N|Grind until you're within 8 bars of level 38.|LVL|37;-24260|
+R Grom'gol Base Camp|ACTIVE|581|M|32.87,28.73|Z|1434|US|
+T Hunt for Yenniku|QID|581|M|32.16,27.72|Z|1434|N|To Nimboya.| ;2300
 A Headhunting|QID|582|M|32.16,27.72|Z|1434|N|From Nimboya.|PRE|581|
-T Bloodscalp Insight|QID|9436|M|31.97,28.60|Z|1434|N|To Nemeth Hawkeye.|
+T Bloodscalp Insight|QID|9436|M|31.97,28.60|Z|1434|N|To Nemeth Hawkeye.| ;3100
 A An Unusual Patron|QID|9457|M|31.97,28.60|Z|1434|N|From Nemeth Hawkeye.|PRE|9436|
-T The Defense of Grom'gol|QID|568|M|32.20,28.83|Z|1434|N|To Commander Aggro'gosh.|
+T The Defense of Grom'gol|QID|568|M|32.20,28.83|Z|1434|N|To Commander Aggro'gosh.| ;3500
 A The Defense of Grom'gol|QID|569|M|32.20,28.83|Z|1434|N|From Commander Aggro'gosh.|PRE|568|
-T Mok'thardin's Enchantment|QID|570|M|32.12,29.24|Z|1434|N|To Far Seer Mok'thardin.|
+T Mok'thardin's Enchantment|QID|570|M|32.12,29.24|Z|1434|N|To Far Seer Mok'thardin.| ;2900
 A Mok'thardin's Enchantment|QID|572|M|32.12,29.24|Z|1434|N|From Far Seer Mok'thardin.|PRE|570|
 F Booty Bay|ACTIVE|1182|M|32.54,29.35|Z|1434|
-T Goblin Sponsorship|QID|1182|M|27.23,76.87|Z|1434|N|To Baron Revilgaz.|
+T Goblin Sponsorship|QID|1182|M|27.23,76.87|Z|1434|N|To Baron Revilgaz.| ;3700
 A Goblin Sponsorship|QID|1183|M|27.23,76.87|Z|1434|N|From Baron Revilgaz.|PRE|1182|
-T Bloodscalp Ears|QID|189|M|27.00,77.13|Z|1434|N|To Kebok.|
-T Hostile Takeover|QID|213|M|27.00,77.13|Z|1434|N|To Kebok.|
-T Investigate the Camp|QID|201|M|26.94,77.21|Z|1434|N|To Krazek.|
-T Supply and Demand|QID|575|M|28.29,77.59|Z|1434|N|To Drizzlik.|
+T Bloodscalp Ears|QID|189|M|27.00,77.13|Z|1434|N|To Kebok.| ;2450
+T Hostile Takeover|QID|213|M|27.00,77.13|Z|1434|N|To Kebok.| ;3500
+T Investigate the Camp|QID|201|M|26.94,77.21|Z|1434|N|To Krazek.| ;270
+T Supply and Demand|QID|575|M|28.29,77.59|Z|1434|N|To Drizzlik.| ;1250
 A Some Assembly Required|QID|577|M|28.29,77.59|Z|1434|N|From Drizzlik.|PRE|575|
 A Singing Blue Shards|QID|605|M|27.12,77.22|Z|1434|N|From Crank Fizzlebub.\n[color=FF0000]NOTE: [/color]He's standing beside the bar in the Tavern.|
+
 ; --- Thousand Needles
 b Ratchet|ACTIVE|1183|M|25.87,73.12|Z|1434|N|Take the boat to Ratchet.|
 F Freewind Post|ACTIVE|1183|M|63.09,37.16|Z|1413|
 R Mirage Raceway|ACTIVE|1183|M|80.34,77.10|Z|1441|N|Leave Freewind Post and follow the road east into The Shimmering Flats to Mirage Raceway.|
-T Goblin Sponsorship|QID|1183|M|80.18,75.89|Z|1441|N|To Pozzik.|
+T Goblin Sponsorship|QID|1183|M|80.18,75.89|Z|1441|N|To Pozzik.| ;920
 A The Eighteenth Pilot|QID|1186|M|80.18,75.89|Z|1441|N|From Pozzik.|PRE|1183|
-T The Eighteenth Pilot|QID|1186|M|80.31,76.06|Z|1441|N|To Razzeric.|
+T The Eighteenth Pilot|QID|1186|M|80.31,76.06|Z|1441|N|To Razzeric.| ;370
 A Razzeric's Tweaking|QID|1187|M|80.99,76.09|Z|1441|N|From Razzeric.|PRE|1186|
 
 ; --- The Barrens
 H Orgrimmar|ACTIVE|569|
 F Thunder Bluff|ACTIVE|569|M|45.13,63.90|Z|1454|C|Druid|
+= Level 38 training|ACTIVE|569|N|Do your lv 38 training.\n[color=FF0000]NOTE: [/color]Manually check this step off to continue.|LVL|38|
 F Orgrimmar|ACTIVE|569|M|47.02,49.83|Z|1456|C|Druid|
 ; --- STV
 b Grom'gol Base Camp|ACTIVE|569|M|50.59,12.67|Z|1411|N|Take the Zeppelin to Grom'gol Base Camp.|

--- a/WoWPro_Leveling/Classic_BC/Horde/VAN_BCC_30_40_HordeChapter2.lua
+++ b/WoWPro_Leveling/Classic_BC/Horde/VAN_BCC_30_40_HordeChapter2.lua
@@ -571,7 +571,7 @@ R Venture Co. Base Camp|ACTIVE|570|M|36.8,13.6;40.0,14.9;40.8,14.7;42.61,16.70|C
 C Hostile Takeover|QID|213|L|4106 8|ITEM|4106|N|Venture Co. Geologists\n[color=FF0000]NOTE: [/color]They are spellcasters.|S|
 K Foreman Cozzle|ACTIVE|1182|M|42.72,18.37|Z|1434|L|5851|ITEM|5851|QO|1|N|Foreman Cozzle\nForeman Cozzle is inside the office on the top floor of the Venture Co. Operations Center.\n[color=FF0000]NOTE: [/color]You'll need to pull each mob as there isn't much spacing between them and they will run. Try to avoid the ones out on the first level platform. They tend to pull as a group.|
 C Cozzle's Footlocker|QID|1182|M|43.33,20.33|Z|1434|QO|1|N|Drop down into the water and head inside the little house beside the mill. Click on the chest to open it and loot the Fuel Regulator Blueprints.\n[color=FF0000]NOTE: [/color]There is no one inside.|NC|
-C Hostile Takeover|QID|213|M|43.91,22.90|Z|1434|L|4106 8|ITEM|4106|N|Venture Co. Geologists\n[color=FF0000]NOTE: [/color]They are spellcasters.|US|
+C Hostile Takeover|QID|213|M|43.91,22.90|Z|1434|L|4106 8|ITEM|4106|N|Venture Co. Geologist\n[color=FF0000]NOTE: [/color]They are spellcasters.|US|
 K Panther Mastery|ACTIVE|192|M|48.67,22.86|Z|1434|QO|1|N|Kill Shadowmaw Panthers.|S|
 C Mok'thardin's Enchantment|QID|570|M|48.67,22.86|Z|1434|L|3838 8|ITEM|3838|N|Shadowmaw Panthers|S|
 C Mok'thardin's Enchantment|QID|570|M|48.67,22.86|Z|1434|L|3839|ITEM|3839|N|Stranglethorn Tigresses\nHead up into the hills on the east side of Venture Co, Base Camp.\n[color=FF0000]NOTE: [/color]Watch out for the Mosh'Ogg south of the road.|
@@ -642,39 +642,38 @@ T Some Assembly Required|QID|577|M|28.29,77.59|Z|1434|N|To Drizzlik.|
 A Excelsior|QID|628|M|28.29,77.59|Z|1434|N|From Drizzlik.|PRE|577|
 F Grom'gol|ACTIVE|628|M|26.87,77.09|Z|1434|
 ;L Level 37|LVL|37|N|You should be around level 37 by this point.|
-C Singing Blue Shards|QID|605|M|24.34,17.07|Z|1434|L|3918 10|N|Kill Crystal Spine Basilisks to loot the Singing Crystal Shards.|S|
-C Excelsior|QID|628|M|26.93,20.23|N|Kill Elder Crocolisks to loot the skin.\n[color=FF0000]NOTE: [/color]Follow the shoreline north towards Bal'lal Ruins. The Elder Croclisks share spawn points with the regular ones and may require killing the regular ones to get the Elders to spawn.|S|
+C Singing Blue Shards|QID|605|M|24.34,17.07|Z|1434|L|3918 10|ITEM|3918|N|Crystal Spine Basilisk|S|
+C Excelsior|QID|628|M|26.93,20.23|Z|1434|L|4105|ITEM|4105|N|Elder Croclisk\n[color=FF0000]NOTE: [/color]The Elder Croclisks share spawn points with the regular ones and may require killing the regular ones to get the Elders to spawn.|S|
 R Zuuldaia Ruins|ACTIVE|582|M|27.00,18.60;22.17,16.15|CC|Z|1434|N|Using the north exit, leave Grom'gol and follow the Savage Coast north to the Zuuldaia Ruins.|
 N Bloodscalp Headhunters|ACTIVE|582|N|There are not very many of them around the ruins. If you make your way to the arch in the NE corner and walk up the ramp, you'll find several in this area.\n[color=FF0000]NOTE: [/color]Manually check this step off to continue.|
-C Headhunting|QID|582|M|19.86,11.53|Z|1434|L|1532 20|N|Kill Bloodscalp Headhunters to loot the Shrunken Heads. (50% drop rate)|
-C Bloody Bone Necklaces|QID|596|M|20.87,12.18|Z|1434|L|3915 25|N|Kill any Bloodscalp to loot them.|US|
-R Altar of Naias|ACTIVE|9457|M|21.65,21.53|CC|Z|1434|N|Make your way to the east side of the large island just off the coast.|
-K An Unusual Patron|ACTIVE|9457|M|19.56,22.90|Z|1434|L|23681|N|Use the Gift of Naias near the Altar of Naias to summon Naias and kill him.\n[color=FF0000]NOTE: [/color]Clear any mobs in the immediate area and watch out for Gazban who spawns beside the Altar. He can be annoying as an add.|U|23680|
-R The Vile Reef|ACTIVE|629^9457|M|22.82,23.31|CC|Z|1434|
+C Headhunting|QID|582|M|21.22,11.30|Z|1434|L|1532 20|ITEM|1532|N|Bloodscalp Headhunters|
+C Bloody Bone Necklaces|QID|596|M|20.87,12.18|Z|1434|L|3915 25|ITEM|3915|N|Any Bloodscalp Troll|US|
+R Altar of Naias|ACTIVE|9457|M|21.65,21.53|CS|Z|1434|QO|1|N|Make your way to the east side of the large island just off the coast.|
+K An Unusual Patron|ACTIVE|9457|M|19.56,22.90|Z|1434|L|23681|ITEM|23681|N|Naias\nUse the Gift of Naias near the Altar of Naias to summon Naias.\n[color=FF0000]NOTE: [/color]Clear any mobs in the immediate area and watch out for Gazban who spawns beside the Altar. He can be annoying as an add.|U|23680|
+R The Vile Reef|ACTIVE|629|M|22.82,23.31|CS|Z|1434|QO|1|
 N Giant Clams|ACTIVE|1107|N|While you're in the area, keep an eye out for Giant Clams. They may contain a 'Blue Pearl'. It's a quest item that can be sold in the AH, if you don't use them for the 'Pearl Diving' quest.|S!US|IZ|The Vile Reef|
-C Encrusted Tail Fins|QID|1107|M|24.84,24.28|N|Kill Saltscale Murlocs to loot Encrusted Tail Fins.\n[color=FF0000]NOTE: [/color]The best way to do this is to kite them to the surface so you don't drown by accident.|S|
-C Tablet Shard|QID|629|M|24.8,22.8|Z|1434|QO|1|N|Loot the Tablet Shard. It's leaning against the outside wall.\n[color=FF0000]NOTE: [/color]You can get this without aggroing the 2 Elite mobs on the other side. Swim along the surface to the location and dive straight down.\nIf you do it quick, you'll resurface with 1/3 of your breath left.|NC|
-C Encrusted Tail Fins|QID|1107|M|24.84,24.28|Z|1434|L|5796 10|N|Kill Saltscale Murlocs to loot the Encrusted Tail Fins.\n[color=FF0000]NOTE: [/color]Kite them to the surface so you don't drown by accident.\nMelee classes, focus on Warriors and Foragers. The others are range attack and may require you to fight underwater.|US|
+C Encrusted Tail Fins|QID|1107|M|24.84,24.28|Z|1434|L|5796 10|ITEM|5796|N|Saltscale Murloc\n[color=FF0000]NOTE: [/color]Kite them to the surface so you don't drown by accident.\nMelee classes, focus on Warriors and Foragers. The others are range attack and may require you to fight underwater.|S|
+C Tablet Shard|QID|629|M|24.8,22.8|Z|1434|L|4094|N|The Tablet Shard is leaning against the outside wall.\n[color=FF0000]NOTE: [/color]Swim along the surface to the location and dive straight down.|NC|
+C Encrusted Tail Fins|QID|1107|M|24.84,24.28|Z|1434|L|5796 10|ITEM|5796|N|Saltscale Murloc\n[color=FF0000]NOTE: [/color]Kite them to the surface so you don't drown by accident.\nMelee classes, focus on Warriors and Foragers. The others are range attack and may require you to fight underwater.|US|
 C Singing Blue Shards|QID|605|M|24.76,17.12|Z|1434|L|3918 10|N|Kill Crystal Spine Basilisks to loot the Singing Crystal Shards.|US|
-C Excelsior|QID|628|M|26.93,20.23|N|Work your up and down the shoreline, Killing Elder Crocolisks until you loot the skin.\n[color=FF0000]NOTE: [/color]The Elder Croclisks share spawn points with the regular ones and may require killing the regular ones to get the Elders to spawn.|US|
-R Nesingwary's Expedition|ACTIVE|195|M|35.65,10.66|Z|1434|N|Make your way back to Nesingwary's Expedition.|
+C Excelsior|QID|628|M|26.93,20.23|Z|1434|L|4105|ITEM|4105|N|Elder Croclisk\n[color=FF0000]NOTE: [/color]The Elder Croclisks share spawn points with the regular ones and may require killing the regular ones to get the Elders to spawn.|US|
+R Nesingwary's Expedition|ACTIVE|195|M|35.65,10.66|Z|1434|
 T Raptor Mastery|QID|195|M|35.66,10.81|Z|1434|N|To Hemet Nesingwary Jr.|
 A Raptor Mastery|QID|196|M|35.66,10.81|Z|1434|N|From Hemet Nesingwary Jr.|PRE|195|
 T Tiger Mastery|QID|188|M|35.62,10.62|Z|1434|N|To Ajeck Rouack.|
-R Grom'gol Base Camp|ACTIVE|582|M|35.5,15.1;38.5,23.6;32.87,28.73|CC|Z|1434|N|Return to Grom'gol.|
+R Grom'gol Base Camp|ACTIVE|582|M|35.5,15.1;38.5,23.6;32.87,28.73|CC|Z|1434|
 T Headhunting|QID|582|M|32.16,27.72|Z|1434|N|To Nimboya.|
 * Leftover Shrunken Heads|AVAILABLE|-582|N|Delete any leftover Shrunken Heads.|U|1532|
-T Bloody Bone Necklaces|QID|596|M|32.28,27.71|Z|1434|N|To Kin'weelay.|
 A Bloodscalp Clan Heads|QID|584|M|32.16,27.72|Z|1434|N|From Nimboya.|PRE|582|
+T Bloody Bone Necklaces|QID|596|M|32.28,27.70|Z|1434|N|To Kin'weelay.|
+T The Vile Reef|QID|629|M|32.28,27.70|Z|1434|N|To Kin'weelay.|
 T An Unusual Patron|QID|9457|M|31.97,28.60|Z|1434|N|To Nemeth Hawkeye.|
-F Booty Bay|ACTIVE|577|M|32.54,29.35|Z|1434|
+F Booty Bay|ACTIVE|628|M|32.54,29.35|Z|1434|
 T Excelsior|QID|628|M|28.29,77.59|Z|1434|N|To Drizzlik in the Leatherworking shop.|
 T Singing Blue Shards|QID|605|M|27.12,77.22|Z|1434|N|To Crank Fizzlebub.\n[color=FF0000]NOTE: [/color]He's standing beside the bar in the Tavern.|
 A Venture Company Mining|QID|600|M|27.12,77.21|N|From Crank Fizzlebub.|PRE|605|
-N Bank/AH|ACTIVE|638|N|Before leaving for Dustwallow Marsh, take this opportunity to unload any items you won't need until you return to STV. Also, use the AH to sell any extra 'The Green Hills of Stranglethorn manuscript pages' you may have.|IZ|Booty Bay|
-;;; This section has been removed to reduce exp gain - Hendo72
-;;; --- Kalimdor
-;;; --- Arathi Highlands
+N Bank/AH|ACTIVE|338|N|Before leaving for Dustwallow Marsh, take this opportunity to unload any items you won't need until you return to STV. Also, use the AH to sell any extra 'The Green Hills of Stranglethorn manuscript pages' you may have.\n[color=FF0000]NOTE: [/color]Manually check this step off to continue.|IZ|Booty Bay|
+
 ; -- Dustwallow Marsh
 b Ratchet|AVAILABLE|1268|M|25.87,73.12|Z|1434|N|Take the boat to Ratchet.|
 F Freewind Post|ACTIVE|1107|M|63.09,37.16|Z|1413|

--- a/WoWPro_Leveling/Classic_BC/Horde/VAN_BCC_30_40_HordeChapter2.lua
+++ b/WoWPro_Leveling/Classic_BC/Horde/VAN_BCC_30_40_HordeChapter2.lua
@@ -632,9 +632,9 @@ F Orgrimmar|ACTIVE|569|M|47.02,49.83|Z|1456|C|Druid|
 ; --- STV
 b Grom'gol Base Camp|ACTIVE|569|M|50.59,12.67|Z|1411|N|Take the Zeppelin to Grom'gol Base Camp.|
 R Mizjah Ruins|ACTIVE|569|M|37.02,28.39|Z|1434|N|Use the east exit and follow the road.|
-C Some Assembly Required|QID|577|M|39.78,29.61|Z|1434|L|4104 5|N|Kill Snapjaw Crocolisks along either side of the river shore to loot them.\n[color=FF0000]NOTE: [/color]Be aware of the Sharptooth Frenzys when crossing the river.|S|
+C Some Assembly Required|QID|577|M|39.78,29.61|Z|1434|L|4104 5|ITEM|4104|N|Snapjaw Crocolisk\n[color=FF0000]NOTE: [/color]Be aware of the Sharptooth Frenzys when crossing the river.|S|
 K The Defense of Grom'gol|ACTIVE|569|M|37.51,31.52|Z|1434|QO|1;2|N|Kill Mosh'Ogg Witch Doctors and Brutes in the Mizjah Ruins.\n[color=FF0000]NOTE: [/color]It's much easier to patrol around the outside of the ruins. The mobs inside tend to be pulled in groups of 3. It may take longer, but so does corpse running.|
-C Some Assembly Required|QID|577|M|39.78,29.61|Z|1434|L|4104 5|N|Kill Snapjaw Crocolisks along either side of the river shore to loot them.\n[color=FF0000]NOTE: [/color]Be aware of the Sharptooth Frenzys when crossing the river.|US|
+C Some Assembly Required|QID|577|M|39.78,29.61|Z|1434|L|4104 5|ITEM|4104|N|Snapjaw Crocolisk\n[color=FF0000]NOTE: [/color]Be aware of the Sharptooth Frenzys when crossing the river.|US|
 R Grom'gol Base Camp|ACTIVE|569|M|32.87,28.73|Z|1434|N|Return to Grom'gol.|
 T The Defense of Grom'gol|QID|569|M|32.20,28.83|Z|1434|N|To Commander Aggro'gosh.|
 F Booty Bay|ACTIVE|577|M|32.54,29.35|Z|1434|

--- a/WoWPro_Leveling/Classic_BC/Horde/VAN_BCC_30_40_HordeChapter2.lua
+++ b/WoWPro_Leveling/Classic_BC/Horde/VAN_BCC_30_40_HordeChapter2.lua
@@ -39,7 +39,7 @@ A A New Ore Sample|QID|1153|M|45.10,57.69|Z|1413|N|From Tatternack Steelforge.|P
 R The Great Lift|ACTIVE|5881|M|32.23,20.46|Z|1441|N|Leave Camp Taurajo and follow the Southern Gold Road south to the bottom of The Barrens.|
 T Calling in the Reserves|QID|5881|M|31.87,21.65|Z|1441|N|To Grish Longrunner.|
 A Message to Freewind Post|QID|4542|M|32.24,22.17|Z|1441|N|From Brave Moonhorn.\n[color=FF0000]NOTE: [/color]If he's not here, check the bottom of The Great Lift or wait for him to respawn because he's dead.|
-C A New Ore Sample|QID|1153|L|5842|N|Kill Gravelsnout Surveyors and Diggers until one drops an Unrefined Ore Sample.\n[color=FF0000]NOTE: [/color]They are spread out over the east and west ends of Thousand Needles.|S|
+C A New Ore Sample|QID|1153|L|5842|ITEM|5842|N|Gravelsnout Surveyor/Digger\n[color=FF0000]NOTE: [/color]They're spread out over the east and west ends of Thousand Needles.|S|
 R Freewind Post|ACTIVE|4542|M|31.5,25.3;29.5,34.5;46.84,47.18|CC|Z|1441|N|Take the lift down to the bottom and follow the road (signs) to Freewind Post.|
 T Message to Freewind Post|QID|4542|M|45.66,50.79|Z|1441|N|To Cliffwatcher Longhorn.\n[color=FF0000]NOTE: [/color]The lift to go up is a little further down the road.|
 A Pacify the Centaur|QID|4841|M|45.66,50.79|Z|1441|N|From Cliffwatcher Longhorn.|PRE|4542|
@@ -81,7 +81,7 @@ K Wanted - Arnak Grimtotem|ACTIVE|5147|M|35.7,31.0;37.99,26.64;37.65,31.47|CS|Z|
 A Free at Last|QID|4904|M|37.98,26.59|Z|1441|ELITE|N|[color=80FF00]Escort Quest:[/color]\nFrom Lakota Windsong.\n[color=FF0000]NOTE: [/color]If she's not there, she's either dead or someone else is on the quest and you'll have to wait.|
 A Free at Last|QID|4904|M|37.98,26.59|Z|1441|ELITE|N|[color=80FF00]Escort Quest:[/color]\n[color=CC00FF]QUEST FAILED [/color]\nGo back to Lakota Windsong to restart the quest.\n[color=FF0000]NOTE: [/color]If she's not there, she's either waiting to respawn, or someone else is now on the quest. Either way, you'll have to wait.|FAIL|
 C Free at Last|QID|4904|M|30.99,37.05|Z|1441|QO|1|N|Escort Lakota Windsong across the sky path and out of Darkcloud Pinnacle to the ground below.\nAs you reach each 'plateau', a group of two will spawn and attack you. They stop spawning when you reach the last plateau and begin the downward path.\n[color=FF0000]NOTE: [/color]Leaving all of the pulling of mobs to her. If you pull at the wrong time, you could end up fighting 5 or 6 at once.|
-K Galak Messenger|AVAILABLE|4881|M|22.04,31.52|Z|1441|L|12564|N|Kill him to loot the Assassination note.|S|
+l Assassination Note|AVAILABLE|4881|M|22.04,31.52|Z|1441|L|12564|ITEM|12564|N|Galak Messenger|S|
 A Assassination Plot|QID|4881|N|Click on the Assassination Note to start the quest.|U|12564|O|
 R Whitereach Post|ACTIVE|4865|M|29.2,33.9;21.05,32.32|CC|Z|1441|
 T Serpent Wild|QID|4865|M|21.55,32.34|Z|1441|N|To Motega Firemane.|
@@ -97,12 +97,12 @@ R Whitereach Post|ACTIVE|4770|M|21.05,32.32|Z|1441|
 T Homeward Bound|QID|4770|M|21.55,32.34|Z|1441|N|To Motega Firemane.|
 A Hypercapacitor Gizmo|QID|5151|M|21.43,32.55|Z|1441|ELITE|N|[color=00FFFF]Group of 2 suggested or level up to solo[/color]\nFrom Wizlo Bearingshiner.|
 C Hypercapacitor Gizmo|QID|5151|M|21.8,26.8;22.81,24.45|CC|Z|1441|QO|1|N|Clear the area of any and all mobs and when you're ready, open the cage and prepare to fight.\n[color=FF0000]NOTE: [/color]Being that the Enraged Pather is a lv 30 elite, this quest may not be easy for some classes. Feel free to skip this quest and do it later if you so wish.\nThe exp and reward make this quest worth doing, even in a couple levels.|
-K Galak Messenger|AVAILABLE|4881|M|22.04,31.52|Z|1441|L|12564|N|If you wait (5-10 mins max) at this location facing the road east, he will come to you. Kill him and loot the Assassination note from him.\nIf you don't feel like waiting, You can either follow the road west to Camp E'thok or east to Splithoof Crag. He patrols along the road between the 2 camps.|US|
+l Assassination Note|AVAILABLE|4881|M|22.04,31.52|Z|1441|L|12564|ITEM|12564|N|Galak Messenger\nIf you wait (5-10 mins max) at this location facing the road east, he will come to you.\nIf you don't feel like waiting, You can either follow the road west to Camp E'thok or east to Splithoof Crag. He patrols along the road between the 2 camps.|US|
 A Protect Kanati Greycloud|QID|4966|M|21.26,32.06|Z|1441|N|From Kanati Greycloud.|PRE|4881|
 C Protect Kanati Greycloud|QID|4966|M|21.26,32.06|Z|1441|N|A group of 3 Galak Assassins will spawn and attack you and Kanati. Defeat them to complete the quest.|
 T Protect Kanati Greycloud|QID|4966|M|21.26,32.06|Z|1441|N|To Kanati Greycloud.|
 t Hypercapacitor Gizmo|QID|5151|M|21.47,32.48|Z|1441|N|To Wizlo Bearingshiner.|IZ|Whitereach Post|
-l Incendia Agave|ACTIVE|5062|M|35.56,34.63|Z|1441|L|12732 10|N|Loot these in and around the pond below Darkcloud Pinnacle.|
+C Incendia Agave|QID|5062|M|35.56,34.63|Z|1441|L|12732 10|N|Loot these in and around the pond below Darkcloud Pinnacle.|
 R Freewind Post|ACTIVE|4767|M|46.84,47.18|Z|1441|N|Make your way towards Frewwind Post as you grind.|S|
 L Level 32|ACTIVE|4767|N|Grind until you're within 5 bars of lvl 32.|LVL|31;-10950|
 R Freewind Post|ACTIVE|4767|M|46.84,47.18|Z|1441|N|Run back to Freewind and take the lift up.|US|
@@ -120,8 +120,8 @@ F Orgrimmar|ACTIVE|5088|M|47.02,49.83|Z|1456|C|Rogue,Warlock|
 = Level 32 Training|ACTIVE|5088|N|Take care of any training and other housekeeping you may need to do.\n[color=FF0000]NOTE: [/color]Manually check this step off to continue.|C|Rogue,Warlock|
 A In Search of Menara Voidrender|QID|4737|M|48.46,45.44|Z|1454|ITEM|6900|N|From Zevrost.\n[color=FF0000]NOTE: [/color]This quest begins the chain to earn your Enchanted Gold Bloodrobe.|C|Warlock|
 N Components for the Enchanted Gold Bloodrobe|ACTIVE|4737|N|Before leaving, collect these items to save time later.\n[color=FF0000]NOTE: [/color]Manually check this step off to continue.|C|Warlock|
-B Robes of Arcana|AVAILABLE|1796|L|5770|ITEM|5770|N|- crafted by a Tailor or purchased through the AH.|C|Warlock|
-B Gold Bar|AVAILABLE|4781|L|3577|ITEM|3577|N|- smelted by Miners, found in treasure chests, or purchased from the AH.|C|Warlock|
+B Robes of Arcana|AVAILABLE|1796|L|5770|N|Crafted by a Tailor or purchased through the AH.|C|Warlock|
+B Gold Bar|AVAILABLE|4781|L|3577|N|Smelted by Miners, found in treasure chests, or purchased from the AH.|C|Warlock|
 F Ratchet|ACTIVE|4737|M|45.13,63.90|Z|1454|C|Warlock|
 T In Search of Menara Voidrender|QID|4737|M|62.51,35.45|Z|1413|N|To Menara Voidrender.|
 A Components for the Enchanted Gold Bloodrobe|QID|1796|M|62.51,35.45|Z|1413|N|From Menara Voidrender.|PRE|4737|C|Warlock|
@@ -140,24 +140,24 @@ F Freewind Post|ACTIVE|5088|M|45.13,63.90|Z|1454|C|Rogue| ; from Orgrimmar
 F Freewind Post|ACTIVE|5088|M|63.09,37.16|Z|1413|C|Warlock| ; from Ratchet
 R Sky path access|ACTIVE|5088|M|31.22,36.91|CC|Z|1441|N|Run to the base of the ramp leading up to the sky path.|
 C Sacred Fire of Life|QID|5088|M|33.1,35.3;34.7,31.0;37.2,33.1;38.0,35.3|CC|Z|1441|QO|2|N|Make your way to the Sacred Fire of Life. After clearing the mobs in the area, click on the Sacred Fire of Life to light it and summon Arikara. Kill him to loot his skin.|
-K Arikara|ACTIVE|5088|M|38.24,35.42|Z|1441|L|12925|N|Make your way to the Sacred Fire of Life. After clearing the mobs in the area, click on the Sacred Fire of Life to light it and summon Arikara. Kill him to loot his skin.|
+K Arikara|ACTIVE|5088|M|38.24,35.42|Z|1441|L|12925|ITEM|12925|N|Arikara\nMake your way to the Sacred Fire of Life and after clearing the area, click on the Sacred Fire of Life to light it and summon Arikara.|
 R Whitereach Post|ACTIVE|5088|M|21.05,32.32|Z|1441|N|Make your way back down to the ground and run to Whitereach Post.\n[color=FF0000]NOTE: [/color]To speed this up, you can jump off the center of the first bridge into the pond below.|
 T Arikara|QID|5088|M|21.55,32.34|Z|1441|N|To Motega Firemane.|
 C Hypercapacitor Gizmo|QID|5151|M|21.8,26.8;22.81,24.45|CC|Z|1441|QO|1|N|Clear the area of any and all mobs and when you're ready, open the cage and prepare to fight.|
 R Whitereach Post|ACTIVE|5151|M|22.28,31.56|Z|1441|N|Run back to Whitereach Post.|
-K Steelsnap|ACTIVE|1131|M|13.54,19.88|Z|1441|L|5837|N|Find Steelsnap patrolling the area NW of the Great Lift; kill him and loot the Rib.\n[color=FF0000]NOTE: [/color]He is lv 30 and travels with 2 other lv 29 hyenas. None of them are elite.\nMuch like the Galak Messenger, if you just wait here facing east (towards Camp E'thok), he will come to you. At this location, there are no other mobs to worry about.|
+K Steelsnap|ACTIVE|1131|M|13.54,19.88|Z|1441|L|5837|ITEM|1441|N|Steelsnap\nHe patro;s the area NW of the Great Lift.\n[color=FF0000]NOTE: [/color]He's lv 30 and travels with 2 other lv 29 hyenas. None of them are elite.\nMuch like the Galak Messenger, if you just wait here facing east (towards Camp E'thok), he will come to you. At this location, there are no other mobs to worry about.|
 R Roguefeather Den|ACTIVE|1150|M|27.47,49.57;27.44,51.07|CC|Z|1441|N|Make your way to The Screeching Canyon and walk up the ramp to Roguefeather Den.|
-K Grenka Bloodscreech|ACTIVE|1150|M|26,55.4|Z|1441|L|9843|N|Work your way to the back of the cave. After you clear the area, break one of the crates until Grenka Bloodscreech spawns. Kill her and loot the Claw.|
+K Grenka Bloodscreech|ACTIVE|1150|M|26,55.4|Z|1441|L|9843|ITEM|9843|N|Grenka Bloodscreech\nWork your way to the back of the cave and after clearing the area, break one of the crates until Grenka Bloodscreech spawns.|
 H Freewind Post|ACTIVE|1150|M|26.05,54.53|Z|1441|N|Unless you plan on fighting your way out, run to the VERY back of the cave beside the crates.  Jump up into the small nook in the wall and use your hearthstone in there.\n[color=FF0000]NOTE: [/color]Nothing can attack YOU inside the nook, even if they are aggroed.|
 R The Weathered Nook|ACTIVE|1150|M|53.67,42.74|
 T Test of Endurance|QID|1150|M|53.94,41.49|Z|1441|N|To Dorn Plainstalker.|
 A Test of Strength|QID|1151|M|53.94,41.49|Z|1441|N|From Dorn Plainstalker.|PRE|1150|
 R Highperch area|ACTIVE|1151|M|44.85,58.81;29.67,51.23;18.04,37.81|CC|Z|1441|N|\n[color=FF0000]NOTE: [/color]If you stay high up on the south edge of the canyon wall, you can avoid most of the fights.|
-K Rok'Alim the Pounder|QID|1151|M|17.27,37.07|Z|1441|L|5844|N|Continue west until you find Rok'Alim; kill him and loot the Fragments.|
+K Rok'Alim the Pounder|QID|1151|M|17.27,37.07|Z|1441|L|5844|ITEM|5844|N|Rok'Alim the Pounder\nContinue west until you find him.|
 R The Weathered Nook|ACTIVE|1151|M|53.67,42.74|Z|1441|N|Choose your own path back.|
 T Test of Strength|QID|1151|M|53.94,41.49|Z|1441|N|To Dorn Plainstalker.|
 A Test of Lore|QID|1152|M|53.94,41.49|Z|1441|N|From Dorn Plainstalker.|PRE|1151|
-C A New Ore Sample|QID|1153|N|Kill Gravelsnout Surveyors and Diggers until one drops an Unrefined Ore Sample. They are spread out over the east and west ends of Thousand Needles.|US|
+C A New Ore Sample|QID|1153|N|ITEM|5842|N|Gravelsnout Surveyor/Digger\n[color=FF0000]NOTE: [/color]They're spread out over the east and west ends of Thousand Needles.|US|
 
 ; --- The Barrens
 R Freewind Post|ACTIVE|1153|M|46.84,47.18|Z|1441|
@@ -220,13 +220,13 @@ A Load Lightening|QID|1176|M|80.18,75.89|Z|1441|N|From Pozzik.|
 A A Bump in the Road|QID|1175|M|81.63,77.95|Z|1441|N|From Trackmaster Zherin.|
 r Repair/Restock|ACTIVE|1175|M|80.40,77.01|Z|1441|N|At Synge.\n[color=FF0000]NOTE: [/color]You've just picked up a number of collection quests. It would be in your best interest to free up as much bag space as feasible.|
 N Mob Location|ACTIVE|1104^1105^1110^1175^1176|N|All of the mobs involved in the quests you just picked up are scattered around the Shimmering Flats.\nThere is no real dividing line between levels. You'll find lv 30s mixed with lv 35s.\n[color=FF0000]NOTE: [/color]Manually check this step off to continue.|
-C Salt Flat Venom|QID|1104|L|5794 6|N|The Reavers (lv 31-32) are in the north and the Terrors (33-34) in the south.|S|
+C Salt Flat Venom|QID|1104|L|5794 6|ITEM|5794|N|Reavers (lv 31-32) in the north and Terrors (33-34) in the south.|S|
 C Rocket Car Parts|QID|1110|L|5798 30|N|Pick these up as you see them.|S|
-K A Bump in the Road|ACTIVE|1175|QO|3;2;1|N|The Basilisks (lv 30-31) are in the NW quadrant, the Crystalhides (32-33) all over, and the Gazers (34-35) in the SE quadrant.|S|
+K Basilisks|ACTIVE|1175|QO|3;2;1|N|The Basilisks (lv 30-31) are in the NW quadrant, the Crystalhides (32-33) all over, and the Gazers (34-35) in the SE quadrant.|S|
 C Hollow Vulture Bone|QID|1176|M|87.82,65.57|Z|1441|L|5848 10|N|Kill Scavengers (30-32) Vultures (32-34) to loot these.\n[color=FF0000]NOTE: [/color]The 6 Scavengers at this location have a respawn timer of 10 minutes.|
-l Turtle Meat|AVAILABLE|7321|L|3712 10|N|Kill turtles to loot the Turtle Meat for a quest later.|S|
-C Hardened Tortoise Shell|QID|1105|M|82.37,54.62|Z|1441|L|5795 9|N|Kill any variety of Sparkleshell tortoises.|
-l Turtle Meat|AVAILABLE|7321|M|82.37,54.62|Z|1441|L|3712 10|N|Finish collecting the Turtle Meat.\n[color=FF0000]NOTE: [/color]The drop rate is @30% or 1 in 3 kills.|US|
+l Turtle Meat|AVAILABLE|7321|L|3712 10|ITEM|3712|N|Any Turtle|S|
+C Hardened Tortoise Shell|QID|1105|M|82.37,54.62|Z|1441|L|5795 9|ITEM|5795|N|Any Sparkleshell Tortoise|
+l Turtle Meat|AVAILABLE|7321|M|82.37,54.62|Z|1441|L|3712 10|ITEM|3712|N|Any Turtle|US|
 K A Bump in the Road|ACTIVE|1175|M|73.85,57.34|Z|1441|QO|1|N|Kill the Basilisks. Kill any Crystalhides you come across.|US|
 K A Bump in the Road|ACTIVE|1175|M|77.54,67.81|Z|1441|QO|2|N|Kill the Crystalhides.|
 r Repair/Restock|ACTIVE|1175|M|80.40,77.01|Z|1441|N|While you're in the area, visit Synge.|
@@ -333,13 +333,14 @@ R Ethel Rethor|AVAILABLE|5741|M|42.71,35.91|Z|1443|N|Take the road north out of 
 A Sceptre of Light|QID|5741|M|38.89,27.16|Z|1443|N|From Azore Aldamort at Ethel Rethor.\n[color=FF0000]NOTE: [/color]Go up the hill to the bottom of the ramp, slowly drop off the side of the ramp, and follow the path around to the right.|
 R Kormek's Hut|ACTIVE|5501|M|44.1,34.4;62.02,39.38|CC|Z|1443|
 T Bone Collector|QID|5501|M|62.31,38.96|Z|1443|N|To Bibbly F'utzbuckle.|
-C The Burning of Spirits|QID|1435|L|6435 15|N|Attack a Burning Blade mob and when they are almost dead (<300 hp), use the Burning Gem on them. If they die, you will collect an Infused Burning Gem. They MUST die from the 'Capture Spirit' debuff to collect the gem. The debuff does 100 damage every 3 seconds for 9 seconds.\n[color=FF0000]NOTE: [/color]Using special attacks (DOT) when they are near death could disrupt the Burning Gem effect.\nA side note for Druids. You cannot use the gem while shapeshifted.|U|6436|S|
+C The Burning of Spirits|QID|1435|L|6435 15|ITEM|6435|N|Any Burning Blade\nAttack a Burning Blade mob and when they are almost dead (<300 hp), use the Burning Gem on them. The debuff does 100 damage every 3 seconds for 9 seconds.\n[color=FF0000]NOTE: [/color]They MUST die from the 'Capture Spirit' debuff to collect the gem. Using DOTs when they're near death could disrupt the Burning Gem debuff.|U|6436|C|-Druid|S|
+C The Burning of Spirits|QID|1435|L|6435 15|ITEM|6435|N|Any Burning Blade\nAttack a Burning Blade mob and when they are almost dead (<300 hp), use the Burning Gem on them. The debuff does 100 damage every 3 seconds for 9 seconds.\n[color=FF0000]NOTE: [/color]They MUST die from the 'Capture Spirit' debuff to collect the gem. Using DOTs when they're near death could disrupt the Burning Gem debuff.\nYou cannot use the gem while shapeshifted.|U|6436|C|Druid|S|
 A The Corrupter|QID|1480|N|Click on the Flayed Demon Skin to start the quest.\n[color=FF0000]NOTE: [/color]This item is dropped by Burning Blade mobs.|U|20310|O|
 ; --- destroy excess quest starter item
 * Excess Flayed Demon Skin|AVAILABLE|-1480|N|Once you've accepted the quest, you no longer need to loot these items. If you loot any more, safely destroy them.|U|20310|
 ;L Level 34|QID|1107|N|You should be around level 34 by this point.|
-C Sceptre of Light|QID|5741|M|55.17,30.09|Z|1443|L|15750|N|Kill the Burning Blade Seer to loot the Sceptre of Light.\n[color=FF0000]NOTE: [/color]You'll find the Seer at the top of the Watchtower just inside the entrance. He has 2 Felsworn standing guard outside and an Augur inside with him. You can easily pull the outside guards one at a time.|
-C The Burning of Spirits|QID|1435|L|6435 15|N|Finish collecting the Infused Burning Gems.|U|6436|US|
+C Sceptre of Light|QID|5741|M|55.17,30.09|Z|1443|L|15750|ITEM|15750|N|Burning Blade Seer\n[color=FF0000]NOTE: [/color]You'll find the Seer at the top of the Watchtower just inside the entrance. He has 2 Felsworn standing guard outside and an Augur inside with him. You can easily pull the outside guards one at a time.|
+C The Burning of Spirits|QID|1435|L|6435 15|ITEM|6435|N|Any Burning Blade|U|6436|US|
 T Sceptre of Light|QID|5741|M|38.89,27.16|Z|1443|N|Make your way west back to Azore Aldamort in Ethel Rethor.|
 A Book of the Ancients|QID|6027|M|38.89,27.16|Z|1443|N|From Azore Aldamort.|
 T The Burning of Spirits|QID|1435|M|52.24,53.44|Z|1443|N|Make your way back to Maurin Bonesplitter at Ghost Walker Post.|
@@ -347,12 +348,12 @@ T The Corrupter|QID|1480|M|52.24,53.44|Z|1443|N|To Maurin Bonesplitter.|
 A The Corrupter|QID|1481|M|52.24,53.44|Z|1443|N|From Maurin Bonesplitter.|PRE|1480|
 r Repair|ACTIVE|1481|M|55.59,56.48|Z|1443|N|Visit Muuran before leaving.|
 R Sargeron|ACTIVE|1434^1481^4783|M|49.7,46.8;53.8,37.2;65.8,33.2;70.79,22.77|CC|Z|1443|N|Head north out of Ghost Walker Post and follow the road north to the intersection. Continue east along the road to the 2nd intersection and head north from there into Sargeron.|
-C Vial of Hatefury Blood|ACTIVE|4783|M|74.75,20.36|Z|1443|L|6989 10|N|These drop from the Hatefury Demons.|S|C|Warlock|
-C The Corrupter|QID|1481|M|74.75,20.36|Z|1443|L|6441|N|Kill a Hatefury Shadowstalker to loot its scalp.|S|
+C Vial of Hatefury Blood|ACTIVE|4783|M|74.75,20.36|Z|1443|L|6989 10|ITEM|6989|N|Any Hatefury Demon|S|C|Warlock|
+C The Corrupter|QID|1481|M|74.75,20.36|Z|1443|L|6441|ITEM|6441|N|Hatefury Shadowstalker|S|
 K Befouled by Satyr|ACTIVE|1434|M|74.75,20.36|Z|1443|QO|1;2;3;4|N|Kill Satyrs in the area.|
-C The Corrupter|QID|1481|M|74.75,20.36|Z|1443|L|6441|N|Kill Hatefury Shadowstalkers until you loot a shadowstalker scalp.|US|
-C Vial of Hatefury Blood|ACTIVE|4783|M|74.75,20.36|Z|1443|L|6989 10|N|Finish collecting these from the Hatefury Demons.|US|C|Warlock|
-K Khan Dez'hepah|ACTIVE|1365|M|73.20,42.50;73.30,46.90;74.14,49.12|CC|Z|1443|L|6066|N|Head south from Sargeron to Kolkar Village. Locate Khan Dez'hepah and kill him to loot his head.\n[color=FF0000]NOTE: [/color]He has 3 different spawn locations. If you can't find hm, he's dead and you need to wait.|T|Khan Dez'hepah|
+C The Corrupter|QID|1481|M|74.75,20.36|Z|1443|L|6441|ITEM|6441|N|Hatefury Shadowstalker|US|
+C Vial of Hatefury Blood|ACTIVE|4783|M|74.75,20.36|Z|1443|L|6989 10|ITEM|6989|N|Any Hatefury Demon|US|C|Warlock|
+K Khan Dez'hepah|ACTIVE|1365|M|73.20,42.50;73.30,46.90;74.14,49.12|CC|Z|1443|L|6066|ITEM|N|Khan Dez'hepah\nHead south from Sargeron to Kolkar Village and locate Khan Dez'hepah.\n[color=FF0000]NOTE: [/color]He has 3 different spawn locations. If you can't find hm, he's dead and you need to wait.|T|Khan Dez'hepah|
 R Ghost Walker Post|ACTIVE|1365|M|56.74,56.79|Z|1443|
 T Khan Dez'hepah|QID|1365|M|56.19,59.57|Z|1443|N|To Felgur Twocuts.|
 A Centaur Bounty|QID|1366|M|56.19,59.57|Z|1443|N|From Felgur Twocuts.|PRE|1365|
@@ -371,13 +372,13 @@ T Fish in a Bucket|QID|5421|M|22.46,73.11|Z|1443|L|13546 1|N|To Jinar'Zillen on 
 l Shellfish|AVAILABLE|5421|ACTIVE|5386|M|20.10,79.10|Z|1443|L|13545 5|N|Drop into the water and look for cages on the ocean floor. Open these to collect Shellfish. Jinar'Zillen will trade 5 of these Shellfish for 1 Bloodybelly fish.\n[color=FF0000]NOTE: [/color]If you do not have a means of breathing underwater, locate one of the small, bubbling fissures and use it to restore your breath.\nAlso, be aware that a Drysnap Crawler may spawn and attack you when you open the trap.|
 A Fish in a Bucket|AVAILABLE|5421|ACTIVE|5386|M|22.46,73.11|Z|1443|L|13546 2|N|From Jinar'Zillen on the pier.\n[color=FF0000]NOTE: [/color]You have to do this a second time.|NOCACHE|
 T Fish in a Bucket|QID|5421|M|22.46,73.11|Z|1443|L|13546 2|N|To Jinar'Zillen on the pier.|NOCACHE|
-K Centaurs|ACTIVE|1366|M|70.76,75.30|Z|1443|L|6067 15|N|Kill Centaurs and loot their ears.|S|
+C Centaur Bounty|QID|1366|M|70.76,75.30|Z|1443|L|6067 15|ITEM|6067|N|Any Centaur|S|
 N Reputation Monitoring|ACTIVE|1367^1368|N|Open the Reputation Tab (<U>) and locate the Faction you want to track. Check the box 'Show as Experience Bar' and it will appear above the Exp bar.\n[color=FF0000]NOTE: [/color]Some factions will only show in the list once there's been a change in your rep with them.\n\nResults may vary depending upon your UI layout and other Addons.\nManually check this step off to continue.|
 R Mannoroc Coven|ACTIVE|4783|M|46.89,75.16|Z|1443|N|Follow the main road east out of Shadowprey Village.|C|Warlock|
 C Lesser Infernal Stone|ACTIVE|4783|L|6990|ITEM|6990|N|Lesser Infernals|C|Warlock|
 R Magram Village|ACTIVE|1368|M|69.30,72.67|Z|1443|N|Follow the main road as far east as it goes. The village is on the south side of the road.|
 K Magram Clan Centaurs|ACTIVE|1368|M|70.76,75.30|Z|1443|N|Kill Magram Clan Centaurs until have reached Friendly status (3,000 rep) with The Gelkis Clan.\nIt'll take 75 kills to reach it.|REP|Gelkis Clan Centaur;92;Neutral|
-K Centaurs|ACTIVE|1366|M|70.76,75.30|Z|1443|L|6067 15|N|Finish collecting the ears.|US|
+C Centaur Bounty|QID|1366|M|70.76,75.30|Z|1443|L|6067 15|ITEM|6067|N|Any Centaur|US|
 R Ghost Walker Post|ACTIVE|1366|M|56.74,56.79|Z|1443|
 T Centaur Bounty|QID|1366|M|56.20,59.55|Z|1443|N|To Felgur Twocuts.|
 T Catch of the Day|QID|5386|M|55.41,55.80|Z|1443|N|To Nataka Longhorn.|
@@ -385,19 +386,19 @@ R Gelkis Village|ACTIVE|1368|M|37.64,78.95|Z|1443|
 T Gelkis Alliance|QID|1368|M|36.24,79.25|Z|1443|N|To Uthek the Wise.|
 R Shadowprey Village|AVAILABLE|6161|M|26.50,75.15|Z|1443|
 N Shortcut|AVAILABLE|6161|N|Instead of running all the way around to get to the shoreline in the north, you are going to swim up from Shadowprey Village.\n[color=FF0000]NOTE: [/color]Use this opportunity to collect your Soft-shelled Clam Meat.\nManually check this step off to continue.|
-C Clam Bait|QID|6142|M|33.20,31.66|Z|1443|L|15924 10|N|Open Soft-shelled clams to collect the meat.\n[color=FF0000]NOTE: [/color]You can get them from collecting the Giant Softshell Clams on the ocean floor and by killing Drysnap crawlers/pincers and the Reef Crawlers.\nThe Reef Crawlers will sometimes grab the Giant Softshell Clams.|U|15874|S|
+C Clam Bait|QID|6142|M|33.20,31.66|Z|1443|L|15924 10|N|You can get them from opening the Giant Soft Clams from the ocean floor.\n[color=FF0000]NOTE: [/color]You can also get them from killing Drysnap Crawlers/Pincers and Reef Crawlers.|U|15874|S|
 R Ethel Rethor|AVAILABLE|6161|M|30.5,34.2;35.66,30.67|CC|Z|1443|N|Walk into the water and swim north.|
 A Claim Rackmore's Treasure!|QID|6161|M|36.07,30.43|Z|1443|N|Find Rackmore's Log on top of the barrel beside the wreckage of the boat on shore. Click on it to start the quest.|
-C Rackmore's Golden Key|QID|6161|L|15881|N|Kill Nagas until they drop one.|S|
-C Oracle Crystal|QID|1482|L|6442|N|Kill Slitherblade Oracles until one drops.\n[21% drop rate]|S|
-C Rackmore's Silver Key|QID|6161|M|33.20,31.66|Z|1443|L|15878|N|Kill Drysnap Crawlers/Pincers until they drop the key.\n[color=FF0000]NOTE: [/color]Stick around the bubbling fissure so you don't have to keep swimming to the surface for air. They will come to you.|
-C Clam Bait|QID|6142|M|33.20,31.66|Z|1443|L|15924 10|N|Finish collecting the Soft-shelled Clam Meat.\nYou can get them from opening the Giant Soft Clams on the ocean floor and by killing Drysnap crawlers/pincers. You can also get them from killing the Reef Crawlers.|U|15874|US|
+C Rackmore's Golden Key|QID|6161|L|15881|ITEM|15881|N|Any Naga|S|
+C Oracle Crystal|QID|1482|L|6442|L|6442|ITEM|6442|N|Slitherblade Oracle|S|
+C Rackmore's Silver Key|QID|6161|M|33.20,31.66|Z|1443|L|15878|ITEM|15878|N|Drysnap Crawler/Pincer\n[color=FF0000]NOTE: [/color]Stick around the bubbling fissure so you don't have to keep swimming to the surface for air. They will come to you.|
+C Clam Bait|QID|6142|M|33.20,31.66|Z|1443|L|15924 10|N|You can get them from opening the Giant Soft Clams from the ocean floor.\n[color=FF0000]NOTE: [/color]You can also get them from killing Drysnap Crawlers/Pincers and Reef Crawlers.|U|15874|US|
 K Other Fish to Fry|ACTIVE|6143|M|32.54,22.41|Z|1443|QO|1;2;3|N|Slay Slitherblade Myrmidons, Nagas, and Sorceresses.|
-C Rackmore's Golden Key|QID|6161|L|15881|N|Kill Nagas until they drop one.|US|
+C Rackmore's Golden Key|QID|6161|L|15881|ITEM|15881|N|Any Naga|US|
 R Ranazjar Isle|ACTIVE|6161|M|30.56,9.19|Z|1443|N|Swim to the big island to the north.|
-T Claim Rackmore's Treasure!|QID|6161|M|30.01,8.70|Z|1443|N|After clearing the mobs around the chest, open it to complete the quest.|
-K Lord Kargaru|ACTIVE|6027|M|28.27,6.70|Z|1443|L|15803|N|After clearing the mobs in the area, click on the Serpent Statue to summon Lord Kargaru and kill him to loot the Book of the Ancients.|
-C Oracle Crystal|QID|1482|N|Kill Slitherblade Oracles until one drops an Oracle Crystal.\n21% drop rate|US|
+T Claim Rackmore's Treasure!|QID|6161|M|30.01,8.70|Z|1443|N|After clearing the area around the chest, open it to complete the quest.|
+K Lord Kargaru|ACTIVE|6027|M|28.27,6.70|Z|1443|L|15803|ITEM|15803|N|Lord Kargaru\nAfter clearing the area, click on the Serpent Statue to summon Lord Kargaru.|
+C Oracle Crystal|QID|1482|L|6442|ITEM|6442|N|Slitherblade Oracle|US|
 R Ethel Rethor|ACTIVE|6027|M|38.02,25.15|Z|1443|N|Swim back to shore.|
 T Book of the Ancients|QID|6027|M|40.9,29.0;38.88,27.16|CC|Z|1443|N|To Azore Aldamort, at the top of the ramp.|
 R Ghost Walker Post|ACTIVE|1482|M|58.59,57.04|Z|1443|N|Head towards Ghost Walker as you grind.|S|
@@ -424,7 +425,7 @@ T Knowledge of the Orb of Orahil|QID|4967|M|62.51,35.45|Z|1413|N|To Menara Voidr
 A Fragments of the Orb of Orahil|QID|1799|M|62.51,35.45|Z|1413|N|From Menara Voidrender.|PRE|4967|
 F Shadowprey Village|ACTIVE|1799|M|63.09,37.16|Z|1413|QO|1|C|Warlock|
 R Mannoroc Coven|ACTIVE|1799|M|46.89,75.16|Z|1443|QO|1|N|Follow the main road east out of Shadowprey Village.|C|Warlock|
-C Infernal Orb|ACTIVE|1799|L|7291|ITEM|7291|N|Burning Blade Summoner.|C|Warlock|
+C Infernal Orb|ACTIVE|1799|L|7291|ITEM|7291|N|Burning Blade Summoner|C|Warlock|
 R Shadowprey Village|ACTIVE|4785^1799|M|26.50,75.15|Z|1443|N|Return to Shadowprey Village.|IZ|1443|
 F Ratchet|ACTIVE|4785|M|21.60,74.13|Z|1443|
 b Booty Bay|ACTIVE|4785|M|63.70,38.63|Z|1413|N|Take the boat to Booty Bay.|
@@ -445,7 +446,7 @@ t Soothing Turtle Bisque|QID|7321|M|62.30,19.09|Z|1424|N|To Christoph Jeffcoat.|
 A Helcular's Revenge|QID|552|M|63.88,19.67|Z|1424|N|From Novice Thaivand, standing in the cemetary.|
 A Infiltration|QID|533|M|63.23,20.66|Z|1424|N|From Krusk.|
 R Darrow Hill|ACTIVE|552|M|49.10,32.22|Z|1424|N|Run to the Cave in Darrow Hill.|
-C Helcular's Revenge|ACTIVE|552|M|45.46,31.20|Z|1424|L|3708|N|Kill Yetis until one of them drops Helcular's Rod.|
+C Helcular's Revenge|ACTIVE|552|M|45.46,31.20|Z|1424|L|3708|ITEM|3708|N|Any Yeti in Darrow Hill|
 R Tarren Mill|ACTIVE|552|M|60.35,21.10|Z|1424|N|Return to Tarren Mill.|
 T Helcular's Revenge|QID|552|M|63.88,19.65|Z|1424|N|To Novice Thaivand.|
 A Helcular's Revenge|QID|553|M|63.88,19.65|Z|1424|N|From Novice Thaivand.|
@@ -453,36 +454,36 @@ R Darrow Hill|ACTIVE|553|M|49.10,32.22|Z|1424|N|Return to the Cave in Darrow Hil
 C Flame of Veraz|QID|553|M|44.05,26.55|Z|1424|QO|2|N|Enter the cave and make your way to the bottom of the ramp. Head into the cavern to your left and click on Flame of Veraz.|NC|
 C Flame of Azel|QID|553|M|43.89,28.06|Z|1424|QO|1|N|Make your way to the top of the ramp and click on Flame of Azel.|NC|
 R Alterac Mountains|ACTIVE|1136^553|M|44.60,87.21|Z|1416|N|Exit the cave and head north up the hill.|
-l Mountain Lion Carcass|ACTIVE|1136|M|43.03,80.38|Z|1416|L|5810|N|Kill a Mountain Lion and loot it's carcass. You'll need this to spawn Frostmaw.\nAny type of Mountain Lion will do.\n[color=FF0000]NOTE: [/color]The Fresh Carcass has a time limit of 30 minutes before it despawns and you have to get another one.|
+l Mountain Lion Carcass|ACTIVE|1136|M|43.03,80.38|Z|1416|L|5810|ITEM|5810|N|Any Mountain Lion\nYou'll need this to spawn Frostmaw.\n[color=FF0000]NOTE: [/color]The Fresh Carcass has a time limit of 30 minutes before it despawns and you have to get another one.|
 R Growless Cave|ACTIVE|1136|M|37.58,68.29|Z|1416|N|Giving the Alliance outpost on your left a wide berth, continue north to Growless Cave.|
 N Flame of Uzel|ACTIVE|1136&553|N|This item is used for both 'Frostmaw' and 'Helcular's Revenge'. That being said, if you click on it, I cannot say for certain which quest will activate first. Clicking on the 'Fresh Carcass' will guarantee you start Frostmaw.\n[color=FF0000]NOTE: [/color]Manually check this step off to continue.|
-l Fresh Carcass|ACTIVE|1136|M|41.99,77.39|Z|1416|L|5810|N|You need to go kill a Mountain Lion to get another Fresh Carcass.\n[color=FF0000]NOTE: [/color]Remember, the Fresh Carcass has a time limit of 30 minutes before it despawns.|
-K Frostmaw|ACTIVE|1136|M|37.54,66.24|Z|1416|L|5811|N|Clear all of the Yetis inside the cave. Once cleared, click on (use) the Fresh Carcass at Flame of Uzel. When Frostmaw spawns, kill him and loot his Mane.|U|5810|
+l Fresh Carcass|ACTIVE|1136|M|41.99,77.39|Z|1416|L|5810|ITEM|5810|N|Any Mountain Lion\n[color=FF0000]NOTE: [/color]Remember, the Fresh Carcass has a time limit of 30 minutes before it despawns.|
+K Frostmaw|ACTIVE|1136|M|37.54,66.24|Z|1416|L|5811|ITEM|1416|N|Frostmaw\nClear the cave and click on (use) the Fresh Carcass at Flame of Uzel to spawn Frostmaw.|U|5810|
 C Flame of Uzel|QID|553|M|37.54,66.24|Z|1416|QO|3|N|Click on Flame of Uzel to charge Helcular's Rod.|
 R Lordamere Internment Camp|ACTIVE|544^556|M|21.93,82.32|Z|1416|N|Exit the cave and head west to Dalaran.|
-C Stone Tokens|QID|556|M|21.70,82.83|Z|1416|L|3714 10|N|Kill Dalaran Shield Guards and Theurgists to loot the Stone Tokens.\n[color=FF0000]NOTE: [/color]Keep an eye on your health because the Shield Guards can hit quite hard.|S|
-K Ricter|ACTIVE|544|M|19.96,84.43|Z|1416|L|3689|N|Kill Ricter to loot the Bloodstone Marble.\n[color=FF0000]NOTE: [/color]All of the targets involved in this quest are non-hostile and you can clear the area without fear of aggroing them.|
-K Alina|ACTIVE|544|M|20.33,86.34|Z|1416|L|3690|N|Kill Alina to loot the Bloodstone Shard.|
-K Dermot|ACTIVE|544|M|19.90,85.93|Z|1416|L|3691|N|Kill Dermot to loot the Bloodstone Wedge.|
-K Kegan Darkmar|ACTIVE|544|M|17.86,83.10|Z|1416|L|3688|N|Work your way into the house and up to the top floor. Each 'room' has 2 mobs in it.\nOnce you have dispatached the 2 guards at the top of the stairs, target Warden Belamoore and take her out first. Once the the room is clear, kill Kegan Darkmar to loot the Bloodstone Oval.|T|Warden Belamoore|
+C Stone Tokens|QID|556|M|21.70,82.83|Z|1416|L|3714 10|ITEM|3714|N|Dalaran Shield Guard/Theurgist\n[color=FF0000]NOTE: [/color]Keep an eye on your health because the Shield Guards can hit quite hard.|S|
+K Ricter|ACTIVE|544|M|19.96,84.43|Z|1416|L|3689|ITEM|3689|N|Ricter\n[color=FF0000]NOTE: [/color]All of the targets involved in this quest are non-hostile and you can clear the area without fear of aggroing them.|
+K Alina|ACTIVE|544|M|20.33,86.34|Z|1416|L|3690|ITEM|3690|N|Alina|
+K Dermot|ACTIVE|544|M|19.90,85.93|Z|1416|L|3691|ITEM|3691|N|Dermot|
+K Kegan Darkmar|ACTIVE|544|M|17.86,83.10|Z|1416|L|3688|ITEM|3688|N|Kegan Darkmar\nWork your way into the house and up to the top floor. Each 'room' has 2 mobs in it.\nAfter killing the 2 guards at the top of the stairs, target Warden Belamoore and take her out first. Once the room is clear, kill Kegan Darkmar.|T|Warden Belamoore|
 * Belamoore's Research Journal|QID|9999|N|This item is useless and unsellable. You can safely delete it.|U|3711|
-C Stone Tokens|QID|556|M|21.05,84.03|Z|1416|L|3714 10|N|Kill Dalaran Shield Guards and Theurgists to loot the Stone Tokens.\n[color=FF0000]NOTE: [/color]If they are hard to find, you can head to Dalaran and kill Summoners.|US|
+C Stone Tokens|QID|556|M|21.05,84.03|Z|1416|L|3714 10|ITEM|3714|N|Dalaran Shield Guard/Theurgist\n[color=FF0000]NOTE: [/color]If they are hard to find, you can head to Dalaran and kill Summoners.|US|
 R Corrahn's Dagger|ACTIVE|533|M|29.0,79.4;40.5,84.5;44.09,77.70|CC|Z|1416|N|Leave the camp and head east into the hills. Continue east making sure to stay clear of the Alliance fort at The Headlands.|
 N Sofera's Naze|ACTIVE|533|N|If you find this area busy, you can find more mobs east of here, across the road.\n[color=FF0000]NOTE: [/color]Manually check this step off to continue.|
-C Infiltration|QID|533|M|48.10,81.89|Z|1416|L|3601|N|Kill Syndicate Thieves and Footpads until one drops the Syndicate Missive.|
+C Infiltration|QID|533|M|48.10,81.89|Z|1416|L|3601|ITEM|3601|N|Syndicate Thief/Footpad|
 R Tarren Mill|ACTIVE|533^544^556|M|60.35,21.10|Z|1424|N|Make your way back to Tarren Mill.|
 T Prison Break In|QID|544|M|61.60,20.84|Z|1424|N|To Magus Wordeen Voidglare.\n[color=FF0000]NOTE: [/color]Do not get the follow-up.|
 T Stone Tokens|QID|556|M|61.49,20.94|Z|1424|N|To Keeper Bel'varil.\n[color=FF0000]NOTE: [/color]Do not get the follow-up.|
 T Infiltration|QID|533|M|63.24,20.66|Z|1424|N|To Krusk.\n[color=FF0000]NOTE: [/color]Do not get the follow-up quest.|
 R The River|ACTIVE|7321^553|M|67.66,19.73|CC|Z|1424|N|Head east to the river.|
-C Turtle Meat|QID|7321|L|3712 10|N|Kill Turtles to loot their meat.|S|
+C Turtle Meat|QID|7321|L|3712 10|ITEM|3712|N|Any Turtle|S|
 R Southshore|ACTIVE|553|M|54.47,51.56|Z|1424|N|Follow the river south to Southshore.\n[color=FF0000]NOTE: [/color]Keep your distance from the Alliance guards patroling the edge of Southshore.|
 T Helcular's Revenge|QID|553|M|52.76,53.34|Z|1424|N|Click on Helcular's tombstone to turn in the quest.\n[color=FF0000]NOTE: [/color]Do not stick around as this area is patrolled by a couple Alliance guards.|
-C Turtle Meat|QID|7321|L|3712 10|N|Finish collecting your Turtle meat as you make your way north along the river towards Tarren Mill.\n[color=FF0000]NOTE: [/color]You may have to travel up and down the river to kill enough turtles.|US|
+C Turtle Meat|QID|7321|L|3712 10|ITEM|3712|N|Any Turtle\n[color=FF0000]NOTE: [/color]You may have to travel up and down the river to kill enough turtles.|US|
 
 ; --- Arathi Highlands
 R Arathi Highlands|AVAILABLE|655|M|20.04,29.38|Z|1417|N|Before leaving the area, we are going to make the run through Arathi Highlands to get the FP at Hammerfall.\n[color=FF0000]NOTE: [/color]Manually check this step off to continue.|
-C Smoldering Coal|ACTIVE|4784|M|25.45,30.26|Z|1417|L|6991 2|ITEM|6991|N|Burning Exiles in Circle of West Binding.\n[color=FF0000]NOTE: [/color]They are immune to fire damage.|
+C Smoldering Coal|ACTIVE|4784|M|25.45,30.26|Z|1417|L|6991 2|ITEM|6991|N|Burning Exile in Circle of West Binding.\n[color=FF0000]NOTE: [/color]They are immune to fire damage.|
 R Hammerfall|AVAILABLE|655|M|45.3,58.9;25.45,30.26|CC|Z|1417|N|Continue eastward along the road until you reach the signpost for Hammerfall. Head northeast as indicated by the sign, keeping an eye out for more signs as you follow the road along.|
 f Hammerfall|AVAILABLE|655|M|73.07,32.61|Z|1417|N|From Urda.\n[color=FF0000]NOTE: [/color]Open the flight map to populate the FPs.|
 A Hammerfall|QID|655|M|72.63,33.93|Z|1417|N|From Gor'mul.|
@@ -492,7 +493,7 @@ T Hammerfall|QID|655|M|74.72,36.29|Z|1417|N|To Tor'gan.|
 R Thandol Span|ACTIVE|1805|M|49.5,45.2;44.30,87.56|CC|Z|1417|N|Return to the sign post at the main road and follow the road south.|
 R Dun Modir|ACTIVE|1805|M|50.58,14.05|Z|1437|N|Cross the bridge and start following the road south.|
 R Angerfang Encampment|ACTIVE|1805|M|48.97,44.34|Z|1437|N|Continue south over the bridge, through the cemetary and up the hill.|
-C Rod of Channeling|ACTIVE|1805|L|6930 3|ITEM|6930|N|Dragonmaw Bonewarders and Shadowwarders.\n[color=FF0000]NOTE: [/color]These mobs will be grey to you.|
+C Rod of Channeling|ACTIVE|1805|L|6930 3|ITEM|6930|N|Dragonmaw Bonewarder/Shadowwarder\n[color=FF0000]NOTE: [/color]These mobs will be grey to you.|
 
 ; --- Thunder Bluff
 H Orgrimmar|ACTIVE|1136||M|60.35,21.10|Z|1424|N|Use your hearth to save time. If it's on CD, run back to Tarren Mills, fly to Undercity and take the Zeppelin to Orgrimmar.|
@@ -546,11 +547,11 @@ A Tiger Mastery|QID|185|M|35.62,10.62|Z|1434|N|From Ajeck Rouack.|PRE|583|
 A Panther Mastery|QID|190|M|35.56,10.54|Z|1434|N|From Sir S. J. Erlgadin.|PRE|583|
 A The Green Hills of Stranglethorn|QID|338|M|35.66,10.53|Z|1434|N|From Barnil Stonepot.|PRE|583|
 N Chapter Quests|ACTIVE|338|AVAILABLE|339^340^341^342|N|Going forward, every time you return to the Camp, check in with Barnil Stonepot to see if you have enough pages to finish a Chapter quest. You'll want to get rid of the pages as soon as you can to save bag space.\n[color=FF0000]NOTE: [/color]To save log space, do not accept the Chapter quests until you can complete them.|S!US|IZ|Nesingwary's Expedition|
-C Supply and Demand|QID|575|M|40.60,13.03|Z|1434|L|4053 2|N|Kill River Crocolisks to loot the skins.|S|
+C Supply and Demand|QID|575|M|40.60,13.03|Z|1434|L|4053 2|ITEM|4053|N|River Crocolisk|S|
 K Panther Mastery|ACTIVE|190|M|37.70,14.80|Z|1434|QO|1|N|Kill Young Stranglethorn Panthers.|S|
 K Tiger Mastery|ACTIVE|185|M|34.13,11.45|Z|1434|QO|1|N|Heading in a westerly direction from the camp, kill Young Stranglethorn Tigers. In a looping arc, make your way east to the bridge.|
 K Panther Mastery|ACTIVE|190|M|37.7,14.8;39.7,13.7;41.2,12.9;40.83,10.44|CC|Z|1434|QO|1|N|As you make your way east under the bridge, kill Young Panthers. Cross the river to the north side and work your way west in a sweeping arc towards the road.|US|
-C Supply and Demand|QID|575|M|33.46,8.26|Z|1434|L|4053 2|N|Kill River Crocolisks to loot the skins.\n[color=FF0000]NOTE: [/color]Check both sides of the river.|US|
+C Supply and Demand|QID|575|M|33.46,8.26|Z|1434|L|4053 2|ITEM|4053|N|River Crocolisk\n[color=FF0000]NOTE: [/color]Check both sides of the river.|US|
 T Panther Mastery|QID|190|M|35.56,10.54|Z|1434|N|To Sir S. J. Erlgadin, back at Nesingwary's Expedition.|
 A Panther Mastery|QID|191|M|35.56,10.54|Z|1434|N|From Sir S. J. Erlgadin.|PRE|190|
 T Tiger Mastery|QID|185|M|35.62,10.62|Z|1434|N|To Ajeck Rouack.|
@@ -573,9 +574,9 @@ K Foreman Cozzle|ACTIVE|1182|M|42.72,18.37|Z|1434|L|5851|ITEM|5851|QO|1|N|Forema
 C Cozzle's Footlocker|QID|1182|M|43.33,20.33|Z|1434|QO|1|N|Drop down into the water and head inside the little house beside the mill. Click on the chest to open it and loot the Fuel Regulator Blueprints.\n[color=FF0000]NOTE: [/color]There is no one inside.|NC|
 C Hostile Takeover|QID|213|M|43.91,22.90|Z|1434|L|4106 8|ITEM|4106|N|Venture Co. Geologist\n[color=FF0000]NOTE: [/color]They are spellcasters.|US|
 K Panther Mastery|ACTIVE|192|M|48.67,22.86|Z|1434|QO|1|N|Kill Shadowmaw Panthers.|S|
-C Mok'thardin's Enchantment|QID|570|M|48.67,22.86|Z|1434|L|3838 8|ITEM|3838|N|Shadowmaw Panthers|S|
+C Mok'thardin's Enchantment|QID|570|M|48.67,22.86|Z|1434|L|3838 8|ITEM|3838|N|Shadowmaw Panther|S|
 C Mok'thardin's Enchantment|QID|570|M|48.67,22.86|Z|1434|L|3839|ITEM|3839|N|Stranglethorn Tigresses\nHead up into the hills on the east side of Venture Co, Base Camp.\n[color=FF0000]NOTE: [/color]Watch out for the Mosh'Ogg south of the road.|
-C Mok'thardin's Enchantment|QID|570|M|48.67,22.86|Z|1434|L|3838 8|ITEM|3838|N|Shadowmaw Panthers|US|
+C Mok'thardin's Enchantment|QID|570|M|48.67,22.86|Z|1434|L|3838 8|ITEM|3838|N|Shadowmaw Panther|US|
 K Panther Mastery|QID|192|M|48.67,22.86|Z|1434|QO|1|N|Kill Shadowmaw Panthers.\n[color=FF0000]NOTE: [/color]As they can cloak themselves, unless you can track them, you'll have to wander around the area until you find them.|T|Shadowmaw Panther|US|
 R Nesingwary's Expedition|ACTIVE|192|M|35.65,10.66|Z|1434|N|Head back to Nesingwary's Expedition.\n[color=FF0000]NOTE: [/color]Following the road is probably the best route.|
 T Panther Mastery|QID|192|M|35.56,10.54|Z|1434|N|To Sir S. J. Erlgadin.|
@@ -698,7 +699,7 @@ T The Black Shield|QID|1321|M|36.53,30.79|Z|1445|N|To Do'gol.|
 A The Black Shield|QID|1322|M|36.53,30.79|Z|1445|N|From Do'gol.|PRE|1321|
 K Theramore Spies|ACTIVE|1201|M|38.00,26.95|Z|1445|QO|1|N|You'll find them outside of the village to the north and south.\n[color=FF0000]NOTE: [/color]Unless you can track invisible, walk around spamming the targetting button and listen for the sound of them cloaking.\nDon't worry about sneak attacks; they are non-aggressive until attacked.|T|Theramore Infiltrator|
 R Darkmist Cavern|ACTIVE|1322|M|35.85,22.88|Z|1445|
-C The Black Shield|QID|1322|M|33.00,22.00|Z|1445|L|5959 5|N|Kill Darkmist spiders to collect the Acidic Venom Sacs.|
+C The Black Shield|QID|1322|M|33.00,22.00|Z|1445|L|5959 5|ITEM|5959|N|Any type of Darkmist Spider|
 R Brackenwall Village|ACTIVE|1322^1201|M|35.93,30.69|Z|1445|
 T The Black Shield|QID|1322|M|36.53,30.79|Z|1445|N|To Do'gol.|
 A The Black Shield|QID|1323|M|36.53,30.79|Z|1445|N|From Do'gol.|PRE|1322|
@@ -714,20 +715,20 @@ T The Hermit of Witch Hill|QID|11225|M|55.43,26.26|Z|1445|N|To "Swamp Eye" Jarl.
 A Marsh Frog Legs|QID|1218|M|55.43,26.26|Z|1445|N|From "Swamp Eye" Jarl.|
 A What's Haunting Witch Hill?|QID|11180|M|55.58,26.14|Z|1445|N|From Mordant Grimsby.\n[color=FF0000]NOTE: [/color]Periodically, he travels outside the cabin to talk to Jarl and returns inside.|
 A The Lost Report|QID|1238|M|55.44,25.92|Z|1445|N|From the 'Loose Dirt' beside the house.|
-C Marsh Frogs|ACTIVE|1218|M|55.93,25.31|Z|1445|L|33202 10|N|Kill Marsh Frogs to loot their legs.|S|
+C Marsh Frogs|ACTIVE|1218|M|55.93,25.31|Z|1445|L|33202 10|ITEM|33202|N|Marsh Frog|S|
 K Risen Husks/Spirits|ACTIVE|11180|M|55.93,25.31|Z|1445|QO|1|N|Gather information by killing the Risen Husks or Spirits found all around the area.\n[color=FF0000]NOTE: [/color]If you are using a pet, make sure you put them on passive before the Risen dies because you have to land the killing blow.|
 T What's Haunting Witch Hill?|QID|11180|M|55.58,26.14|Z|1445|N|To Mordant Grimsby.|
 A The Witch's Bane|QID|11181|M|55.58,26.14|Z|1445|N|From Mordant Grimsby.|PRE|11180|
 C The Witch's Bane|QID|11181|M|49.99,20.95|Z|1445|L|33112 9|N|Follow the river northward and you'll find the large plants along the shorelines on either side.\n[color=FF0000]NOTE: [/color]'Find Herb' can help with these.|
-C Marsh Frogs|ACTIVE|1218|M|55.93,25.31|Z|1445|L|33202 10|N|Kill Marsh Frogs to loot their legs.|T|Giant Marsh Frog|US|
+C Marsh Frogs|ACTIVE|1218|M|55.93,25.31|Z|1445|L|33202 10|ITEM|33202|N|Marsh Frog|T|Giant Marsh Frog|US|
 T Marsh Frog Legs|QID|1218|M|55.44,26.26|Z|1445|N|To "Swamp Eye" Jarl.\n[color=FF0000]NOTE: [/color]The rest of this quest chain isn't worth the extra time.|
 T The Witch's Bane|QID|11181|M|55.58,26.14|Z|1445|N|To Mordant Grimsby.|
 A Cleansing Witch Hill|QID|11183|M|55.58,26.14|Z|1445|N|From Mordant Grimsby.|PRE|11181|
 K Zelfrax|ACTIVE|11183|M|55.27,26.57|Z|1445|QO|1|N|Use the Witchbane Torch on the dock and kill Zelfrax when it appears.|U|33113|
 T Cleansing Witch Hill|QID|11183|M|55.58,26.14|Z|1445|N|To Mordant Grimsby.|
-C Hungry!|QID|1177|M|57.42,16.89|Z|1445|L|5847 8|N|Kill Mirefin Murlocs to collect the Mirefin Heads.|S|
+C Hungry!|QID|1177|M|57.42,16.89|Z|1445|L|5847 8|ITEM|5847|N|Mirefin Murloc|S|
 R Dreadmurk Shore|ACTIVE|1202|M|57.85,19.01|Z|1445|N|Make your way to the Dreadmurk Shore.|
-C Hungry!|QID|1177|M|57.42,16.89|Z|1445|L|5847 8|N|Kill Mirefin Murlocs to collect the Mirefin Heads.\n[color=FF0000]NOTE: [/color]They are runners and watch your back for adds.|US|
+C Hungry!|QID|1177|M|57.42,16.89|Z|1445|L|5847 8|ITEM|5847|N|Mirefin Murloc\n[color=FF0000]NOTE: [/color]They are runners and watch your back for adds.|US|
 R Theramore Isle|ACTIVE|1202|M|66.13,43.56|Z|1445|N|Make your way to the Theramore Isle. Follow the shore line the whole way there.\n[color=FF0000]NOTE: [/color]Do not go near the front entrance. This is an Alliance city and the guards will kill you.|
 C Captain's Footlocker|QID|1202|M|71.54,51.19|Z|1445|L|5882|N|Work your way around the island to the dock at the back.\nLocate the Captain's Footlocker under the dock and open it to loot the Captain's Documents.\n[color=FF0000]NOTE: [/color]You can avoid the guards at the back gate by going into the water when you get there.|
 R Main Road|AVAILABLE|1270|M|63.20,43.10|CC|Z|1445|N|As you did earlier, make your way around the island, while avoiding the Alliance guards, and cross the water to the main land. Head up the bank to the main road.|
@@ -749,7 +750,6 @@ T Check Up on Tabetha|QID|11213|M|46.06,57.09|Z|1445|N|To Tabetha inside the hou
 R Mudsprocket|ACTIVE|11215|M|40.0,61.8;40.6,68.8;41.87,72.46|CC|Z|1445|N|Head back to the sign post at the intersection and head south to the next sign post.|
 T Help Mudsprocket|QID|11215|M|42.33,72.93|Z|1445|N|To Drazzit Dripvalve.|
 f Mudsprocket|AVAILABLE|1273|M|42.82,72.43|Z|1445|N|At Dyslix Silvergrub. He's outside the wall just east of the main entrance.|TAXI|-Mudsprocket|
-; -- Eliminated finishing Witch Hill dirt pile quest chain - Hendo72
 F Brackenwall Village|AVAILABLE|1273|M|42.82,72.43|Z|1445|
 R Main Road|AVAILABLE|1273|M|39.14,37.96|CC|Z|1445|N|Exit Brackenwall from the south and follow the road until it ends at the main road.|
 N Questioning Reethe Bugged?|AVAILABLE|1273|M|42.32,37.91|Z|1445|N|Before you start the next quest, verify that Reethe's alone. If he's not, the quest has bugged and you'll need to clear the mobs before you can start it.\n[color=FF0000]NOTE: [/color]If/When Reethe is alone, manually check this step off to continue.|


### PR DESCRIPTION
- Simplifying things by using |ITEM| on loot quests. All you need is who/what drops the item and note if there are any specific details.
- Added filters to eliminate surviving travel steps.
- removed notes from travel steps where not required.
- added a Level 38 check and train step (The travel steps were already in place, the train step was missing)

FYI: The numbers at the end of the T steps are the exp gained for the level check.