### PR TITLE
Update DF_Intro.lua

### DIFF
--- a/WoWPro_Leveling/Neutral/DF_Intro.lua
+++ b/WoWPro_Leveling/Neutral/DF_Intro.lua
@@ -2,13 +2,14 @@ local guide = WoWPro:RegisterGuide('Dragonflight Intro', 'Leveling', 'The Waking
 WoWPro:GuideSort(guide, 1)
 WoWPro:GuideName(guide,"Dragonflight Intro")
 WoWPro:GuideLevels(guide,60, 60, 60)
+WoWPro:GuideNextGuide(guide, 'The_Waking_Shores')
 WoWPro:GuideSteps(guide, function()
 return [[
 
-A The Dragon Isles Await|QID|65436|M|PLAYER|Z|84|N|From UI Alert.|FACTION|Alliance|
-A The Dragon Isles Await|QID|65435|M|PLAYER|Z|85|N|From UI Alert.|FACTION|Horde|
-T The Dragon Isles Await|QID|65436|M|79.79,27.00|Z|84|N|To Wrathion in Stormwind.|FACTION|Alliance|
-T The Dragon Isles Await|QID|65435|M|44.22,38.11|Z|85|N|To Ebyssian in Orgrimmar.|FACTION|Horde|
+;A The Dragon Isles Await|QID|65436|M|PLAYER|Z|84|N|From UI Alert.|FACTION|Alliance|
+;A The Dragon Isles Await|QID|65435|M|PLAYER|Z|85|N|From UI Alert.|FACTION|Horde|
+t The Dragon Isles Await|QID|65436|M|79.79,27.00|Z|84|N|To Wrathion in Stormwind.|FACTION|Alliance|
+t The Dragon Isles Await|QID|65435|M|44.22,38.11|Z|85|N|To Ebyssian in Orgrimmar.|FACTION|Horde|
 A Aspectral Invitation|QID|66577|PRE|65436|M|79.79,27.00|Z|84|N|From Wrathion.|FACTION|Alliance|
 A Aspectral Invitation|QID|65437|PRE|65435|M|44.22,38.11|Z|85|N|From Ebyssian.|FACTION|Horde|
 C Aspectral Invitation|QID|66577|M|79.79,27.00|Z|84|QO|1|CHAT|N|Speak with Wrathion.|FACTION|Alliance|
@@ -76,11 +77,11 @@ A Where is Wrathion?|QID|70125|PRE|70122|M|76.62,33.63|Z|2022|N|From Toddy Whisk
 A Where is Wrathion?|QID|69910|PRE|65452|M|76.62,33.63|Z|2022|N|From Naleidea Rivergleam.|FACTION|Horde|
 C Where is Wrathion?|QID|70125^69910|M|76.61,33.65|Z|2022|CHAT|N|Ask Sendrax why the Dragons aren't here.|
 T Where is Wrathion?|QID|70125^69910|M|76.61,33.65|Z|2022|N|To Sendrax.|
-A Adventuring in the Dragon Isles|QID|72293|M|76.61,33.65|Z|2022|N|To Sendrax.|ACH|16363;;true|
+A Adventuring in the Dragon Isles|QID|72293|M|76.61,33.65|Z|2022|N|From Sendrax.|ACH|16759;;;true|
 T Dragon Isles Supplies|QID|72708|M|76.54,34.25|N|To Cartographer Jakes.|
 A Funding a Treasure Hunt|QID|72709|PRE|72708|M|76.54,34.25|N|From Cartographer Jakes.|
 B Archeologist Artifact Notes|ACTIVE|72709|QO|1|M|76.54,34.25|N|Buy the notes from Cartographer Jakes.|
-C Funding a Treasure Hunt|QID|72709|QO|2|M|PLAYER|U|198854|N|Click to read the notes.|
+C Funding a Treasure Hunt|QID|72709|QO|2|M|PLAYER|U|198854|NC|N|Click to read the notes.|
 T Funding a Treasure Hunt|QID|72709|M|76.54,34.25|N|To Cartographer Jakes.|
 C Adventuring in the Dragon Isles|QID|72293|M|76.52,34.22|Z|2022|NC|N|Open the Scouting Map to choose which zone to adventure in. You can pick up all of them and save yourself a trip back later.|
 ;A Waking Shores|QID|72266|M|76.52,34.22|Z|2022|N|From Scouting Map UI.|ACTIVE|72293|


### PR DESCRIPTION
**Merged Cagomei's changes to avoid over writing**

- commented out UI Alert A steps and converted their T steps to t steps
- corrected wording on A Adventuring in the Dragon Isles|QID|72293| and updated ACH tag with missing ';' and ID (which I believe is the right one for Adventure Mode according to WH and it works as intended... for now)
- added NC tag to C Funding a Treasure Hunt|QID|72709|