### PR TITLE
10.1.5 Horde exiles reach updates

### DIFF
--- a/WoWPro_Leveling/Horde/BFA_Intro.lua
+++ b/WoWPro_Leveling/Horde/BFA_Intro.lua
@@ -12,25 +12,6 @@ C Battle for Azeroth: Mission Statement|QID|60361^51443|M|48.55,71.49|Z|Orgrimma
 C Battle for Azeroth: Mission Statement|QID|60361^51443|M|54.62,78.34|Z|Orgrimmar|QO|2|N|Go to the Broken Tusk Inn and meet your team|NC|
 T Battle for Azeroth: Mission Statement|QID|60361^51443|M|54.45,78.42|Z|Orgrimmar|N|To Nathanos Blightcaller.|
 
-A The Stormwind Extraction|QID|50769|M|54.45,78.42|Z|Orgrimmar|N|From Nathanos Blightcaller.|PRE|51443^60361|
-C The Stormwind Extraction|QID|50769|M|54.55,78.37|Z|Orgrimmar|QO|1|N|Take a potion. Don't use it!|H|
-C The Stormwind Extraction|QID|50769|M|50.89,83.96|Z|Orgrimmar|QO|2|N|Fly up to the ramparts and hop on an eagle. This will enter you into the next scenario, (Stockades/Stormwind).|V|
-C In the Dead of Night|QID|50769|M|47.21,59.58|Z|Stormwind City!Stormwind City!Instance|SO|1;1|N|Infiltrate Stormwind City|NC|
-C Down the Drain|QID|50769|M|46.23,58.19|Z|Stormwind City!Stormwind City!Instance|SO|2;2|N|Open the sewer access gate|H|
-C Down the Drain|QID|50769|M|41.29,62.51|Z|Stormwind City!Stormwind City!Instance|SO|2;1|N|Go in the sewer access gate.|H|
-C The Stockades|QID|50769|M|51.30,39.62|Z|The Stockade!The Stockade!Instance|SO|3;1|N|Fight your way to meet up with Rokhan.|
-C Honor and Loyalty|QID|50769|M|48.05,33.68|Z|The Stockade!The Stockade!Instance|SO|4;2|N|Click on the Door to Saurfang's cell and go in.|H|
-C Honor and Loyalty|QID|50769|M|48.05,33.68|Z|The Stockade!The Stockade!Instance|SO|4;1|N|Talk to Saurfang.|CHAT|
-C The Primary Objective|QID|50769|M|56.00,64.16|Z|The Stockade!The Stockade!Instance|SO|5;1|N|Fight your way to the next waypoint and open the cell to release the Princess and the Prophet.|
-C The Primary Objective|QID|50769|M|56.67,40.64;87.01,23.28|Z|The Stockade!The Stockade!Instance|CS|SO|5;2|N|Fight your way down the hall and to the sewer grate, Click on the grade to go thru.|
-C The City Stirs|QID|50769|M|55.78,56.46|Z|Stormwind City!Stormwind City!Instance|SO|6;1|N|Talk to Rokhan and then follow closely so you stay in his invis-o sphere.|CHAT|
-C WAY Behind Enemy Lines|QID|50769|M|55.87,56.88|Z|Stormwind City!Stormwind City!Instance|SO|7;1|N|Defeat the worgen ambush.|
-C Escape Cathedral Square|QID|50769|M|45.42,43.19|Z|Stormwind City!Stormwind City!Instance|SO|7;2|N|Keep following your buddies and fighting your way thru Stormwind. Chat with Nathanos when you get to him, to end this stage.|
-C No Diplomatic Solution|QID|50769|M|39.67,41.04|Z|Stormwind City!Stormwind City!Instance|SO|8;1|N|Break down the ice wall.|
-C Reach Talanji's ship|QID|50769|M|20.59,25.79|Z|Stormwind City!Stormwind City!Instance|SO|9;1|N|Continue on with your buddies, killing those pesky Alliance trying to stop you from reaching Talanji's ship|
-C Escape Stormwind Harbor|QID|50769|M|20.63,28.92|Z|Stormwind City!Stormwind City!Instance|SO|10;1|N|Talk to Talanji on the bridge of her ship.|CHAT|
-T The Stormwind Extraction|QID|50769|M|39.50,70.83|Z|1164|N|To Nathanos Blightcaller.|
-
 A Welcome to Zuldazar|QID|46957|M|57.95,62.46|Z|Zuldazar|N|From Princess Talanji|PRE|50769|
 C Welcome to Zuldazar|QID|46957|M|57.94,56.59|Z|Zuldazar|N|Follow Princess Talanji. You will need to stay close, otherwise she will stop running.|NC|
 T Welcome to Zuldazar|QID|46957|M|57.97,56.50|Z|Zuldazar|N|To General Jakra'zet.|
@@ -45,7 +26,7 @@ C Speaker of the Horde|QID|46931|M|57.95,44.31|Z|Zuldazar|QO|3|N|Head back insid
 C Speaker of the Horde|QID|46931|M|67.00,71.83|Z|The Great Seal!Dazar'alor|QO|4|N|To the left, head down the stairs to the Hall of Ancient Paths. These will be your portals to the Horde Cities once this quest is complete.|NC|
 C Speaker of the Horde|QID|46931|M|32.22,70.00|Z|The Great Seal!Dazar'alor|CS|QO|5|N|Head back up the stairs, across the corridor, then down the stairs to the Vault of the King.|NC|
 T Speaker of the Horde|QID|46931|M|41.28,66.75|Z|The Great Seal!Dazar'alor|N|Back up the stairs, to Princess Talanji.|
-A Area to Explore|QID|47512^47513^47514|M|41.77,69.35|Z|1164|N|Pick which zone you want to adventure in first from Scouting Map.|PRE|46931|
+A Area to Explore|QID|47512^47513^47514|M|41.77,69.35|Z|1164|N|Pick Zuldazar from the map.|PRE|46931|
 t Nazmir|QID|47512|M|40.50,68.25|Z|1164|N|To Princess Talanji take the elevator behind you, she is on her throne.|
 t Vol'dun|QID|47513|M|40.50,68.25|Z|1164|N|To Princess Talanji take the elevator behind you, she is on her throne.|
 t Zuldazar|QID|47514|M|40.50,68.25|Z|1164|N|To Princess Talanji take the elevator behind you, she is on her throne.|
@@ -58,7 +39,7 @@ h The Great Seal|ACTIVE|47103^47313^49615|M|48.50,71.75|Z|The Great Seal!Dazar'a
 ; professions
 N Cooking|ACTIVE|49615|M|28.44,50.42|Z|1164|N|Train BfA Cooking at T'sarah the Royal Chef.|P|Cooking;185|RECIPE|259430|;
 N Archaeology|ACTIVE|49615|M|36.17,46.42|Z|1164|N|Train BfA Archaeology at Examiner Alerinda who wanders around in the Vault of Kings. Check off manually when done.|P|Archaeology;794|RECIPE|278910|;need to determine correct spell ID to autocomplete
-R Terrace of Crafters|AVAILABLE|51465|M|43.15,35.51|Z|Dazar'alor|N|Run down to Terrace of the Crafters to train you various professions.|
+R Terrace of Crafters|AVAILABLE|51465|M|43.15,35.51|Z|Dazar'alor|N|Run down to Terrace of the Crafters to train your various professions.|
 N Skinning|ACTIVE|49615|M|43.76,34.67|Z|Dazar'alor|N|Train BfA skinning at Ranna the Cutta.|P|Skinning;393|RECIPE|257152|;
 N Leatherworking|ACTIVE|49615|M|44.07,34.65|Z|Dazar'alor|N|Train BfA Leatherworking at Xanjo.|P|Leatherworking;165|RECIPE|256756|;265813
 N Tailoring|ACTIVE|49615|M|44.49,33.90|Z|Dazar'alor|N|Train BfA Tailoring at Pin'jin the Patient.|P|Tailoring;197|RECIPE|257103|;265815
@@ -66,9 +47,6 @@ N Herbalism|ACTIVE|49615|M|42.11,35.61|Z|Dazar'alor|N|Train BfA Herbalism at Jah
 N Alchemy|ACTIVE|49615|M|42.23,37.96|Z|Dazar'alor|N|Train BfA Alchemy at Clever Kumali.|P|Alchemy;171|RECIPE|252382|;
 N Inscription|ACTIVE|49615|M|42.33,39.72|Z|Dazar'alor|N|Train BfA Inscription at Chronicler Grazzul.|P|Inscription;773|RECIPE|264777|;265809
 N Engineering|ACTIVE|49615|M|45.13,40.58|Z|Dazar'alor|N|Train BfA Engineering at Shuga Blastcaps.|P|Engineering;202|RECIPE|255392|;265807
-A A Load of Scrap|QID|51465|M|45.03,39.61|Z|Dazar'alor|N|From Myxle "The Searat" Gutwrench.|
-C A Load of Scrap|QID|51465|M|44.96,39.97|Z|Dazar'alor|NC|N|Find the Tattered pants in your bags and put them in the Shred-Master MkI. You can now destroy crafted and dropped gear to get tradeskill mats based on the type of item being scrapped. (much like disenchanting, but for other mats.)|
-T A Load of Scrap|QID|51465|M|45.03,39.61|Z|Dazar'alor|N|To Myxle "The Searat" Gutwrench.|
 N Mining|ACTIVE|49615|M|44.13,38.97|Z|Dazar'alor|N|Train BfA Mining at Secott the Goldsmith.|P|Mining;186|RECIPE|253333|;267482
 N Blacksmithing|ACTIVE|49615|M|43.65,38.30|Z|Dazar'alor|N|Train BfA Blacksmithing at Forgemaster Zak'aal.|P|Blacksmithing;164|RECIPE|253183|;
 N Jewelcrafting|ACTIVE|49615|M|47.05,37.94|Z|Dazar'alor|N|Train BfA Jewelcrafting at Seshuli.|P|Jewelcrafting;755|RECIPE|256689|;265811

--- a/WoWPro_Leveling/Horde/INTRO_Exiles_Reach.lua
+++ b/WoWPro_Leveling/Horde/INTRO_Exiles_Reach.lua
@@ -212,12 +212,9 @@ A Welcome to Orgrimmar|QID|60343|M|52.51,88.06|Z|Orgrimmar|N|From Warlord Breka 
 T Welcome to Orgrimmar|QID|60343|M|51.92,85.35|Z|Orgrimmar|N|To Cork Fizzlepop.|
 A Finding Your Way|QID|60344|M|51.92,85.35|Z|Orgrimmar|N|From Cork Fizzlepop.|PRE|60343|
 C Finding Your Way|QID|60344|M|52.46,84.19|Z|Orgrimmar|QO|1|CHAT|N|Ask a guard for directions to the Stable Master.|
-C Finding Your Way|QID|60344|M|52.23,84.44|Z|Orgrimmar|QO|2|CHAT|N|Speak with Cork Fizzlepop to lead the way.|
-C Finding Your Way|QID|60344|M|62.09,33.24|Z|Orgrimmar|QO|3|NC|N|Follow Cork Fizzlepop to the Stables. You must be near him for him to move towards the stables, and he must reach the stables for the quest to be completable.|
+C Finding Your Way|QID|60344|M|52.23,84.44|Z|Orgrimmar|QO|2|CHAT|N|Speak with Cork Fizzlepop for a ride.|
+C Finding Your Way|QID|60344|M|62.09,33.24|Z|Orgrimmar|QO|3|NC|N|Enjoy the ride. Don't dismount from the bike as it can cause this quest to bug.|
 T Finding Your Way|QID|60344|M|61.43,32.76|Z|Orgrimmar|N|To Rohaka Tuskmaul.|
-A License to Ride|QID|60345|M|61.43,32.76|Z|Orgrimmar|N|From Rohaka Tuskmaul.|PRE|60344|
-C License to Ride|QID|60345|M|61.32,34.59|Z|Orgrimmar|NC|N|Speak to Kildar and learn Apprentice Riding.|
-T License to Ride|QID|60345|M|61.43,32.76|Z|Orgrimmar|N|To Rohaka Tuskmaul.|
 ; Choose your class sp
 A What's Your Specialty?|QID|60346|M|61.44,32.96|Z|Orgrimmar|N|From Cork Fizzlepop.|PRE|60345|C|Druid|
 C What's Your Specialty?|QID|60346|M|72.92,43.25|Z|Orgrimmar|QO|1|CHAT|N|Speak with Telotha Pinegrove to learn about specializations.|C|Druid|


### PR DESCRIPTION
Finding your Way: Cork now gives the player a free ride to the stables
License to Ride: Removed from the game as the riding skill is now grated automatically at L10
The Stormwind Extraction: The entire scenario's been removed from the game, Players now spawn directly in Daz'aralor
Area to Explore: Players are no longer given a choice of the order of zones they do - they have to do Zuldazar first
A Load of Scrap: Quest is no longer offered