### PR TITLE
Update LEGION_Stormheim.lua

### DIFF
--- a/WoWPro_Leveling/Horde/LEGION_Stormheim.lua
+++ b/WoWPro_Leveling/Horde/LEGION_Stormheim.lua
@@ -273,43 +273,43 @@ T The Runewood's Revenge|QID|39788|M|68.48,54.31|N|To Vydhar.|
 A The Dreaming Fungus|QID|38810|PRE|38778&39788|M|68.48,54.31|N|From Vydhar.|
 A Bjornharta|QID|38808|PRE|38778&39788|M|68.48,54.31|N|From Vydhar.|
 C Bjornharta|QID|38808|M|70.39,53.00|S|N|Kill bears and loot the Engorged Bear Hearts.|
-C The Dreaming Fungus|QID|38810|M|69.93,52.64|S|NC|N|Gather Soulcaps|
-K Mordvigbjorn|QID|38837|M|72.60,49.99|QO|1|ITEM|129035|T|Mordvigbjorn|N|Silver - Kill and loot for a bit of treasure and resources.|RANK|2|RARE|
-C The Dreaming Fungus|QID|38810|US|M|69.93,52.64|NC|N|Finish gathering Soulcaps|
+C The Dreaming Fungus|QID|38810|M|69.93,52.64|S|H|N|Gather Soulcaps|
+K Mordvigbjorn|QID|38837|QO|1|M|72.60,49.99|ITEM|129035|T|Mordvigbjorn|N|Silver - Kill and loot for a bit of treasure and resources.|RANK|2|RARE|
+C The Dreaming Fungus|QID|38810|US|M|69.93,52.64|H|N|Finish gathering Soulcaps|
 C Bjornharta|QID|38808|M|70.39,53.00|US|N|Finish collecting the Engorged Bear Hearts.|
-T The Dreaming Fungus|QID|38810|M|68.51,54.27|N|To Vydhar.|
-T Bjornharta|QID|38808|M|68.51,54.27|N|To Vydhar.|
-A Judgment Day|QID|38811|PRE|38808&38810|M|68.51,54.27|N|From Vydhar.|
-A Lay Them to Rest|QID|39791|PRE|38808&38810|M|68.51,54.27|N|From Vydhar.|
-C Lay Them to Rest|QID|39791|M|64.71,45.39|U|128772|S|N|Weaken them, below 75% and then use Runewood Branch to return the Restless Ancestors to the earth.|
-C Judgment Day|QID|38811|M|64.81,46.56|QO|2|N|Click on the offering bowl and be ready to fight.|T|Rythas the Oracle|
+T The Dreaming Fungus|QID|38810|M|68.48,54.31|N|To Vydhar.|
+T Bjornharta|QID|38808|M|68.48,54.31|N|To Vydhar.|
+A Judgment Day|QID|38811|PRE|38808&38810|M|68.48,54.31|N|From Vydhar.|
+A Lay Them to Rest|QID|39791|PRE|38808&38810|M|68.48,54.31|N|From Vydhar.|
+C Lay Them to Rest|QID|39791|M|64.71,45.39|S|U|128772|N|Weaken them, below 75% and then use Runewood Branch to return the Restless Ancestors to the earth.|
+C Judgment Day|QID|38811QO|2||M|64.81,46.56|T|Rythas the Oracle|N|Click on the offering bowl and be ready to fight.|
 $ Small Treasure Chest|QID|43205|M|65.37,43.12|N|Loot for a bit of treasure and resources.|RANK|2|
 C Judgment Day|QID|38811|M|67.56,43.00|QO|1|N|Judged by Heimir of the Black Fist.|T|Heimir of the Black Fist|
-K The Nameless King|QID|38685|M|67.26,39.93|QO|1|T|The Nameless King|N|Click on his offering shrine to start the vignette.  Kill him and earn treasure and resources.|RANK|2|RARE|
-C Judgment Day|QID|38811|M|66.87,45.77|QO|3|N|Judged by Oktel Dragonblood|T|Oktel Dragonblood|
+K The Nameless King|QID|38685|QO|1|M|67.26,39.93|T|The Nameless King|N|Click on his offering shrine to start the vignette.  Kill him and earn treasure and resources.|RANK|2|RARE|
+C Judgment Day|QID|38811|QO|3|M|66.87,45.77|T|Oktel Dragonblood|N|Judged by Oktel Dragonblood|
 $ Small Treasure Chest|QID|43302|M|64.20,41.58;64.29,39.55|CS|N|Loot for a bit of treasure and resources.|RANK|2|
 C Lay Them to Rest|QID|39791|M|64.71,45.39|U|128772|US|N|Finish returning the Restless Ancestors to the earth.|
-T Judgment Day|QID|38811|M|68.18,48.69|N|To Shieldmaiden Iounn.|
-A Regal Remains|QID|38817|PRE|38811|M|68.18,48.69|N|From Shieldmaiden Iounn.|
-T Lay Them to Rest|QID|39791|M|68.18,48.69|N|To Shieldmaiden Iounn.|
-A Breaking the Bonespeakers|QID|38816|PRE|38811|M|68.18,48.69|N|From Shieldmaiden Iounn.|
+T Judgment Day|QID|38811|M|68.16,48.73|N|To Shieldmaiden Iounn.|
+A Regal Remains|QID|38817|PRE|38811|M|68.16,48.73|N|From Shieldmaiden Iounn.|
+T Lay Them to Rest|QID|39791|M|68.16,48.73|N|To Shieldmaiden Iounn.|
+A Breaking the Bonespeakers|QID|38816|PRE|38811|M|68.16,48.73|N|From Shieldmaiden Iounn.|
 C Breaking the Bonespeakers|QID|38816|M|71.58,45.40|S|N|Kill Bonespeaker allies.|
 A The Runes that Bind|QID|38823|M|69.80,45.73|N|From Rune Carved Tablet.|
-C Regal Remains|QID|38817|M|72.97,43.89|S|NC|N|Collect Ashildir's Bones.|
+C Regal Remains|QID|38817|M|72.97,43.89|S|H|N|Collect Ashildir's Bones.|
 $ Small Treasure Chest|QID|38637|M|69.35,44.97;69.13,44.77|CS|N|Use grapple point to reach chest. Loot for treasure and resources.|RANK|2|
-$ Small Treasure Chest|QID|40086|M|69.0,41.9|CS|N|In the room with the ritual stone. Loot for treasure and resources.|RANK|2|
-C The Runes that Bind|QID|38823|M|69.46,41.96;73.00,44.05;71.42,45.24|CN|N|Click on the ritual stones to destroy them.|
-$ Small Treasure Chest|QID|43305|M|72.24,43.75;71.95,44.14|CS|N|Use your grappling hook to go up and get this chest. Loot for a bit of treasure and resources.|RANK|2|
+$ Small Treasure Chest|QID|40086|M|68.97,41.84|N|In the room with the ritual stone. Loot for treasure and resources.|RANK|2|
+C The Runes that Bind|QID|38823|M|69.46,41.96;73.00,44.05;71.42,45.24|CN|H|N|Click on the ritual stones to destroy them.|
+$ Small Treasure Chest|QID|43305|M|72.24,43.75;71.91,44.07;71.93,44.25|CS|N|Use your grappling hook to go up and get this chest. Loot for a bit of treasure and resources.|RANK|2|
+$ Small Treasure Chest|QID|43306|M|73.25,42.68;74.12,42.43;74.41,41.84|CS|N|Get this before you complete the next quest or you will have to run a long ways back to get it.  Use Hook to get up to alcove above. Loot for a bit of treasure and resources.|RANK|3|
 C Breaking the Bonespeakers|QID|38816|M|71.58,45.40|US|N|Finish killing Bonespeaker allies.|
-C Regal Remains|QID|38817|M|72.97,43.89|US|NC|N|Finish collecting Ashildir's Bones.|
+C Regal Remains|QID|38817|M|72.97,43.89|US|H|N|Finish collecting Ashildir's Bones.|
 T Regal Remains|QID|38817|M|69.89,45.52|N|To Shieldmaiden Iounn.|
 T Breaking the Bonespeakers|QID|38816|M|69.89,45.52|N|To Shieldmaiden Iounn.|
 T The Runes that Bind|QID|38823|M|69.89,45.52|N|To Shieldmaiden Iounn.|
 A Waking the Shieldmaiden|QID|38815|PRE|38817&38816&38823|M|69.89,45.52|N|From Shieldmaiden Iounn.|
-$ Small Treasure Chest|QID|43306|M|73.25,42.68;74.41,41.84|CS|N|Get this before you complete the next quest or you will have to run a long ways back to get it.  Use Hook to get up to alcove above. Loot for a bit of treasure and resources.|RANK|3|
-C Waking the Shieldmaiden|QID|38815|M|71.42,42.49|NC|N|Click on the Rune of Reformation to activate.|
-T Waking the Shieldmaiden|QID|38815|M|71.45,42.50|N|To Ashildir.|
-A The Final Judgment|QID|38818|PRE|38815|M|71.45,42.50|N|From Ashildir.|
+C Waking the Shieldmaiden|QID|38815|M|71.46,42.49|H|N|Click on the Rune of Reformation to activate.|
+T Waking the Shieldmaiden|QID|38815|M|71.46,42.49|N|To Ashildir.|
+A The Final Judgment|QID|38818|PRE|38815|M|71.46,42.49|N|From Ashildir.|
 $ Small Treasure Chest|QID|40085|M|73.33,41.51|N|Loot for treasure and resources.|RANK|2|
 C The Final Judgment|QID|38818|M|73.12,40.06|N|Confront Runeseer Faljar.|
 T The Final Judgment|QID|38818|M|65.61,47.17|Z|Helheim|N|To Ashildir.|


### PR DESCRIPTION
- Coordinate and H/NC tweaks.
- moved the one small treasure chest to be done earlier when you are in the area and on the same floor. Technically it could be done before you activate the Rune, but you are going past where you need to be and the room you are in earlier is right around the corner from it. (I may tweak it depending on the chest just before it)