### PR TITLE
Thaldrazus fixes

### DIFF
--- a/WoWPro_Leveling/Neutral/DF_Thaldraszus.lua
+++ b/WoWPro_Leveling/Neutral/DF_Thaldraszus.lua
@@ -425,7 +425,7 @@ t So How Did It Go?|QID|70854|M|10.32,58.37|Z|2112|N|To Jyhanna.|
 T A Dryad's Work Is Never Done|QID|67094|M|72.89,66.17|Z|2112|N|To Thalendra.|
 A A Dryadic Remedy|QID|67606|PRE|67094|M|72.89,66.17|Z|2112|N|From Thalendra.|
 l Barrel of Confiscated Treats|QID|67606|M|9.50,55.87|Z|2112|QO|1|N|Loot the treasure to collect a Tasty Hatchling's Treat. You can also get the treats on the Auction House or cook them up if you have the recipe.|
-C A Dryadic Remedy|QID|67606|M|66.39, 58.10|Z|2212|QO|2|CHAT|Adminster Thalendra's Remedy to the Despondant Duckling. It's hiding under the leaves of the plant.| 
+C A Dryadic Remedy|QID|67606|M|66.39, 58.10|Z|2212|QO|2|CHAT|N|Adminster Thalendra's Remedy to the Despondant Duckling. It's hiding under the leaves of the plant.| 
 
 T Archival Assistance|QID|67007|M|34.95,28.15|Z|2112|N|To Kemora.|
 A Preserving the Past|QID|66868^66870^66871^66872^66873^66874^66875|PRE|67007|M|34.95,28.15|Z|2112|N|From Kemora. This is your weekly dungeon quest, it will vary each week.|LVL|70|

--- a/WoWPro_Leveling/Neutral/DF_Thaldraszus.lua
+++ b/WoWPro_Leveling/Neutral/DF_Thaldraszus.lua
@@ -425,7 +425,7 @@ t So How Did It Go?|QID|70854|M|10.32,58.37|Z|2112|N|To Jyhanna.|
 T A Dryad's Work Is Never Done|QID|67094|M|72.89,66.17|Z|2112|N|To Thalendra.|
 A A Dryadic Remedy|QID|67606|PRE|67094|M|72.89,66.17|Z|2112|N|From Thalendra.|
 l Barrel of Confiscated Treats|QID|67606|M|9.50,55.87|Z|2112|QO|1|N|Loot the treasure to collect a Tasty Hatchling's Treat. You can also get the treats on the Auction House or cook them up if you have the recipe.|
-C A Dryadic Remedy|QID|67606|M|66.39, 58.10|Z|2212|QO|2|CHAT|N|Adminster Thalendra's Remedy to the Despondant Duckling. It's hiding under the leaves of the plant.| 
+C A Dryadic Remedy|QID|67606|M|66.39, 58.10|Z|2212|QO|2|CHAT|N|Adminster Thalendra's Remedy to the Despondant Duckling. It's hiding under the leaves of the plant.|
 
 T Archival Assistance|QID|67007|M|34.95,28.15|Z|2112|N|To Kemora.|
 A Preserving the Past|QID|66868^66870^66871^66872^66873^66874^66875|PRE|67007|M|34.95,28.15|Z|2112|N|From Kemora. This is your weekly dungeon quest, it will vary each week.|LVL|70|

--- a/WoWPro_Leveling/Neutral/DF_Thaldraszus.lua
+++ b/WoWPro_Leveling/Neutral/DF_Thaldraszus.lua
@@ -425,7 +425,7 @@ t So How Did It Go?|QID|70854|M|10.32,58.37|Z|2112|N|To Jyhanna.|
 T A Dryad's Work Is Never Done|QID|67094|M|72.89,66.17|Z|2112|N|To Thalendra.|
 A A Dryadic Remedy|QID|67606|PRE|67094|M|72.89,66.17|Z|2112|N|From Thalendra.|
 l Barrel of Confiscated Treats|QID|67606|M|9.50,55.87|Z|2112|QO|1|N|Loot the treasure to collect a Tasty Hatchling's Treat. You can also get the treats on the Auction House or cook them up if you have the recipe.|
-C A Dryadic Remedy|QID|67606|M|66.39, 58.10|Z|2212|QO|2|CHAT|N|Adminster Thalendra's Remedy to the Despondant Duckling. It's hiding under the leaves of the plant.|
+C A Dryadic Remedy|QID|67606|M|66.39, 58.10|Z|2112|QO|2|CHAT|N|Adminster Thalendra's Remedy to the Despondant Duckling. It's hiding under the leaves of the plant.|
 
 T Archival Assistance|QID|67007|M|34.95,28.15|Z|2112|N|To Kemora.|
 A Preserving the Past|QID|66868^66870^66871^66872^66873^66874^66875|PRE|67007|M|34.95,28.15|Z|2112|N|From Kemora. This is your weekly dungeon quest, it will vary each week.|LVL|70|

--- a/WoWPro_Leveling/Neutral/DF_Thaldraszus.lua
+++ b/WoWPro_Leveling/Neutral/DF_Thaldraszus.lua
@@ -347,7 +347,7 @@ T Return to the Present|QID|66032|M|60.06,82.46|Z|2025|N|To Nozdormu.|
 T Temporal Tuning|QID|66029|M|60.06,82.46|Z|2025|N|To Nozdormu.|
 A To the... Past?|QID|66033|PRE|66029|M|60.06,82.46|Z|2025|N|From Nozdormu.|
 A Temporal Two-ning|QID|72519|PRE|66032|M|60.06,82.46|Z|2025|N|From Nozdormu.|
-P Azmerloth|ACTIVE|66033|M|59.98,82.08|Z|2025|N|Take the portal to Temporal Conflux.|
+P Azmerloth|ACTIVE|66033|M|59.98,82.08|Z|2025|N|Take the portal to Azmerloth.|
 T To the... Past?|QID|66033|M|59.83,66.14|Z|2092|N|To Andantenormu.|
 A Murloc Motes|QID|66035|PRE|66033|M|59.83,66.14|Z|2092|N|From Andantenormu.|
 A Mugurlglrlgl!|QID|66036|PRE|66033|M|59.91,65.99|Z|2092|N|From Varian Wryngrrlgulgll.|FACTION|Alliance|

--- a/WoWPro_Leveling/Neutral/DF_Thaldraszus.lua
+++ b/WoWPro_Leveling/Neutral/DF_Thaldraszus.lua
@@ -424,6 +424,8 @@ t So How Did It Go?|QID|70854|M|10.32,58.37|Z|2112|N|To Jyhanna.|
 
 T A Dryad's Work Is Never Done|QID|67094|M|72.89,66.17|Z|2112|N|To Thalendra.|
 A A Dryadic Remedy|QID|67606|PRE|67094|M|72.89,66.17|Z|2112|N|From Thalendra.|
+l Barrel of Confiscated Treats|QID|67606|M|9.50,55.87|Z|2112|QO|1|N|Loot the treasure to collect a Tasty Hatchling's Treat. You can also get the treats on the Auction House or cook them up if you have the recipe.|
+C A Dryadic Remedy|QID|67606|M|66.39, 58.10|Z|2212|QO|2|CHAT|Adminster Thalendra's Remedy to the Despondant Duckling. It's hiding under the leaves of the plant.| 
 
 T Archival Assistance|QID|67007|M|34.95,28.15|Z|2112|N|To Kemora.|
 A Preserving the Past|QID|66868^66870^66871^66872^66873^66874^66875|PRE|67007|M|34.95,28.15|Z|2112|N|From Kemora. This is your weekly dungeon quest, it will vary each week.|LVL|70|


### PR DESCRIPTION
1. Update the note for the Portal to Azmerloth to match the portal's name.
2. Added the steps to complete the quest "A Dryadic remedy".