### PR TITLE
DK Intro Guide Fixes

### DIFF
--- a/WoWPro_Leveling/WoWPro_Leveling.lua
+++ b/WoWPro_Leveling/WoWPro_Leveling.lua
@@ -87,7 +87,7 @@ function WoWPro.Leveling:OnEnable()
             WoWPro.Leveling:dbp("Loading starter %s guide: %s",engRace,tostring(WoWPro.Leveling.StartGuides[engRace]))
             if WoWPro.CLASSIC then
                 WoWProDB.char.currentguide = WoWPro.Leveling.ClassicStartGuides[engRace]
-            elseif WoWPro.BC then
+            elseif WoWPro.BC or WoWPro.WRATH then
                 WoWProDB.char.currentguide = WoWPro.Leveling.ClassicBCStartGuides[engRace]
             else
 				local mapID = _G.C_Map.GetBestMapForUnit("player");
@@ -104,6 +104,9 @@ function WoWPro.Leveling:OnEnable()
             end
             WoWPro:LoadGuide(WoWProDB.char.currentguide)
         -- New Death Knight --
+		elseif currentLevel == 55 and currentXP < 1000 and engClass == "DEATHKNIGHT" and WoWPro.WRATH then
+			WoWPro.Leveling:dbp("Loading starter %s guide",locClass)
+            WoWPro:LoadGuide("WOTLK-DK")
         elseif currentLevel == 8 and currentXP < 300 and engClass == "DEATHKNIGHT" then
             WoWPro.Leveling:dbp("Loading starter %s guide",locClass)
             WoWPro:LoadGuide("JamScar5558")

--- a/WoWPro_Leveling/Wrath/Neutral/Guides.xml
+++ b/WoWPro_Leveling/Wrath/Neutral/Guides.xml
@@ -1,5 +1,5 @@
 <Ui xmlns="http://www.blizzard.com/wow/ui/">
-    <Script file="INTRO_DK.lua"/>
+    <Script file="INTRO_WOTLK_DK.lua"/>
 	<Script file="BCC_Netherstorm.lua"/>
 	<Script file="WOTLK_Sholazar_Basin.lua"/>
 	<Script file="WOTLK_ZulDrak.lua"/>

--- a/WoWPro_Leveling/Wrath/Neutral/INTRO_WOTLK_DK.lua
+++ b/WoWPro_Leveling/Wrath/Neutral/INTRO_WOTLK_DK.lua
@@ -1,10 +1,12 @@
-local guide = WoWPro:RegisterGuide("JamSca5558", "Leveling", "The Scarlet Enclave", "WoW-Pro Team", "Horde", 3)
-WoWPro:GuideNickname(guide, "The Scarlet Enclave")
-WoWPro:GuideName(guide, "Plaguelands: The Scarlet Enclave")
+local guide = WoWPro:RegisterGuide("WOTLK-DK", "Leveling", "Plaguelands: The Scarlet Enclave!Instance", "WoW-Pro Team", "Neutral", 3)
+WoWPro:GuideContent(guide, "Intro")
+WoWPro:GuideNickname(guide, "Death Knight: Intro")
+WoWPro:GuideName(guide,"Death Knight: Intro")
 WoWPro:GuideLevels(guide, 55, 58)
 WoWPro:GuideClassSpecific(guide,"DeathKnight")
-WoWPro:GuideNextGuide(guide, "JamHel6062"|"JamHel6063")
+WoWPro:GuideNextGuide(guide, "Hellfire Peninsula")
 WoWPro:GuideSteps(guide, function()
+
 return [[
 
 A In Service Of The Lich King|QID|12593|M|51.34,35.17|Z|124|N|From The Lich King.|
@@ -158,7 +160,5 @@ T Where Kings Walk|QID|13188|Z|Stormwind City|M|85.6,31.8|N|To King Anduin Wrynn
 A Saurfang's Blessing|QID|13189|PRE|13166|FACTION|Horde|M|83.4,49.4|N|From Highlord Darion Mograine.|
 P Durotar|QID|13189|M|84.58,50.49|Z|Eastern Plaguelands|N|Click on the portal to go to Orgrimmar.|FACTION|Horde|
 T Saurfang's Blessing|QID|13189|Z|Orgrimmar|M|48.14,70.56|N|To High Overlord Saurfang.|FACTION|Horde|
-N It's Chromie Time!|QID|62567|M|62.25,29.93|Z|Stormwind City|JUMP|Chromie Time|LVL|10|N|You can now accept Chromie's Call at the Hero's Call board in Stormwind. This will allow you to choose which expansion you want to level in.\n\nClick the guide button next to this frame to direct you to Chromie!|FACTION|Alliance|
-N It's Chromie Time!|QID|62568|M|40.82,80.13|Z|Orgrimmar|JUMP|Chromie Time|LVL|10|N|You can now accept Chromie's Call at the Warchief's Command Board in Orgrimmar. This will allow you to choose which expansion you want to level in.\n\nClick the guide button next to this frame to direct you to Chromie!|FACTION|Horde|
 ]]
 end)


### PR DESCRIPTION
Fixed the issues with the intro guide, next guide is set properly to hellfire, guide is neutral. All names/nicknames were specified appropriately and zone matched that in ZoneData. Also renamed file to match that of the naming convention previously used.

Updated leveling addon to recognize starter guides in Wrath expansion as well as the level 55 Death Knights.