### PR TITLE
Update BFA_Nazmir.lua

### DIFF
--- a/WoWPro_Leveling/Horde/BFA_Endgame_Story.lua
+++ b/WoWPro_Leveling/Horde/BFA_Endgame_Story.lua
@@ -7,17 +7,18 @@ WoWPro:GuideSteps(guide, function()
 return [[
 N A Bargain of Blood|AVAILABLE|47199|M|40.89,73.00|Z|Hall of Croniclers!Dazar'alor|N|The first part of the these questlines require you to have completed the zone achievement for Nazmir as well as Zandalar. Vol'dun will be required eventually you should start working on all 3. If you're trying to just go for these achievements and don't care about sidequests, try running the guide on Rank 1 with rares and treasures disabled.|ACH|11861+11868|
 A The Blood Gate|QID|47199|M|40.89,73.00|Z|Hall of Croniclers!Dazar'alor|N|Baine Bloodhoof.|ACH|11861;;true+11868;;true|
-F The Sliver|ACTIVE|47199|M|51.89,41.21|Z|Dazar'alor|N|At Paku'ai Rokota.|
+F The Sliver|ACTIVE|47199|M|51.89,41.21|Z|Dazar'alor|N|At Paku'ai Rokota or from the closest flight master to you.|
+R Blood Gate|ACTIVE|47199|M|61.12,27.60;60.62,23.68|CS|Z|Zuldazar|N|Make your way out of the city and up the road.|
 T The Blood Gate|QID|47199|M|60.39,22.03|Z|Zuldazar|N|To King Rastakhan.|
 A Ticks|QID|47200|M|60.38,22.02|Z|Zuldazar|N|From King Rastakhan.|PRE|47199|
 A They Want Us Alive|QID|47198|M|60.38,22.02|Z|Zuldazar|N|From King Rastakhan.|PRE|47199|
 C Ticks|QID|47200|M|59.58,19.46|Z|Zuldazar|S|N|Kill Bloodbelly Flyers as you look for captives to assist.|
-C They Want Us Alive|QID|47198|M|59.66,19.00|Z|Zuldazar|NC|N|Click on the Wounded Captives.|
+C They Want Us Alive|QID|47198|M|59.66,19.00|Z|Zuldazar|H|N|Click on the Wounded Captives.\n[color=FF0000]NOTE: [/color]Some of the Flyers on the ground are carrying Captives... 1 kill, 2 objectives. :)|
 C Ticks|QID|47200|M|59.58,19.46|Z|Zuldazar|US|N|Finish up your quota of Bloodbelly Flyers.|
 T Ticks|QID|47200|M|60.39,22.03|Z|Zuldazar|N|To King Rastakhan.|
 T They Want Us Alive|QID|47198|Z|Zuldazar|M|60.39,22.03|N|To King Rastakhan.|
 A Rokhan|QID|47201|M|60.39,22.03|Z|Zuldazar|N|From King Rastakhan.|PRE|47200&47198|
-C Rokhan|QID|47201|M|60.99,20.53|Z|Zuldazar|QO|1|NC|N|Click on Old Rotana to go for a short ride.|
+C Rokhan|QID|47201|M|60.99,20.53|Z|Zuldazar|QO|1|V|N|Click on Old Rotana to go for a short ride.|
 T Rokhan|QID|47201|M|56.92,19.10|Z|Zuldazar|N|To Rokhan.|
 A Warmother|QID|47205|M|56.92,19.10|Z|Zuldazar|N|From Rokhan.|PRE|47201|
 A The New Frontline|QID|47204|M|56.92,19.10|Z|Zuldazar|N|From Rokhan.|PRE|47201|
@@ -27,14 +28,15 @@ C The New Frontline|QID|47204|M|57.08,20.68|Z|Zuldazar|US|N|Finish your share of
 T Warmother|QID|47205|M|56.92,19.11|Z|Zuldazar|N|To Rokhan.|
 T The New Frontline|QID|47204|M|56.92,19.11|Z|Zuldazar|N|To Rokhan.|
 A Bulwark of Torcali|QID|47229|M|56.92,19.11|Z|Zuldazar|N|From Rokhan.|PRE|47204&47205|
-C Bulwark of Torcali|QID|47229|M|56.90,19.73|Z|Zuldazar|NC|QO|1|N|Hop back onto Old Rotana.|
-C Bulwark of Torcali|QID|47229|M|58.07,20.39|Z|Zuldazar|NC|QO|2|N|Destroy Blood Troll forces.\n1 is Cone AE\n2 is ligtning bolt, multi target\n3 is charge, must not be moving to use.|
-T Bulwark of Torcali|QID|47229|M|57.98,17.83|Z|Zuldazar|N|Make your way to Princess Talanji and eject from Old Rotana.|
+C Bulwark of Torcali|QID|47229|M|56.90,19.73|Z|Zuldazar|V|QO|1|N|Hop back onto Old Rotana.|
+C Bulwark of Torcali|QID|47229|M|58.07,20.39|Z|Zuldazar|QO|2|N|Destroy Blood Troll forces.\n1 is Cone AE\n2 is ligtning bolt, multi target\n3 is charge, must not be moving to use.|
+T Bulwark of Torcali|QID|47229|M|58.00,18.69|Z|Zuldazar|N|Make your way to Princess Talanji and eject from Old Rotana.|
 A Prepare for a Siege|QID|47258|M|60.05,22.23|Z|Zuldazar|N|From King Rastakhan.|PRE|47229|
+H The Great Seal|ACTIVE|47258|M|48.78,71.83|Z|The Great Seal!Dazar'alor|N|Hearth or start the long journey back (bonus for you if you can fly).|
 T Prepare for a Siege|QID|47258|M|41.33,72.50|Z|Hall of Croniclers!Dazar'alor|N|To Baine Bloodhoof.|
+N Secrets in the Sands|AVAILABLE|50954|N|You must finish the Vol'dun storyline achievment now.\nIf you're interested in only completing the zone achievement, run the Vol'dun guide at Rank 1 with Treasures and Rares disabled.|ACH|11861+11868+12478|JUMP|EmmVoldun|
 A Zandalar Forever!|QID|50954|M|60.05,22.23|Z|Zuldazar|N|From King Rastakhan.|PRE|47229|ACH|11861;;true+11868;;true+12478;;true|
 R The Sliver|ACTIVE|50954|M|60.05,22.23|Z|Zuldazar|CHAT|N|Talk to the King to start the scenario.|
-N Complete Vol'dun Story|AVAILABLE|50954|N|You must finish the Vol'dun story achievment. If you're interested in completing only this zone achievement you can run the Vol'dun guide at Rank 1 with treasures and rares disabled to get through the story content.|ACH|11861+11868+12478|
 C Prepare the Assault|ACTIVE|50954|SO|1;1|NC|N|Click on Old K'zlotec in front of you to mount.|
 C Blood Troll Army slain|ACTIVE|50954|M|60.96,22.17|Z|Zuldazar!Instance|SO|2;1|N|Destroy the Nazmani invaders in the Sliver.\nAll three buttons are AE attacks.\n#3 requires a target.|
 C Secure the bridge to Dazar'alor|ACTIVE|50954|M|60.62,31.86|Z|Zuldazar!Instance|SO|3;1|NC|N|Just enjoy the ride to the next area.|

--- a/WoWPro_Leveling/Horde/BFA_Nazmir.lua
+++ b/WoWPro_Leveling/Horde/BFA_Nazmir.lua
@@ -664,7 +664,7 @@ A What Rots Beneath|QID|51244|M|50.51,58.34|N|From Rokhan.|PRE|50087|
 C What Rots Beneath|QID|51244|M|50.51,58.34|QO|1|CHAT|N|Ask Rokhan for a ride down to the Altar of Rot.|
 C What Rots Beneath|QID|51244|M|53.15,70.61;51.73,65.69|CS|QO|2|CHAT|N|Run down the hill to find Titan Keeper Hezrel and speak to him.|
 T What Rots Beneath|QID|51244|M|51.73,65.69|N|To Titan Keeper Hezrel.|
-A The Underrot: Sealing G'huun's Corruption|QID|51302|M|51.73,65.69|ELITE|N|[color=E6CC80]Dungeon: 'The Underrot'[/color]\nFrom Titan Keeper Hezrel.|RANK|2|PRE|51244|
+A The Underrot:Sealing G'huun's Corruption|QID|51302|M|51.73,65.69|ELITE|N|[color=E6CC80]Dungeon: 'The Underrot'[/color]\nFrom Titan Keeper Hezrel.|RANK|2|PRE|51244|
 A Halting the Empire's Fall|QID|50808|M|51.91,65.56|N|From Rokhan. If you are sticking around for the remainder of the quests and rares, don't take Rokhan's offered flight.|PRE|51244|RANK|3|
 A Halting the Empire's Fall|QID|50808|M|51.91,65.56|N|From Rokhan.|PRE|51244|
 F Zul'jan Ruins|ACTIVE|50808|M|51.91,65.56|N|Queue if you want to do the dugeon now or ask Rokhan for a ride back to Zul'jan. Alternatively check this off manually and hearth to The Great Seal.|RANK|-1|

--- a/WoWPro_Leveling/Horde/BFA_Nazmir.lua
+++ b/WoWPro_Leveling/Horde/BFA_Nazmir.lua
@@ -664,7 +664,7 @@ A What Rots Beneath|QID|51244|M|50.51,58.34|N|From Rokhan.|PRE|50087|
 C What Rots Beneath|QID|51244|M|50.51,58.34|QO|1|CHAT|N|Ask Rokhan for a ride down to the Altar of Rot.|
 C What Rots Beneath|QID|51244|M|53.15,70.61;51.73,65.69|CS|QO|2|CHAT|N|Run down the hill to find Titan Keeper Hezrel and speak to him.|
 T What Rots Beneath|QID|51244|M|51.73,65.69|N|To Titan Keeper Hezrel.|
-A The Underrot:Sealing G'huun's Corruption|QID|51302|M|51.73,65.69|ELITE|N|[color=E6CC80]Dungeon: 'The Underrot'[/color]\nFrom Titan Keeper Hezrel.|RANK|2|PRE|51244|;DUNGEON|
+A The Underrot:Sealing G'huun's Corruption|QID|51302|M|51.73,65.69|ELITE|N|[color=E6CC80]Dungeon: 'The Underrot'[/color]\nFrom Titan Keeper Hezrel.|RANK|3|PRE|51244|;DUNGEON|
 A Halting the Empire's Fall|QID|50808|M|51.91,65.56|N|From Rokhan. If you are sticking around for the remainder of the quests and rares, don't take Rokhan's offered flight.|PRE|51244|RANK|3|
 A Halting the Empire's Fall|QID|50808|M|51.91,65.56|N|From Rokhan.|PRE|51244|
 F Zul'jan Ruins|ACTIVE|50808|M|51.91,65.56|N|Queue if you want to do the dugeon now or ask Rokhan for a ride back to Zul'jan. Alternatively check this off manually and hearth to The Great Seal.|RANK|-1|

--- a/WoWPro_Leveling/Horde/BFA_Nazmir.lua
+++ b/WoWPro_Leveling/Horde/BFA_Nazmir.lua
@@ -595,7 +595,7 @@ A Protocol Recovery|QID|49957|M|68.66,35.12|N|From Titan Keeper Hezrel.|PRE|4995
 C Not Fit for This Plane|QID|49955|M|71.10,29.58|S|N|Kill Faceless Ones as you proceed towards the Seal of Nazmir. *large building*|
 C Void is Prohibited|QID|49956|M|70.95,29.09|U|156542|NC|N|Use the Void Disrupter to seal the Void Portals.|
 C Not Fit for This Plane|QID|49955|M|71.10,29.58|US|N|Finish off the Faceless Ones before you go inside.|
-K Overlord Kraxis|ACTIVE|49957|M|72.58,29.16|QO|1|T|Overlord Kraxis|N|Kill Overlord Kraxis to recover the Containment Protocol.|
+K Overlord Kraxis|ACTIVE|49957|M|72.73,29.02|QO|1|T|Overlord Kraxis|N|Kill Overlord Kraxis to recover the Containment Protocol.|
 T Not Fit for This Plane|QID|49955|M|72.47,29.38|N|To Titan Keeper Hezrel.|
 T Void is Prohibited|QID|49956|M|72.47,29.38|N|To Titan Keeper Hezrel.|
 T Protocol Recovery|QID|49957|M|72.47,29.38|N|To Titan Keeper Hezrel.|
@@ -604,39 +604,39 @@ C Containment Procedure|QID|49980|M|72.47,29.38|QO|1|CHAT|N|Tell Titan Keeper He
 K Grand Ma'da Ateena|ACTIVE|49980|M|72.85,28.99|QO|2|T|Grand Ma'da Ateena|N|Attempt to defeat Grand Ma'da Ateena.|
 T Containment Procedure|QID|49980|M|72.47,29.37|N|To Titan Keeper Hezrel.|
 A Return to Gloom Hollow|QID|49985|M|72.47,29.37|N|From Titan Keeper Hezrel.|PRE|49980|
-C Return to Gloom Hollow|QID|49985|M|66.01,39.13|QO|1|V|N|Hop on Titan Keeper Hezrel for a ride back to Gloom Hollow.|
+C Return to Gloom Hollow|QID|49985|M|71.84,30.38;66.01,39.13|CS|QO|1|V|N|Follow Titan Keeper Hezrel outside and hop on for a free ride back to Gloom Hollow.|
 T Return to Gloom Hollow|QID|49985|M|67.43,42.23|N|To Princess Talanji.|
 A Down by the Riverside|QID|49569|M|67.43,42.23|N|From Princess Talanji.|PRE|49985|
 t WANTED: Ayame|QID|52477|M|67.76,41.85|N|To Korkush.|
 ;  Bleeding the Blood Trolls
 C Down by the Riverside|QID|49569|M|65.70,45.09|QO|1|CHAT|N|Speak with Patch to board the barge|
-C Down by the Riverside|QID|49569|M|39.89,84.92|QO|2|NC|N|Use the "1" key to destroy enemies as you sail down the river, at one point, near zuldazar, use the "2" key to destroy the big water serpent.|
-K Blood Priest Xak'lar|QID|48541|M|43.20,90.55;43.27,91.37|CS|QO|1|T|Blood Priest Xak'lar|N|Into this cave to kill a Silver Elite for artifact power and resources.|RANK|2|RARE|;item unknown
+C Down by the Riverside|QID|49569|M|39.89,84.92|QO|2|T|Dominated Hydra|N|When the serpent shows up, target it and use the "2" key to kill it.\n[color=FF0000]NOTE: [/color]The Blood trolls do nothing and can be ignored. The Serpent is the only thing that will stop you.|
+K Blood Priest Xak'lar|QID|48541|M|43.20,90.55;43.27,91.37|CS|QO|1|T|Blood Priest Xak'lar|N|Enter the cave between the waterfalls to kill a Silver Elite for artifact power and resources.|RANK|2|RARE|;item unknown
 t WANTED: Tojek|QID|51089|M|39.12,79.87|N|To Rovash the One Eyed.|
-T Down by the Riverside|QID|49569|M|39.41,78.17|N|To Princess Talanji.|
-A Rally the Warriors|QID|50076|M|39.41,78.17|N|From Princess Talanji.|PRE|49569|
-C Rally the Warriors|QID|50076|M|39.37,77.48|QO|1|NC|N|Click the Ancient Gong; then listen to the Princess' speech.|
+T Down by the Riverside|QID|49569|M|39.40,78.14|N|To Princess Talanji.|
+A Rally the Warriors|QID|50076|M|39.40,78.14|N|From Princess Talanji.|PRE|49569|
+C Rally the Warriors|QID|50076|M|39.37,77.48|QO|1|H|N|Click the Ancient Gong and then listen to the Princess' speech.|
 T Rally the Warriors|QID|50076|M|39.33,77.68|N|To Princess Talanji.|
 A The Battle of Bloodfire Ravine|QID|50138|M|39.33,77.68|N|From Princess Talanji.|PRE|50076|
-R Bloodfire Ravine|ACTIVE|50138|M|41.93,74.12|
-C The Battle of Bloodfire Ravine|QID|50138|M|42.25,72.63|QO|1|NC|N|Meet Talanji at Bloodfire Ravine.|
-A Undying Totems|QID|50078|M|42.29,72.64|N|From Princess Talanji.|PRE|50076|
+R Bloodfire Ravine|ACTIVE|50138|M|41.93,74.12|N|Exit by the north and head northeast from the stairs.|
+R The Battle of Bloodfire Ravine|ACTIVE|50138|M|42.25,72.63|QO|1|N|Meet Talanji at Bloodfire Ravine.|
+A Undying Totems|QID|50078|M|42.21,72.75|N|From Princess Talanji.|PRE|50076|
 C The Battle of Bloodfire Ravine|QID|50138|M|43.18,72.56|QO|2|S|N|Kill Blood Trolls as you go.|
-C Undying Totems|QID|50078|M|43.99,69.77|N|Destroy the Reanimating Totems.|
-T Undying Totems|QID|50078|M|44.03,70.02|N|To Princess Talanji.|
-C The Battle of Bloodfire Ravine|QID|50138|M|43.18,72.56|QO|2|US|N|Finish your quota of Blood Trolls.|
+C Undying Totems|QID|50078|M|43.38,71.53|H|N|Destroy the Reanimating Totems.|
+T Undying Totems|QID|50078|M|PLAYER|N|To Princess Talanji beside you.|
+C The Battle of Bloodfire Ravine|QID|50138|M|43.18,72.56|QO|2|US|N|Finish up killing the Blood Trolls.|
 K Warmother Molaka|ACTIVE|50138|M|44.80,68.91|QO|3|T|Warmother Molaka|N|Kill Warmother Molaka.|
 T The Battle of Bloodfire Ravine|QID|50138|M|44.96,68.60|N|To Princess Talanji.|
 A The Road of Pain|QID|50081|M|44.96,68.60|N|From Princess Talanji.|PRE|50138&50078|
 A Boom goes the Bomb|QID|50079|M|44.98,68.34|N|From Patch.|PRE|50138&50078|
-C The Road of Pain|QID|50081|M|44.02,63.98|NC|S|N|Click on the prostrate Zandalari Soldiers to heal them.|
-C Boom goes the Bomb|QID|50079|M|44.37,67.21|QO|1|U|156847|NC|N|Use the smoke grenade to mark the first barricade.|
-C Boom goes the Bomb|QID|50079|M|44.07,65.52|QO|2|U|156847|NC|N|Use the smoke grenade to mark the second barricade.|
-C The Road of Pain|QID|50081|M|44.02,63.98|NC|US|N|Finish healing the Zandalari Soldiers.|
-C Boom goes the Bomb|QID|50079|M|44.02,63.98|QO|3|U|156847|NC|N|Use the smoke grenade to mark the third Barricade.|
+C The Road of Pain|QID|50081|M|44.02,63.98|H|S|N|Click on the prostrate Zandalari Soldiers to heal them.|
+C Boom goes the Bomb|QID|50079|M|44.48,66.88|QO|1|U|156847|NC|N|Use the smoke grenade to mark the first barricade.\n[color=FF0000]NOTE: [/color]The air strike won't do anything to you.|
+C Boom goes the Bomb|QID|50079|M|44.18,64.98|QO|2|U|156847|NC|N|Use the smoke grenade to mark the second barricade.|
+C The Road of Pain|QID|50081|M|44.02,63.98|H|US|N|Finish healing the Zandalari Soldiers.|
+C Boom goes the Bomb|QID|50079|M|44.16,63.59|QO|3|U|156847|NC|N|Use the smoke grenade to mark the third Barricade.|
 T The Road of Pain|QID|50081|M|44.19,62.85|N|To Princess Talanji.|
 T Boom goes the Bomb|QID|50079|M|44.19,62.85|N|To Princess Talanji.|
-A Target of Opportunity|QID|50082|M|44.19,62.85|N|From Princess Talanji.|PRE|50321&50080|
+A Target of Opportunity|QID|50082|M|44.19,62.85|N|From Princess Talanji.|PRE|50079|
 C Target of Opportunity|QID|50082|M|44.98,60.97|QO|1|CHAT|N|Tell Talanji you are ready.|
 C Target of Opportunity|QID|50082|M|45.47,60.24|QO|2|N|Confront Grand Ma'da Ateena. You kill the adds while Talanji duels with Ateena.|
 T Target of Opportunity|QID|50082|M|45.21,60.54|N|To Princess Talanji.|
@@ -644,7 +644,7 @@ A Petitioning Krag'wa|QID|52073|M|45.21,60.54|N|From Princess Talanji.|
 A The Crawg Ma'da|QID|50083|M|45.34,58.59|N|From Rokhan.|RANK|3|PRE|50323|
 K Amaka the Crawg Ma'da|ACTIVE|50083|QO|2|M|46.99,54.11|U|156868|T|Amaka the Crawg Ma'da|N|Optionally, if you have one, you can use the poison gland to weaken and do additional damage to Amaka.|
 T The Crawg Ma'da|QID|50083|M|48.53,53.54|N|To Rokhan.|
-A A Message of Blood and Fire|QID|50085|M|48.53,53.54|N|From Rokhan.|PRE|50083|RANK|3|;may be spurious, but quest isnt avail until you turn in The Crawg Ma'da
+A A Message of Blood and Fire|QID|50085|M|48.53,53.54|N|From Rokhan.|PRE|50083|RANK|3|;may be spurious, but quest isnt avail until you turn in The Crawg Ma'da ** This quest is the follow-up to The Crawg Ma'da... not spurious. - Hendo72
 ;A Raiding the Raiders|QID|50080|M|48.46,52.69|N|Bonus Objective - Autoaccepted.|LVL|-50|RANK|3|PRE|50079&50081| ** Not required - Hendo72
 C Raiding the Raiders|QID|50080|M|48.46,52.69|S|N|Bonus Objective - Kill blood trolls, rescue captives and pick up the crates to complete.|
 C A Message of Blood and Fire|QID|50085|M|48.85,52.58|U|156931|S|NC|N|Use the wand to set huts on fire, some will take more than one torching to find the right spot.|
@@ -655,14 +655,14 @@ C Raiding the Raiders|QID|50080|M|45.34,58.59|US|N|Bonus Objective - Finish this
 K Jax'teb the Reanimated|QID|50307|M|45.17,51.79|QO|1|RARE|ITEM|160969|T|Jax'teb the Reanimated|N|One more Silver Elite to kill and loot for artifact power and resources.|RANK|3|
 T A Message of Blood and Fire|QID|50085|M|44.28,54.06|N|To Rokhan. The path up from Jax'teb takes you to Rokhan.|
 K Mala'kili|QID|50040|M|45.67,56.83;50.17,53.91;53.06,54.30|CS|QO|1|RARE|ITEM|163703|T|Mala'kili|N|Run down the hill for this Silver Elite. Mala'kili's pet crawg, Rohn'kor, will come join in the fight. Kill and loot for artifact power and resources. After you kill it, back up the hill to find Krag'wa.|RANK|3|;there is not any very good place for this. I think this is the closest. ... Although perhaps after picking up the dungeon quest is better.
-C Petitioning Krag'wa|QID|52073|M|45.18,60.70|CHAT|N|Petition Krag'wa for aid. (you need to be dismounted)|
+C Petitioning Krag'wa|QID|52073|M|45.14,60.80|CHAT|N|Petition Krag'wa for aid.\n[color=FF0000]NOTE: [/color]You need to be dismounted.|
 T Petitioning Krag'wa|QID|52073|M|49.39,57.19|N|To Princess Talanji.|
-A Ateena's Fall|QID|50087|M|49.39,57.19|N|From Princess Talanji.|;pres per Grail not correct
+A Ateena's Fall|QID|50087|M|49.39,57.19|N|From Princess Talanji.|PRE|52073|;pres per Grail not correct ** This PRE activates the step - Hendo72
 K Grand Ma'da Ateena|ACTIVE|50087|M|51.88,60.59|QO|1|T|Grand Ma'da Ateena|N|Chase Grand Ma'da Ateena around the top of the building avoiding the pools of corruption and damaging her.|
 T Ateena's Fall|QID|50087|M|50.60,58.46|N|To Princess Talanji.|
 A What Rots Beneath|QID|51244|M|50.51,58.34|N|From Rokhan.|PRE|50087|
 C What Rots Beneath|QID|51244|M|50.51,58.34|QO|1|CHAT|N|Ask Rokhan for a ride down to the Altar of Rot.|
-C What Rots Beneath|QID|51244|M|51.73,65.69|QO|2|NC|N|Run down the hill to find Titan Keeper Hezrel and speak to him.|
+C What Rots Beneath|QID|51244|M|53.15,70.61;51.73,65.69|CS|QO|2|CHAT|N|Run down the hill to find Titan Keeper Hezrel and speak to him.|
 T What Rots Beneath|QID|51244|M|51.73,65.69|N|To Titan Keeper Hezrel.|
 A The Underrot: Sealing G'huun's Corruption|QID|51302|M|51.73,65.69|NA|N|From Titan Keeper Hezrel. This is a dungeon quest.|RANK|2|PRE|51244|
 A Halting the Empire's Fall|QID|50808|M|51.91,65.56|N|From Rokhan. If you are sticking around for the remainder of the quests and rares, don't take Rokhan's offered flight.|PRE|51244|RANK|3|

--- a/WoWPro_Leveling/Horde/BFA_Nazmir.lua
+++ b/WoWPro_Leveling/Horde/BFA_Nazmir.lua
@@ -664,7 +664,7 @@ A What Rots Beneath|QID|51244|M|50.51,58.34|N|From Rokhan.|PRE|50087|
 C What Rots Beneath|QID|51244|M|50.51,58.34|QO|1|CHAT|N|Ask Rokhan for a ride down to the Altar of Rot.|
 C What Rots Beneath|QID|51244|M|53.15,70.61;51.73,65.69|CS|QO|2|CHAT|N|Run down the hill to find Titan Keeper Hezrel and speak to him.|
 T What Rots Beneath|QID|51244|M|51.73,65.69|N|To Titan Keeper Hezrel.|
-A The Underrot:Sealing G'huun's Corruption|QID|51302|M|51.73,65.69|ELITE|N|[color=E6CC80]Dungeon: 'The Underrot'[/color]\nFrom Titan Keeper Hezrel.|RANK|2|PRE|51244|
+A The Underrot:Sealing G'huun's Corruption|QID|51302|M|51.73,65.69|ELITE|N|[color=E6CC80]Dungeon: 'The Underrot'[/color]\nFrom Titan Keeper Hezrel.|RANK|2|PRE|51244|;DUNGEON|
 A Halting the Empire's Fall|QID|50808|M|51.91,65.56|N|From Rokhan. If you are sticking around for the remainder of the quests and rares, don't take Rokhan's offered flight.|PRE|51244|RANK|3|
 A Halting the Empire's Fall|QID|50808|M|51.91,65.56|N|From Rokhan.|PRE|51244|
 F Zul'jan Ruins|ACTIVE|50808|M|51.91,65.56|N|Queue if you want to do the dugeon now or ask Rokhan for a ride back to Zul'jan. Alternatively check this off manually and hearth to The Great Seal.|RANK|-1|

--- a/WoWPro_Leveling/Horde/BFA_Nazmir.lua
+++ b/WoWPro_Leveling/Horde/BFA_Nazmir.lua
@@ -664,7 +664,7 @@ A What Rots Beneath|QID|51244|M|50.51,58.34|N|From Rokhan.|PRE|50087|
 C What Rots Beneath|QID|51244|M|50.51,58.34|QO|1|CHAT|N|Ask Rokhan for a ride down to the Altar of Rot.|
 C What Rots Beneath|QID|51244|M|53.15,70.61;51.73,65.69|CS|QO|2|CHAT|N|Run down the hill to find Titan Keeper Hezrel and speak to him.|
 T What Rots Beneath|QID|51244|M|51.73,65.69|N|To Titan Keeper Hezrel.|
-A The Underrot: Sealing G'huun's Corruption|QID|51302|M|51.73,65.69|NA|N|From Titan Keeper Hezrel. This is a dungeon quest.|RANK|2|PRE|51244|
+A The Underrot: Sealing G'huun's Corruption|QID|51302|M|51.73,65.69|ELITE|N|[color=E6CC80]Dungeon: 'The Underrot'[/color]\nFrom Titan Keeper Hezrel.|RANK|2|PRE|51244|
 A Halting the Empire's Fall|QID|50808|M|51.91,65.56|N|From Rokhan. If you are sticking around for the remainder of the quests and rares, don't take Rokhan's offered flight.|PRE|51244|RANK|3|
 A Halting the Empire's Fall|QID|50808|M|51.91,65.56|N|From Rokhan.|PRE|51244|
 F Zul'jan Ruins|ACTIVE|50808|M|51.91,65.56|N|Queue if you want to do the dugeon now or ask Rokhan for a ride back to Zul'jan. Alternatively check this off manually and hearth to The Great Seal.|RANK|-1|

--- a/WoWPro_Leveling/Horde/BFA_Zuldazar.lua
+++ b/WoWPro_Leveling/Horde/BFA_Zuldazar.lua
@@ -731,7 +731,7 @@ H The Great Seal|ACTIVE|50963|M|70.77,29.59|N|Use your hearthstone.\n[color=FF00
 F The Great Seal|ACTIVE|50963|M|70.77,29.59|N|Take the flightpath at Loz the Paku'ai.|
 T Of Dark Deeds and Dark Days|QID|50963|M|41.22,66.92|Z|Hall of Croniclers!Dazar'alor|N|To Princess Talanji.|
 t Atal'Dazar: Yazma the Fallen Priestess|QID|49901|M|41.22,66.92|Z|Hall of Croniclers!Dazar'alor|N|To Princess Talanji.|
-A The Blood Gate|QID|47199|M|40.89,73.00|Z|Hall of Croniclers!Dazar'alor|N|Baine Bloodhoof. This quest requires you have completed the zone achievement for Nazmir as well as Zandalar. The completion of this quest is included in the end game storyline guide.|PRE|50963&50808|;not spurious - necesary for guide flow
+A The Blood Gate|QID|47199|M|40.89,73.00|Z|Hall of Croniclers!Dazar'alor|N|Baine Bloodhoof. This quest requires you have completed the zone achievement for Nazmir as well as Zandalar. The completion of this quest is included in the end game storyline guide.|PRE|50963&50808|;not spurious - necessary for guide flow
 A Sandscar Breach|QID|49940|M|67.00,71.58|Z|Hall of Croniclers!Dazar'alor|N|From Natal'hakata.|RANK|2|
 ; R3 quest chain begins and R1 will drop to the end of the guide from here.
 A The Bones of Xibala|QID|47257|M|69.89,47.50|Z|Hall of Croniclers!Dazar'alor|N|From Chronicler To'kini.|RANK|3|
@@ -798,7 +798,7 @@ T The Sethrak Incursion|QID|49679|M|47.33,25.14|N|To Beastmother Jabati.|
 T Lil' Tika|QID|49681|M|47.33,25.14|N|To Beastmother Jabati.|
 ;A Bargain of Blood
 F The Sliver|ACTIVE|47199|M|49.72,26.28|N|At Paku'ai Rip'nata.|
-J End Game Storyline Guide|QID|47199|N|To continue the storyline, click here to jump to the next guide.|GUIDE|EliEndgame|
+J End Game Storyline Guide|QID|47199|N|To continue the storyline, click here to jump to the next guide.|JUMP|EliEndgame|
 D The End.|N|This Concludes Zuldazar. The war campaign guide will automatically load when you check this step off. If instead you want to go elsewhere, select the next area and let that guide autoload.|GUIDE|EmmHWarCampaign|
 ]]
 end)

--- a/WoWPro_Leveling/Horde/BFA_Zuldazar.lua
+++ b/WoWPro_Leveling/Horde/BFA_Zuldazar.lua
@@ -244,9 +244,9 @@ C Direhorn Daycare|QID|47259|M|69.10,44.91|S|H|N|Click on the soothing lilybud b
 K Kandak|QID|48543|M|68.66,48.72|QO|1|RARE|ITEM|160984|T|Kandak|N|Silver Elite to kill for azerite power and resources.|RANK|2|
 C Direhorn Daycare|QID|47259|M|69.10,44.91|US|H|N|Finish satiating your hatchling.|
 C Ravenous Landsharks|QID|48527|M|68.81,48.09|US|N|Finish your quota of Irritable Diemetradons.|
-T Direhorn Daycare|QID|47259|M|66.81,42.51|N|To Beastlord L'kala.|
-T Ravenous Landsharks|QID|48527|M|66.81,42.51|N|To Beastlord L'kala.|
-A Headbutting 101|QID|47311|M|66.81,42.51|N|From Beastlord L'kala.|RANK|2|PRE|47259&48527|
+T Direhorn Daycare|QID|47259|M|66.80,42.55|N|To Beastlord L'kala.|
+T Ravenous Landsharks|QID|48527|M|66.80,42.55|N|To Beastlord L'kala.|
+A Headbutting 101|QID|47311|M|66.80,42.55|N|From Beastlord L'kala.|RANK|2|PRE|47259&48527|
 A Direhorn Growth Hormone|QID|47272|M|66.81,42.58|N|From Trader Alexxi Cruzpot.|RANK|2|PRE|47259&48527|
 A WANTED: Jabra'kan|QID|51980|M|69.05,40.83|N|From Wanted Poster.|RANK|2|
 A Queenfeather|QID|47312|M|69.02,40.72|N|From Wingrider Nivek.|RANK|2|
@@ -259,8 +259,8 @@ C Direhorn Growth Hormone|QID|47272|M|70.62,40.58|US|NC|N|Finish collecting the 
 C Headbutting 101|QID|47311|M|70.42,40.31|US|N|Command your Hatchling to fight|
 T Queenfeather|QID|47312|M|69.01,40.71|N|To Wingrider Nivek.|
 T Direhorn Growth Hormone|QID|47272|M|66.81,42.58|N|To Trader Alexxi Cruzpot.|
-T Headbutting 101|QID|47311|M|66.81,42.51|N|To Beastlord L'kala.|
-A Wings for the Kraal|QID|51990|M|66.81,42.51|N|From Beastlord L'kala.|RANK|2|PRE|47311|
+T Headbutting 101|QID|47311|M|66.80,42.55|N|To Beastlord L'kala.|
+A Wings for the Kraal|QID|51990|M|66.80,42.55|N|From Beastlord L'kala.|RANK|2|PRE|47311|
 A DGH: Now With Real Direhorn|QID|51998|M|66.81,42.58|N|From Trader Alexxi Cruzpot.|RANK|2|PRE|47311|
 C DGH: Now With Real Direhorn|QID|51998|M|66.79,34.09|S|N|Kill Pterrordax' and loot to collect the Partially Digested Direhorn Flesh.|
 C Wings for the Kraal|QID|51990|M|66.72,34.46|S|NC|N|Pick up the nearly-hatching Pterrordax Egg.|
@@ -271,10 +271,10 @@ C WANTED: Jabra'kan|QID|51980|M|67.07,37.15|T|Jabra'kan|N|Kill Jabra'kan the Poa
 t WANTED: Jabra'kan|QID|51980|M|69.01,40.71|N|To Wingrider Nivek.|
 T DGH: Now With Real Direhorn|QID|51998|M|66.81,42.58|N|To Trader Alexxi Cruzpot.|
 T Wings for the Kraal|QID|51990|M|66.80,42.51|N|To Beastlord L'kala.|
-A Growing Pains|QID|47418|M|66.81,42.56|N|From Trader Alexxi Cruzpot.|RANK|2|PRE|47272|
+A Growing Pains|QID|47418|M|66.80,42.55|N|From Trader Alexxi Cruzpot.|RANK|2|PRE|47272|
 C Growing Pains|QID|47418|M|66.85,42.44|QO|1|U|147897|NC|N|Feed the DGH to your Hatchling.|
 T Growing Pains|QID|47418|M|66.81,42.58|N|To Trader Alexxi Cruzpot.|
-A How to Train Your Direhorn|QID|47261|M|66.81,42.51|N|From Beastlord L'kala.|RANK|2|PRE|47418&47311|
+A How to Train Your Direhorn|QID|47261|M|66.80,42.55|N|From Beastlord L'kala.|RANK|2|PRE|47418&47311|
 C How to Train Your Direhorn|QID|47261|M|67.56,43.45|QO|1|CHAT|N|Talk to Training Master B'khor.|
 C How to Train Your Direhorn|QID|47261|M|69.12,45.08|QO|2|NC|N|Go into the training pen to meet Pinky.|
 C How to Train Your Direhorn|QID|47261|M|69.76,43.83|QO|3|NC|N|Use the "1" key to sprint away from Pinky towards the North gate.|
@@ -284,21 +284,22 @@ C How to Train Your Direhorn|QID|47261|M|67.60,43.41|QO|6|NC|N|Return to Kraal M
 T How to Train Your Direhorn|QID|47261|M|67.55,43.44|N|To Kraal Master B'khor.|
 A A Good Spanking|QID|48581|M|67.55,43.44|N|From Kraal Master B'khor.|RANK|2|PRE|47261|
 C A Good Spanking|QID|48581|M|67.87,44.97|N|Go beat up on Pinky to tire him out.|
-T A Good Spanking|QID|48581|M|66.81,42.51|N|To Beastlord L'kala.|
-A Naptime|QID|47310|M|66.81,42.51|N|From Beastlord L'kala.|RANK|2|PRE|48581|
-C Naptime|QID|47310|M|68.29,42.05|NC|N|Click on the gates to send your Juvenile Direhorn into the "stable"|
+T A Good Spanking|QID|48581|M|66.80,42.55|N|To Beastlord L'kala.|
+A Naptime|QID|47310|M|66.80,42.55|N|From Beastlord L'kala.|RANK|2|PRE|48581|
+C Naptime|QID|47310|M|68.29,42.05|NC|N|Click on the gates to send your Direhorn Juvenile into the "stable"|
 T Naptime|QID|47310|M|66.79,42.50|N|To Beastlord L'kala.|
 N Pet Opportunity|AVAILABLE|47260|N|After you reach lvl 50, you will get a letter inviting you back to complete 3 more quests for a new pet.\n[color=FF0000]NOTE: [/color]Manually check this step off to continue.|PRE|47310| ; Level may be different - Hendo72
-A Side Effects May Include...|QID|47260|M|68.14,41.81|N|From Direhorn Juvinile where you left him taking a nap.|PRE|47310|LVL|50|
-T Side Effects May Include...|QID|47260|M|66.81,42.56|N|To Beastlord L'kala.|
-A Alchemy is an Inexact Science|QID|52855|M|66.81,42.56|N|From Trader Alexxi Cruzpot.|PRE|47260|
-R Savagelands|ACTIVE|52855|M|70.50,35.27|N|Mount up its a bit of a run to find the needed reagents.|
-C Alchemy is an Inexact Science|QID|52855|M|70.50,35.27|NC|N|Click on Incandescent Duskwings to collect the dust.|
-C Alchemy is an Inexact Science|QID|52855|M|70.45,34.59|NC|N|Pick the flower after you have all the duskwings, it sometimes bugs out otherwise.|
-T Alchemy is an Inexact Science|QID|52855|M|66.81,42.58|N|To Trader Alexxi Cruzpot.|
-A Held For Observation|QID|52857|M|66.81,42.56|N|From Trader Alexxi Cruzpot.|PRE|52855|
-C Held For Observation|QID|52857|M|68.14,41.81|U|162589|NC|N|Give your Direhorn Juvenile the remedy.|
-T Held For Observation|QID|52857|M|66.81,42.56|N|To Beastlord L'kala.|
+F Warbeast Kraal|ACTIVE|47199|AVAILABLE|47260|M|51.92,41.20|Z|Dazar'alor|N|At Paku'ai Rokota.| ; ** Nazmir joins here - Hendo72
+A Side Effects May Include...|QID|47260|M|68.17,41.74|N|From Direhorn Juvenile where you left him taking a nap.\n[color=FF0000]NOTE: [/color]Click on the gate to open it.|PRE|47310|LVL|50|
+T Side Effects May Include...|QID|47260|M|66.80,42.55|N|To Beastlord L'kala.|
+A Alchemy is an Inexact Science|QID|52855|M|66.74,42.70|N|From Trader Alexxi Cruzpot.|PRE|47260|
+R Savagelands|ACTIVE|52855|M|66.74,42.70|N|Mount up its a bit of a run to find the needed reagents.|
+C Alchemy is an Inexact Science|QID|52855|M|70.50,35.27|QO|2|H|N|Click on Incandescent Duskwings to collect the dust.\n[color=FF0000]NOTE: [/color]Do not pick the flower until you are done this. It may bug out you.|
+C Alchemy is an Inexact Science|QID|52855|M|70.48,34.59|QO|1|H|N|Pick the flower.|
+T Alchemy is an Inexact Science|QID|52855|M|66.74,42.70|N|To Trader Alexxi Cruzpot.|
+A Held For Observation|QID|52857|M|66.74,42.70|N|From Trader Alexxi Cruzpot.|PRE|52855|
+C Held For Observation|QID|52857|M|68.17,41.74|T|Direhorn Juvenile|U|162589|NC|N|Give your Direhorn Juvenile the remedy.|
+T Held For Observation|QID|52857|M|66.80,42.55|N|To Beastlord L'kala.|
 F Scaletrader Post|ACTIVE|49768|M|67.26,43.03|N|At Paku'ai Verraki.|
 R Nesingwary's Trek|ACTIVE|49768|M|69.23,27.56;68.53,23.01;67.91,21.19;67.54,18.00|CS|N|And on to find Nesingwary.|RANK|2|
 T Nesingwary's Trek|QID|49768|M|67.50,17.70|N|To Hemet Nesingwary.|


### PR DESCRIPTION
- note and coordinate tweaks
- update NC
- A Target of Opportunity|QID|50082| has the wrong PRE. 50321 didn't make it into Live and 50080 is the BO you get after. Correct PRE is 50079
- updated/added PRE|52073| for A Ateena's Fall|QID|50087|. Quest appears once you turn it in.