### PR TITLE
Guide ID fixes and DF Continent and guide work

### DIFF
--- a/WoWPro/WoWPro_Widgets.lua
+++ b/WoWPro/WoWPro_Widgets.lua
@@ -140,7 +140,11 @@ function WoWPro:CreateJumpButton(parent, id)
     local jumpicon = jumpbutton:CreateTexture(nil, "ARTWORK")
     jumpicon:SetWidth(24)
     jumpicon:SetHeight(24)
-    jumpicon:SetTexture("Interface\\Icons\\Inv_7xp_inscription_talenttome02")
+	if WoWPro.RETAIL then
+		jumpicon:SetTexture("Interface\\Icons\\Inv_7xp_inscription_talenttome02")
+	else
+		jumpicon:SetTexture("Interface\\Icons\\inv_misc_book_12")
+	end
     jumpicon:SetAllPoints(jumpbutton)
     jumpbutton:RegisterForClicks("anyUp")
     jumpbutton:Hide()

--- a/WoWPro_Leveling/Classic_BC/Neutral/BCC_Netherstorm.lua
+++ b/WoWPro_Leveling/Classic_BC/Neutral/BCC_Netherstorm.lua
@@ -1,4 +1,4 @@
-local guide = WoWPro:RegisterGuide('BC-Netherstorm', "Leveling", 'Netherstorm', 'Crackerhead22', 'Neutral', 2)
+local guide = WoWPro:RegisterGuide('CLASSIC_BC_Netherstorm', "Leveling", 'Netherstorm', 'Crackerhead22', 'Neutral', 2)
 WoWPro:GuideSort(guide, 7)
 WoWPro:GuideNickname(guide, "Netherstorm")
 WoWPro:GuideName(guide,"Netherstorm")

--- a/WoWPro_Leveling/Neutral/DF_Azure_Span.lua
+++ b/WoWPro_Leveling/Neutral/DF_Azure_Span.lua
@@ -1,7 +1,7 @@
-local guide = WoWPro:RegisterGuide('The Azure Span', 'Leveling', 'The Azure Span', 'WoWPro Team', 'Neutral')
-WoWPro:GuideSort(guide, 6)
+local guide = WoWPro:RegisterGuide('The_Azure_Span', 'Leveling', 'The Azure Span!Dragon Isles', 'WoWPro Team', 'Neutral')
+WoWPro:GuideSort(guide, 3)
 WoWPro:GuideName(guide,"The Azure Span")
-WoWPro:GuideLevels(guide,60, 70)
+WoWPro:GuideLevels(guide,60, 70, 65)
 WoWPro:GuideNextGuide(guide, 'Thaldraszus')
 WoWPro:GuideSteps(guide, function()
 return [[

--- a/WoWPro_Leveling/Neutral/DF_Ohnahran_Plains.lua
+++ b/WoWPro_Leveling/Neutral/DF_Ohnahran_Plains.lua
@@ -1,7 +1,7 @@
-local guide = WoWPro:RegisterGuide('Ohnahran_Plains', 'Leveling', 'Ohnahran_Plains', 'Ohnahran_Plains', 'Neutral')
-WoWPro:GuideSort(guide, 6)
+local guide = WoWPro:RegisterGuide('Ohnahran_Plains', 'Leveling', "Ohn'ahran Plains", 'WoWPro Team', 'Neutral')
+WoWPro:GuideSort(guide, 2)
 WoWPro:GuideName(guide,"Ohnahran Plains")
-WoWPro:GuideLevels(guide,60, 70)
+WoWPro:GuideLevels(guide,60, 70, 62)
 WoWPro:GuideNextGuide(guide, 'The Azure Span')
 WoWPro:GuideSteps(guide, function()
 return [[

--- a/WoWPro_Leveling/Neutral/DF_Thaldraszus.lua
+++ b/WoWPro_Leveling/Neutral/DF_Thaldraszus.lua
@@ -1,7 +1,7 @@
 local guide = WoWPro:RegisterGuide('Thaldraszus', 'Leveling', 'Thaldraszus', 'WoWPro Team', 'Neutral')
-WoWPro:GuideSort(guide, 6)
+WoWPro:GuideSort(guide, 4)
 WoWPro:GuideName(guide,"Thaldraszus")
-WoWPro:GuideLevels(guide,60, 70)
+WoWPro:GuideLevels(guide,60, 70, 68)
 WoWPro:GuideSteps(guide, function()
 return [[
 A Private Shikzar|QID|70986|M|37.57,83.27|Z|2025|

--- a/WoWPro_Leveling/Neutral/DF_Waking_Shores.lua
+++ b/WoWPro_Leveling/Neutral/DF_Waking_Shores.lua
@@ -1,7 +1,7 @@
-local guide = WoWPro:RegisterGuide('The Waking_Shores', 'Leveling', 'Stormwind City', 'WowPro Team', 'Neutral', 10)
-WoWPro:GuideSort(guide, 6)
+local guide = WoWPro:RegisterGuide('The_Waking_Shores', 'Leveling', 'The Waking Shores', 'WowPro Team', 'Neutral')
+WoWPro:GuideSort(guide, 1)
 WoWPro:GuideName(guide,"Waking Shores")
-WoWPro:GuideLevels(guide,60, 70)
+WoWPro:GuideLevels(guide,60, 70, 60)
 WoWPro:GuideNextGuide(guide, 'Ohnahran_Plains')
 WoWPro:GuideSteps(guide, function()
 return [[

--- a/WoWPro_Leveling/Neutral/Guides.xml
+++ b/WoWPro_Leveling/Neutral/Guides.xml
@@ -17,7 +17,7 @@
 	<Script file="INTRO_DeathKnight.lua"/>
 	<Script file="INTRO_DeathKnight_Allied.lua"/>
 	<Script file="INTRO_Demon_Hunter.lua"/>
-	<Script file="INTRO_Drakthyr.lua"/>
+	<Script file="INTRO_Dracthyr.lua"/>
 	<Script file="INTRO_Pandaren.lua"/>
 	<Script file="LEGION_Argus.lua"/>
 	<Script file="LEGION_Azsuna.lua"/>

--- a/WoWPro_Leveling/Neutral/INTRO_Dracthyr.lua
+++ b/WoWPro_Leveling/Neutral/INTRO_Dracthyr.lua
@@ -1,5 +1,7 @@
-local guide = WoWPro:RegisterGuide('Intro_Drakthyr', 'Leveling', 'Stormwind City', 'WowPro Team', 'Neutral', 10)
-WoWPro:GuideName(guide,"Drakthyr Intro")
+local guide = WoWPro:RegisterGuide('Intro_Dracthyr', 'Leveling', 'Stormwind City', 'WowPro Team', 'Neutral')
+WoWPro:GuideName(guide,"Dracthyr Intro")
+WoWPro:GuideContent(guide, "Intro")
+WoWPro:GuideSort(guide, 19)
 WoWPro:GuideLevels(guide,58, 60)
 WoWPro:GuideSteps(guide, function()
 return [[

--- a/WoWPro_Leveling/WoWPro_Leveling.lua
+++ b/WoWPro_Leveling/WoWPro_Leveling.lua
@@ -81,7 +81,6 @@ function WoWPro.Leveling:OnEnable()
         local currentLevel = _G.UnitLevel("player")
         local currentXP = _G.UnitXP("player")
 
-
         -- New Level 1 Character --
         if currentLevel == 1 and currentXP < 100 then
             WoWPro.Leveling:dbp("Loading starter %s guide: %s",engRace,tostring(WoWPro.Leveling.StartGuides[engRace]))
@@ -107,6 +106,9 @@ function WoWPro.Leveling:OnEnable()
 		elseif currentLevel == 55 and currentXP < 1000 and engClass == "DEATHKNIGHT" and WoWPro.WRATH then
 			WoWPro.Leveling:dbp("Loading starter %s guide",locClass)
             WoWPro:LoadGuide("WOTLK-DK")
+		elseif currentLevel == 58 and currentXP < 1000 and engRace == "Dracthyr" then
+			WoWPro.Leveling:dbp("Loading starter %s guide",engRace)
+            WoWPro:LoadGuide("Intro_Dracthyr")
         elseif currentLevel == 8 and currentXP < 300 and engClass == "DEATHKNIGHT" then
             WoWPro.Leveling:dbp("Loading starter %s guide",locClass)
             WoWPro:LoadGuide("JamScar5558")

--- a/WoWPro_Leveling/WoWPro_Leveling_GuideList.lua
+++ b/WoWPro_Leveling/WoWPro_Leveling_GuideList.lua
@@ -42,6 +42,7 @@ local continentToXpac = {
     [1414] = _G.LE_EXPANSION_CLASSIC, -- Kalimdor
     [1415] = _G.LE_EXPANSION_CLASSIC, -- Eastern Kingdoms
     [1550] = _G.LE_EXPANSION_SHADOWLANDS, -- The Shadowlands
+	[1978] = _G.LE_EXPANSION_DRAGONFLIGHT, -- Dragonflight
 }
 
 -- /dump C_Map.GetMapInfo(1355)

--- a/WoWPro_Leveling/Wrath/Alliance/BC_WOTLK_Blades_Edge_Mountains.lua
+++ b/WoWPro_Leveling/Wrath/Alliance/BC_WOTLK_Blades_Edge_Mountains.lua
@@ -1,7 +1,7 @@
-local guide = WoWPro:RegisterGuide("JamBla6870", "Leveling", "Blade's Edge Mountains", "WowPro Team", "Alliance", 3)
+local guide = WoWPro:RegisterGuide("CLASSIC_WOTLK_Blades_Edge_Mountains", "Leveling", "Blade's Edge Mountains", "WowPro Team", "Alliance", 3)
 WoWPro:GuideNickname(guide, "Blade's Edge Mountains")
 WoWPro:GuideName(guide, "Blade's Edge Mountains")
-WoWPro:GuideNextGuide(guide, "JamBor7072")
+WoWPro:GuideNextGuide(guide, "CLASSIC_WOTLK_Shadowmoon")
 WoWPro:GuideLevels(guide, 68, 70)
 WoWPro:GuideSteps(guide, function()
 return [[

--- a/WoWPro_Leveling/Wrath/Alliance/BC_WOTLK_Hellfire.lua
+++ b/WoWPro_Leveling/Wrath/Alliance/BC_WOTLK_Hellfire.lua
@@ -1,7 +1,7 @@
-local guide = WoWPro:RegisterGuide("JamHel6062", "Leveling", "Hellfire Peninsula", "WowPro Team", "Alliance", 3)
+local guide = WoWPro:RegisterGuide("CLASSIC_WOTLK_Hellfire", "Leveling", "Hellfire Peninsula", "WowPro Team", "Alliance", 3)
 WoWPro:GuideNickname(guide, "Hellfire Peninsula")
 WoWPro:GuideName(guide, "Hellfire Peninsula")
-WoWPro:GuideNextGuide(guide, "Zangarmarsh")
+WoWPro:GuideNextGuide(guide, "CLASSIC_WOTLK_Zangarmarsh")
 WoWPro:GuideLevels(guide, 60, 62)
 WoWPro:GuideSteps(guide, function()
 return [[

--- a/WoWPro_Leveling/Wrath/Alliance/BC_WOTLK_Nagrand.lua
+++ b/WoWPro_Leveling/Wrath/Alliance/BC_WOTLK_Nagrand.lua
@@ -1,7 +1,7 @@
-local guide = WoWPro:RegisterGuide("JamNag6668", "Leveling", "Nagrand", "WowPro Team", "Alliance", 3)
+local guide = WoWPro:RegisterGuide("CLASSIC_WOTLK_Nagrand", "Leveling", "Nagrand", "WowPro Team", "Alliance", 3)
 WoWPro:GuideNickname(guide, "Nagrand")
 WoWPro:GuideName(guide, "Nagrand")
-WoWPro:GuideNextGuide(guide, "Blade's Edge Mountains")
+WoWPro:GuideNextGuide(guide, "CLASSIC_WOTLK_Shadowmoon")
 WoWPro:GuideLevels(guide, 66, 68)
 WoWPro:GuideSteps(guide, function()
 return [[

--- a/WoWPro_Leveling/Wrath/Alliance/BC_WOTLK_Shadowmoon.lua
+++ b/WoWPro_Leveling/Wrath/Alliance/BC_WOTLK_Shadowmoon.lua
@@ -1,9 +1,9 @@
-local guide = WoWPro:RegisterGuide('CLASSIC_BC_Shadowmoon', "Leveling", 'Shadowmoon Valley', 'WoWPro Team', 'Alliance', 3)
+local guide = WoWPro:RegisterGuide('CLASSIC_WOTLK_Shadowmoon', "Leveling", 'Shadowmoon Valley', 'WoWPro Team', 'Alliance', 3)
 WoWPro:GuideSort(guide, 6)
 WoWPro:GuideNickname(guide, "Shadowmoon Valley BC")
 WoWPro:GuideName(guide,"Shadowmoon Valley")
 WoWPro:GuideLevels(guide, 68, 70)
-WoWPro:GuideNextGuide(guide, 'Netherstorm')
+WoWPro:GuideNextGuide(guide, 'wotlkintro')
 WoWPro:GuideSteps(guide, function()
 return [[
 A Zorus the Judicator|QID|11045|M|33.00,30.25|Z|Terokkar Forest|N|From Fantei in Lower City, Shattrath.|RANK|3|

--- a/WoWPro_Leveling/Wrath/Alliance/BC_WOTLK_Terokkar.lua
+++ b/WoWPro_Leveling/Wrath/Alliance/BC_WOTLK_Terokkar.lua
@@ -1,7 +1,7 @@
-local guide = WoWPro:RegisterGuide("JamTerA6466", "Leveling", "Terokkar Forest", "WowPro Team", "Alliance", 3)
+local guide = WoWPro:RegisterGuide("CLASSIC_WOTLK_Terokkar", "Leveling", "Terokkar Forest", "WowPro Team", "Alliance", 3)
 WoWPro:GuideNickname(guide, "Terokkar Forest")
 WoWPro:GuideName(guide, "Terokkar Forest")
-WoWPro:GuideNextGuide(guide, "Nagrand")
+WoWPro:GuideNextGuide(guide, "CLASSIC_WOTLK_Nagrand")
 WoWPro:GuideLevels(guide, 64, 66)
 WoWPro:GuideSteps(guide, function()
 return [[

--- a/WoWPro_Leveling/Wrath/Alliance/BC_WOTLK_Zangarmarsh.lua
+++ b/WoWPro_Leveling/Wrath/Alliance/BC_WOTLK_Zangarmarsh.lua
@@ -1,7 +1,7 @@
-local guide = WoWPro:RegisterGuide("JamZan6466", "Leveling", "Zangarmarsh", "WowPro Team", "Alliance", 3)
+local guide = WoWPro:RegisterGuide("CLASSIC_WOTLK_Zangarmarsh", "Leveling", "Zangarmarsh", "WowPro Team", "Alliance", 3)
 WoWPro:GuideNickname(guide, "Zangarmarsh")
 WoWPro:GuideName(guide, "Zangarmarsh")
-WoWPro:GuideNextGuide(guide, "Terokkar Forest")
+WoWPro:GuideNextGuide(guide, "CLASSIC_WOTLK_Terokkar")
 WoWPro:GuideLevels(guide, 62, 66)
 WoWPro:GuideSteps(guide, function()
 return [[

--- a/WoWPro_Leveling/Wrath/Alliance/Guides.xml
+++ b/WoWPro_Leveling/Wrath/Alliance/Guides.xml
@@ -18,6 +18,7 @@
   <Script file="VAN_WOTLK_42_50_Alliance.lua"/>
   <Script file="VAN_WOTLK_50_55_Alliance.lua"/>
   <Script file="VAN_WOTLK_55_60_Alliance.lua"/>
+  <Script file="WOTLK_Intro.lua"/>
   <Script file="WOTLK_Borean_Tundra.lua"/>
   <Script file="WOTLK_Dragonblight.lua"/>
   <Script file="WOTLK_Grizzly_Hills.lua"/>

--- a/WoWPro_Leveling/Wrath/Alliance/VAN_WOTLK_55_60_Alliance.lua
+++ b/WoWPro_Leveling/Wrath/Alliance/VAN_WOTLK_55_60_Alliance.lua
@@ -1,7 +1,7 @@
 local guide = WoWPro:RegisterGuide('WOTLK_Alliance5560', 'Leveling', 'Tanaris', 'WoWPro Team', 'Alliance', 3)
 WoWPro:GuideName(guide, 'Alliance Ch6')
 WoWPro:GuideLevels(guide,55, 60)
-WoWPro:GuideNextGuide(guide, 'CLASSIC_BC_Hellfire')
+WoWPro:GuideNextGuide(guide, 'CLASSIC_WOTLK_Hellfire')
 WoWPro:GuideSteps(guide, function()
 return [[
 A Taking Back Silithus|QID|8275|M|58.52,47.33|Z|Ironforge|N|From Cenarion Emissary Jademoon.|

--- a/WoWPro_Leveling/Wrath/Alliance/WOTLK_Borean_Tundra.lua
+++ b/WoWPro_Leveling/Wrath/Alliance/WOTLK_Borean_Tundra.lua
@@ -1,7 +1,7 @@
-local guide = WoWPro:RegisterGuide("JamBor6872", "Leveling", "Borean Tundra", "WoWPro Team", "Alliance", 3)
+local guide = WoWPro:RegisterGuide("WOTLK_Borean_Tundra", "Leveling", "Borean Tundra", "WoWPro Team", "Alliance", 3)
 WoWPro:GuideName(guide,"Borean Tundra")
 WoWPro:GuideLevels(guide,70, 72)
-WoWPro:GuideNextGuide(guide, "Howling Fjord")
+WoWPro:GuideNextGuide(guide, "WOTLK_Dragonblight")
 WoWPro:GuideSteps(guide, function()
 return [[
 B Overcharged Capacitor|QID|11650|M|60.80,71.38|Z|Stormwind City|N|The quest Just a Few More Things... in Borean Tundra will require an Overcharged Capacitor.  The quest leads to two further quests, so worth while looking for this item now in Auction House if you can't find an Engineer with 4 Cobalt Bars and 1 Crystallized Earth. You can leave it in your delivery box to save space, as the questgiver above is near a mailbox.|L|39682|

--- a/WoWPro_Leveling/Wrath/Alliance/WOTLK_Dragonblight.lua
+++ b/WoWPro_Leveling/Wrath/Alliance/WOTLK_Dragonblight.lua
@@ -1,7 +1,7 @@
-local guide = WoWPro:RegisterGuide("JamDra7475", "Leveling", "Dragonblight", "WoWPro Team", "Alliance", 3)
+local guide = WoWPro:RegisterGuide("WOTLK_Dragonblight", "Leveling", "Dragonblight", "WoWPro Team", "Alliance", 3)
 WoWPro:GuideNickname(guide, "Dragonblight")
 WoWPro:GuideName(guide, "Dragonblight")
-WoWPro:GuideNextGuide(guide, "Grizzly Hills")
+WoWPro:GuideNextGuide(guide, "WOTLK_Grizzly_Hills")
 WoWPro:GuideLevels(guide, 71, 75)
 WoWPro:GuideSteps(guide, function()
 return [[

--- a/WoWPro_Leveling/Wrath/Alliance/WOTLK_Grizzly_Hills.lua
+++ b/WoWPro_Leveling/Wrath/Alliance/WOTLK_Grizzly_Hills.lua
@@ -1,7 +1,7 @@
-local guide = WoWPro:RegisterGuide("JamGri7577", "Leveling", "Grizzly Hills", "WoWPro Team", "Alliance", 3)
+local guide = WoWPro:RegisterGuide("WOTLK_Grizzly_Hills", "Leveling", "Grizzly Hills", "WoWPro Team", "Alliance", 3)
 WoWPro:GuideNickname(guide, "Grizzly Hills")
 WoWPro:GuideName(guide, "Grizzly Hills")
-WoWPro:GuideNextGuide(guide, "Zul'Drak")
+WoWPro:GuideNextGuide(guide, "WOTLK_ZulDrak")
 WoWPro:GuideLevels(guide, 73, 75)
 WoWPro:GuideSteps(guide, function()
 return [[

--- a/WoWPro_Leveling/Wrath/Alliance/WOTLK_Howling_Fjord.lua
+++ b/WoWPro_Leveling/Wrath/Alliance/WOTLK_Howling_Fjord.lua
@@ -1,7 +1,7 @@
-local guide = WoWPro:RegisterGuide("JamHow7274", "Leveling", "Howling Fjord", "WoWPro Team", "Alliance", 3)
+local guide = WoWPro:RegisterGuide("WOTLK_Howling_Fjord", "Leveling", "Howling Fjord", "WoWPro Team", "Alliance", 3)
 WoWPro:GuideNickname(guide, "Howling Fjord")
 WoWPro:GuideName(guide, "Howling Fjord")
-WoWPro:GuideNextGuide(guide, "Dragonblight")
+WoWPro:GuideNextGuide(guide, "WOTLK_Dragonblight")
 WoWPro:GuideLevels(guide, 68, 72)
 WoWPro:GuideSteps(guide, function()
 return [[

--- a/WoWPro_Leveling/Wrath/Alliance/WOTLK_Icecrown.lua
+++ b/WoWPro_Leveling/Wrath/Alliance/WOTLK_Icecrown.lua
@@ -1,4 +1,4 @@
-local guide = WoWPro:RegisterGuide("NLXIce7980", "Leveling", "Icecrown", "WoWPro Team", "Alliance", 3)
+local guide = WoWPro:RegisterGuide("WOTLK_Icecrown", "Leveling", "Icecrown", "WoWPro Team", "Alliance", 3)
 WoWPro:GuideNickname(guide, "Icecrown")
 WoWPro:GuideName(guide, "Icecrown")
 WoWPro:GuideLevels(guide, 77, 80)

--- a/WoWPro_Leveling/Wrath/Alliance/WOTLK_Intro.lua
+++ b/WoWPro_Leveling/Wrath/Alliance/WOTLK_Intro.lua
@@ -1,0 +1,16 @@
+local guide = WoWPro:RegisterGuide("wotlkintro", "Leveling", "Stormwind City", "Elidion", "Alliance", 3)
+WoWPro:GuideLevels(guide, 68, 75)
+WoWPro:GuideSort(guide, 1)
+WoWPro:GuideContent(guide, "Wrath of the Lich King")
+WoWPro:GuideNickname(guide, "WOTLK: Intro")
+WoWPro:GuideName(guide,"WOTLK: Intro")
+WoWPro:GuideQuestTriggers(guide,60096)
+WoWPro:GuideNextGuide(guide, "Borean Tundra")
+WoWPro:GuideSteps(guide, function()
+return
+[[
+N Choose Borean Tundra|QID|99999|M|56.26,17.31|JUMP|WOTLK_Borean_Tundra|S|N|Easiest to get to for most, you can hop on a boat in Stormwind Harbor.|
+N Choose Howling Fjord|QID|99999|M|56.26,17.31|JUMP|WOTLK_Howling_Fjord|S|N|A little bit trickier, you need to travel to Menethil Harbor in Wetlands to take the boat here.|
+N Make your choice|QID|99999|M|56.26,17.31|N|In Wrath of Lich King there are 2 starting zone, you can choose which you want to go to.|
+]]
+end)

--- a/WoWPro_Leveling/Wrath/Alliance/WOTLK_Storm_Peaks.lua
+++ b/WoWPro_Leveling/Wrath/Alliance/WOTLK_Storm_Peaks.lua
@@ -1,7 +1,7 @@
-local guide = WoWPro:RegisterGuide("CybSto7980", "Leveling", "The Storm Peaks", "WoWPro Team", "Alliance", 3)
+local guide = WoWPro:RegisterGuide("WOTLK_Storm_Peaks", "Leveling", "The Storm Peaks", "WoWPro Team", "Alliance", 3)
 WoWPro:GuideNickname(guide, "The Storm Peaks")
 WoWPro:GuideName(guide, "The Storm Peaks")
-WoWPro:GuideNextGuide(guide, "Icecrown")
+WoWPro:GuideNextGuide(guide, "WOTLK_Icecrown")
 WoWPro:GuideLevels(guide, 77, 80)
 WoWPro:GuideSteps(guide, function()
 return [[

--- a/WoWPro_Leveling/Wrath/Neutral/BC_WOTLK_Netherstorm.lua
+++ b/WoWPro_Leveling/Wrath/Neutral/BC_WOTLK_Netherstorm.lua
@@ -1,8 +1,9 @@
-local guide = WoWPro:RegisterGuide('BC-Netherstorm', "Leveling", 'Netherstorm', 'Crackerhead22', 'Neutral', 3)
+local guide = WoWPro:RegisterGuide('CLASSIC_WOTLK_Netherstorm', "Leveling", 'Netherstorm', 'Crackerhead22', 'Neutral', 3)
 WoWPro:GuideSort(guide, 7)
 WoWPro:GuideNickname(guide, "Netherstorm")
 WoWPro:GuideName(guide,"Netherstorm")
 WoWPro:GuideLevels(guide, 68, 70)
+WoWPro:GuideNextGuide(guide, 'wotlkintro')
 WoWPro:GuideSteps(guide, function()
 return [[
 A Assist Exarch Orelis|QID|11038|LEAD|10241|M|47.44,26.61|Z|Shattrath City|N|From Vindicator Aeus.|REP|Aldor;932|

--- a/WoWPro_Leveling/Wrath/Neutral/Guides.xml
+++ b/WoWPro_Leveling/Wrath/Neutral/Guides.xml
@@ -1,6 +1,6 @@
 <Ui xmlns="http://www.blizzard.com/wow/ui/">
     <Script file="INTRO_WOTLK_DK.lua"/>
-	<Script file="BCC_Netherstorm.lua"/>
+	<Script file="BC_WOTLK_Netherstorm.lua"/>
 	<Script file="WOTLK_Sholazar_Basin.lua"/>
 	<Script file="WOTLK_ZulDrak.lua"/>
 	<Script file="73_80_Dungeon_Wrath_Ahnkahet_The Old Kingdom.lua"/>

--- a/WoWPro_Leveling/Wrath/Neutral/WOTLK_Sholazar_Basin.lua
+++ b/WoWPro_Leveling/Wrath/Neutral/WOTLK_Sholazar_Basin.lua
@@ -1,12 +1,10 @@
-local guide = WoWPro:RegisterGuide("ScoSho7879", "Leveling", "Sholazar Basin", "WoWPro Team", "Neutral", 3)
+local guide = WoWPro:RegisterGuide("WOTLK_Sholazar_Basin", "Leveling", "Sholazar Basin", "WoWPro Team", "Neutral", 3)
 WoWPro:GuideNickname(guide, "Sholazar Basin")
 WoWPro:GuideName(guide, "Sholazar Basin")
-WoWPro:GuideNextGuide(guide, "The Storm Peaks")
+WoWPro:GuideNextGuide(guide, "WOTLK_Storm_Peaks")
 WoWPro:GuideLevels(guide, 76, 78)
 WoWPro:GuideSteps(guide, function()
 return [[
-N It's Chromie Time!|AVAILABLE|62567|M|62.25,29.93|Z|Stormwind City|JUMP|Chromie Time|S!US|N|You can now accept Chromie's Call at the Hero's Call board in Stormwind. This will allow you to choose which expansion you want to level in and scale the content to your level.\n\nYou're free to continue your current guide by skipping this and continuing on, but it won't continue to scale. If you want to enable Chromie Time, click the guide button next to this frame to direct you to Chromie in Stormwind!|LVL|-50|CT|FACTION|Alliance|
-N It's Chromie Time!|AVAILABLE|62568|M|40.82,80.13|Z|Orgrimmar|JUMP|Chromie Time|S!US|N|You can now accept Chromie's Call at the Warchief's Command Board in Orgrimmar. This will allow you to choose which expansion you want to level in and scale the content to your level.\n\nYou're free to continue your current guide by skipping this and continuing on, but it won't continue to scale. If you want to enable Chromie Time, click the guide button next to this frame to direct you to Chromie in  Orgrimmar!|LVL|-50|CT|FACTION|Horde|
 F Dalaran|QID|12521|N|Head to Dalaran.|
 A Where in the World is Hemet Nesingwary?|QID|12521|N|From Archmage Pentarus, near the exit from Krasus' Landing.|M|68.68,42.06|Z|Dalaran City@Dalaran|
 T Where in the World is Hemet Nesingwary?|QID|12521|N|Talk to the Archmage again to get a flight. To Monte Muzzleshot. He's hanging from a tree.|M|35.68,58.65|

--- a/WoWPro_Leveling/Wrath/Neutral/WOTLK_ZulDrak.lua
+++ b/WoWPro_Leveling/Wrath/Neutral/WOTLK_ZulDrak.lua
@@ -1,7 +1,7 @@
-local guide = WoWPro:RegisterGuide("ScoZul7778", "Leveling", "Zul'Drak", "WoWPro Team", "Neutral", 3)
+local guide = WoWPro:RegisterGuide("WOTLK_ZulDrak", "Leveling", "Zul'Drak", "WoWPro Team", "Neutral", 3)
 WoWPro:GuideNickname(guide, "Zul'Drak")
 WoWPro:GuideName(guide, "Zul'Drak")
-WoWPro:GuideNextGuide(guide, "Sholazar Basin")
+WoWPro:GuideNextGuide(guide, "WOTLK_Sholazar_Basin")
 WoWPro:GuideLevels(guide, 74, 77)
 WoWPro:GuideSteps(guide, function()
 return [[


### PR DESCRIPTION
needed to register the new expansion and continent in the leveling module and then the guides themselves needed to be named correctly. Guide IDs on Classic were messed up a bit and got Dracthyr Intro guide loading on new character startup.