### PR TITLE
Repair friendship reputation lookup for DF

### DIFF
--- a/WoWPro/WoWPro_Broker.lua
+++ b/WoWPro/WoWPro_Broker.lua
@@ -2331,7 +2331,7 @@ function WoWPro.NextStep(guideIndex, rowIndex)
                 WoWPro.why[guideIndex] = "NextStep(): Reputation steps skipped by default"
                 local standingId, earnedValue, hasBonusRepGain
                 if Friendship then
-                    local reputationInfo = C_GossipInfo.GetFriendshipReputation(factionIndex)
+                    local reputationInfo = _G.C_GossipInfo.GetFriendshipReputation(factionIndex)
                     local friendTextLevel = reputationInfo.reaction:lower()
                     standingId = Rep2IdAndClass[friendTextLevel][1]
                     earnedValue = reputationInfo.standing - reputationInfo.nextThreshold

--- a/WoWPro/WoWPro_Broker.lua
+++ b/WoWPro/WoWPro_Broker.lua
@@ -2331,11 +2331,11 @@ function WoWPro.NextStep(guideIndex, rowIndex)
                 WoWPro.why[guideIndex] = "NextStep(): Reputation steps skipped by default"
                 local standingId, earnedValue, hasBonusRepGain
                 if Friendship then
-                    local _, friendRep, _, name, _, _, friendTextLevel, friendThreshold = _G.GetFriendshipReputation(factionIndex);
-                    friendTextLevel = friendTextLevel:lower()
-                    standingId = Rep2IdAndClass[friendTextLevel][1]
-                    earnedValue = friendRep - friendThreshold
-                    WoWPro:dbp("NPC %s is a %s: standing %d, earned %d", name, friendTextLevel, standingId, earnedValue)
+                    local reputationInfo = C_GossipInfo.GetFriendshipReputation(factionIndex)
+                    friendTextLevel = reputationInfo.reaction:lower()
+                    standingId = Rep2IdAndClass[reputationInfo.reaction][1]
+                    earnedValue = reputationInfo.standing - reputationInfo.nextThreshold
+                    WoWPro:dbp("NPC %s is a %s: standing %d, earned %d", reputationInfo.name, reputationInfo.reaction, standingId, earnedValue)
                 else
                     local name, bottomValue, _
                     name, _, standingId, bottomValue, _, earnedValue, _, _, _, _, _, _, _, _, hasBonusRepGain = _G.GetFactionInfoByID(factionIndex)

--- a/WoWPro/WoWPro_Broker.lua
+++ b/WoWPro/WoWPro_Broker.lua
@@ -2332,10 +2332,10 @@ function WoWPro.NextStep(guideIndex, rowIndex)
                 local standingId, earnedValue, hasBonusRepGain
                 if Friendship then
                     local reputationInfo = C_GossipInfo.GetFriendshipReputation(factionIndex)
-                    friendTextLevel = reputationInfo.reaction:lower()
-                    standingId = Rep2IdAndClass[reputationInfo.reaction][1]
+                    local friendTextLevel = reputationInfo.reaction:lower()
+                    standingId = Rep2IdAndClass[friendTextLevel][1]
                     earnedValue = reputationInfo.standing - reputationInfo.nextThreshold
-                    WoWPro:dbp("NPC %s is a %s: standing %d, earned %d", reputationInfo.name, reputationInfo.reaction, standingId, earnedValue)
+                    WoWPro:dbp("NPC %s is a %s: standing %d, earned %d", reputationInfo.name, friendTextLevel, standingId, earnedValue)
                 else
                     local name, bottomValue, _
                     name, _, standingId, bottomValue, _, earnedValue, _, _, _, _, _, _, _, _, hasBonusRepGain = _G.GetFactionInfoByID(factionIndex)


### PR DESCRIPTION
Hi! Long time user of WoW-Pro here, and ran into an issue working on my Tillers rep.  I believe in Dragonflight, the `GetFriendshipReputation` API call has been removed in favor of `C_GossipInfo.GetFriendshipReputation`.

This change works for me locally and lets me make progress in the guide, although this is my first time writing Lua.

https://wowpedia.fandom.com/wiki/API_GetFriendshipReputation
https://wowpedia.fandom.com/wiki/API_C_GossipInfo.GetFriendshipReputation  