### PR TITLE
Possible Tabbed Config Page with an Extra tab for Version and About Wowpro

### DIFF
--- a/WoWPro/WoWPro_Config.lua
+++ b/WoWPro/WoWPro_Config.lua
@@ -1,16 +1,14 @@
--- luacheck: globals pairs ipairs
-
------------------------------
---      WoWPro_Config      --
------------------------------
-
 local L = WoWPro_Locale
-local config = _G.LibStub("AceConfig-3.0")
-local dialog = _G.LibStub("AceConfigDialog-3.0")
+local AceConfig = LibStub("AceConfig-3.0")
+local AceConfigDialog = LibStub("AceConfigDialog-3.0")
 local LSM = _G.LibStub("LibSharedMedia-3.0")
 
 local MediaType_BORDER = LSM.MediaType.BORDER
 LSM:Register(MediaType_BORDER, "Eli Border", [[Interface\AddOns\WoWPro\Textures\Eli-Edge.tga]])
+
+function WoWPro:CreateConfig()
+    -- Add your code here...
+end
 
 function WoWPro:RefreshConfig()
     WoWPro:LoadGuide()
@@ -37,907 +35,926 @@ local soundfiles = {
     ["Boat Docked"] = 566652,
 }
 
-
-local function CreateDisplayConfig()
-    return {
-        type = "group",
-        order = 2,
-        name = L["Guide Display"],
-        desc = L["Options that alter the way the guide frame looks"],
-        args = {
-            desc = {
-                order = 0,
-                type = "description",
-                name = L["On this page you can edit the way the guide frame looks."],
-            },
-            blank1 = {
-                order = 1,
-                type = "description",
-                name = " ",
-            },
-            drag = {
-                order = 2,
-                type = "toggle",
-                name = L["Enable Drag"],
-                desc = L["Enables the guide window to be moved by clicking anywhere on it and dragging"],
-                get = function(info) return WoWProDB.profile.drag end,
-                set = function(info,val) WoWProDB.profile.drag = val
-                    WoWPro.DragSet() end,
-            },
-            padding = {
-                order = 4,
-                type = "range",
-                name = L["Padding"],
-                desc = L["The padding determines how much blank space is left between the guide text and the border of the guide frame."],
-                min = 0, max = 20, step = 1,
-                get = function(info) return WoWProDB.profile.pad end,
-                set = function(info,val) WoWProDB.profile.pad = val
-                    WoWPro.PaddingSet(); WoWPro.RowSizeSet() end
-            },
-            spacing = {
-                order = 5,
-                type = "range",
-                name = L["Spacing"],
-                desc = L["Spacing determines how much blank space is left between lines in the guide text. "],
-                min = 0, max = 10, step = 1,
-                get = function(info) return WoWProDB.profile.space end,
-                set = function(info,val) WoWProDB.profile.space = val
-                    WoWPro.RowSizeSet() end
-            },
-            hide = {
-                order = 6,
-                type = "toggle",
-                name = L["Enable Instance Hiding"],
-                desc = L["Enables/Disables hiding the active module when inside an instance (Dungeon, Arena ...), unless the guide wants you there!"],
-                get = function(info) return WoWProCharDB.AutoHideInsideInstances ; end,
-                set = function(info,val)
-                        if WoWProCharDB.AutoHideInsideInstances == true then WoWProCharDB.AutoHideInsideInstances=false; else WoWProCharDB.AutoHideInsideInstances=true; end
-                    end
-            },
-            notify = {
-                order = 6.5,
-                type = "toggle",
-                name = L["Enable Instance Notify"],
-                desc = L["Enables/Disables notifying when inside an instance (Dungeon, Arena ...), unless the guide wants you there!"],
-                get = function(info) return WoWProCharDB.AutoHideInsideInstancesNotify ; end,
-                set = function(info,val)
-                        if WoWProCharDB.AutoHideInsideInstancesNotify == true then WoWProCharDB.AutoHideInsideInstancesNotify=false; else WoWProCharDB.AutoHideInsideInstancesNotify=true; end
-                    end
-            },
-            combathide = {
-                order = 7,
-                type = "toggle",
-                name = L["Enable Combat Hiding"],
-                desc = L["Enables/Disables hiding the active module when you are in combat."],
-                get = function(info) return WoWProCharDB.AutoHideInCombat ; end,
-                set = function(info,val)
-                        if WoWProCharDB.AutoHideInCombat == true then WoWProCharDB.AutoHideInCombat=false; else WoWProCharDB.AutoHideInCombat=true; end
-                    end
-            },
-            noteshow = {
-                order = 8,
-                type = "toggle",
-                name = L["Mouseover Notes"],
-                desc = L["Show notes on mouseover instead of always displaying them."],
-                get = function(info) return WoWProDB.profile.mousenotes end,
-                set = function(info,val) WoWProDB.profile.mousenotes = val
-                    WoWPro.RowSizeSet() end
-            },
-            minimap = {
-                order = 9,
-                type = "toggle",
-                name = L["Minimap Button"],
-                desc = L["Show/hide WoW-Pro mini map button."],
-                get = function(info) return not WoWProDB.profile.minimap.hide end,
-                set = function(info,val) WoWProDB.profile.minimap.hide = not val
-                     WoWPro.MinimapSet() end
-            },
-            track = {
-                order = 10,
-                type = "toggle",
-                name = L["Quest Tracking"],
-                desc = L["Allows tracking of quests in the guide frame"],
-                get = function(info) return WoWProDB.profile.track end,
-                set = function(info,val) WoWProDB.profile.track = val
-                    WoWPro:UpdateGuide("Config: Quest Tracking") end
-            },
-            showcoords = {
-                order = 11,
-                type = "toggle",
-                name = L["Show Coordinates"],
-                desc = L["Shows the coordinates in the note text."],
-                get = function(info) return WoWProDB.profile.showcoords end,
-                set = function(info,val) WoWProDB.profile.showcoords = val
-                    WoWPro:UpdateGuide("Config: Show Coordinates") end
-            },
-            autoload = {
-                order = 12,
-                type = "toggle",
-                name = L["Auto-Load Guide"],
-                desc = L["Will automatically load the next guide when you complete one."],
-                get = function(info) return WoWProDB.profile.autoload end,
-                set = function(info,val) WoWProDB.profile.autoload = val end
-            },
-            blank2 = {
-                order = 20,
-                type = "description",
-                name = " ",
-            },
-            guidescroll = {
-                order = 21,
-                type = "toggle",
-                name = L["Scroll Mode"],
-                desc = L["Displays full, scrollable guide in guide frame, instead of need-to-know info."],
-                get = function(info) return WoWProDB.profile.guidescroll end,
-                set = function(info,val) WoWProDB.profile.guidescroll = val
-                    WoWPro:TitlebarSet()
-                    WoWPro:UpdateGuide("Config: Scroll Mode") end
-            },
-            checksoundfile = {
-                order = 22,
-                type = "select",
-                name = L["Step Completed Sound"],
-                desc = L["Sound played when a guide step is completed"],
-                values = function() local values = {}
-                    for k,v in pairs(soundfiles) do
-                        values[v] = k
-                    end
-                    return values end,
-                get = function(info)
-                    return WoWProDB.profile.checksoundfile end,
-                set = function(info,val) WoWProDB.profile.checksoundfile = val
-                    _G.PlaySoundFile(val) end,
-                disabled = function(...) return not WoWProDB.profile.checksound end,
-            },
-            checksound = {
-                order = 23,
-                type = "toggle",
-                name = L["Enable Sound"],
-                desc = L["Plays a check-off sound when a guide step is completed."],
-                get = function(info) return WoWProDB.profile.checksound end,
-                set = function(info,val) WoWProDB.profile.checksound = val end
-            },
-            lefty = {
-                order = 24,
-                type = "toggle",
-                name = L["Left Handed"],
-                desc = L["Put Use and Target Icons on the right side of the guide window."],
-                get = function(info) return WoWProDB.profile.leftside end,
-                set = function(info,val) WoWProDB.profile.leftside = val end
-            },
-            blank3 = {
-                order = 30,
-                type = "description",
-                name = " ",
-            },
-            resizeheading = {
-                order = 31,
-                type = "header",
-                name = L["Resize Settings"],
-            },
-            resize = {
-                order = 32,
-                type = "toggle",
-                name = L["Resize Handle"],
-                desc = L["Enables the guide window to be resized using the resize handle in the lower right corner. \nTurns off auto resizing."],
-                get = function(info) return WoWProDB.profile.resize end,
-                set = function(info,val) WoWProDB.profile.resize = val
-                    if val then WoWProDB.profile.autoresize = false end
-                    WoWPro.ResizeSet() end
-            },
-            autoresize = {
-                order = 33,
-                type = "toggle",
-                name = L["Auto Resize"],
-                desc = L["Guide will automatically resize to the set number of steps. \nManual resize recommended for advanced users only. \nHides drag handle."],
-                get = function(info) return WoWProDB.profile.autoresize end,
-                set = function(info,val) WoWProDB.profile.autoresize = val
-                    if val then WoWProDB.profile.resize = false end
-                    WoWPro.ResizeSet(); WoWPro.RowSizeSet() end
-            },
-            numsteps = {
-                order = 34,
-                type = "range",
-                name = L["Auto Resize: Number of Steps"],
-                desc = L["Number of steps displayed in the guide window. \nThe window is automatically resized to show this number of steps. \nDoes not include sticky steps."],
-                min = 1, max = 15, step = 1,
-                get = function(info) return WoWProDB.profile.numsteps end,
-                set = function(info,val) WoWProDB.profile.numsteps = val
-                    WoWPro.RowSizeSet() end,
-                width = "double"
-            },
-            minresizeh = {
-                order = 35,
-                type = "range",
-                name = L["Min Resize - Horiz"],
-                desc = L["Minimum horizontal pixel size the guide window can be set to."],
-                min = 50, max = 1000, step = 10,
-                get = function(info) return WoWProDB.profile.hminresize end,
-                set = function(info,val) WoWProDB.profile.hminresize = val
-                    WoWPro:ResizeSet(); WoWPro.RowSizeSet() end
-            },
-            minresizev = {
-                order = 36,
-                type = "range",
-                name = L["Min Resize - Vert"],
-                desc = L["Minimum vertical pixel size the guide window can be set to."],
-                min = 50, max = 1000, step = 10,
-                get = function(info) return WoWProDB.profile.vminresize end,
-                set = function(info,val) WoWProDB.profile.vminresize = val
-                    WoWPro:ResizeSet(); WoWPro.RowSizeSet() end
-            },
-            blank4 = {
-                order = 40,
-                type = "description",
-                name = " ",
-            },
-            titleheading = {
-                order = 41,
-                type = "header",
-                name = L["Title Bar"],
-            },
-            titlebar = {
-                order = 42,
-                type = "toggle",
-                name = L["Enable Title Bar"],
-                desc = L["Enables/disables the title bar attached to the guide window."],
-                get = function(info) return WoWProDB.profile.titlebar end,
-                set = function(info,val) WoWProDB.profile.titlebar = val
-                    WoWPro.TitlebarSet(); WoWPro.PaddingSet(); WoWPro.RowSizeSet() end
-            },
-            titlecolor = {
-                order = 43,
-                type = "color",
-                name = L["Title Bar Color"],
-                desc = L["Background color for the title bar."],
-                hasAlpha = true,
-                get = function(info) return WoWProDB.profile.titlecolor[1], WoWProDB.profile.titlecolor[2], WoWProDB.profile.titlecolor[3] ,WoWProDB.profile.titlecolor[4] end,
-                set = function(info,r,g,b,a)
-                    WoWProDB.profile.titlecolor = {r,g,b,a}
-                    WoWPro.TitlebarSet() end
-            },
-            blank5 = {
-                order = 50,
-                type = "description",
-                name = " ",
-            },
-            bgheading = {
-                order = 51,
-                type = "header",
-                name = L["Backgrounds"],
-            },
-            bgtexture = {
-                order = 52,
-                type = "select",
-                name = L["Guide Window Background"],
-                desc = L["Texture used for the guide window background."],
-                values = function() local values = {}
-                    local list = LSM:List("background")
-                    local hashtable = LSM:HashTable("background")
-                    for i,handle in ipairs(list) do
-                        values[hashtable[handle]] = handle
-                    end
-                    return values end,
-                get = function(info)
-                    return WoWProDB.profile.bgtexture end,
-                set = function(info,val) WoWProDB.profile.bgtexture = val
-                    WoWPro.BackgroundSet() end
-            },
-            bgcolor = {
-                order = 53,
-                type = "color",
-                name = L["Guide Window Color"],
-                desc = L["Background color for the guide window"],
-                hasAlpha = true,
-                get = function(info) return WoWProDB.profile.bgcolor[1], WoWProDB.profile.bgcolor[2], WoWProDB.profile.bgcolor[3] ,WoWProDB.profile.bgcolor[4] end,
-                set = function(info,r,g,b,a)
-                    WoWProDB.profile.bgcolor = {r,g,b,a}
-                    WoWPro.BackgroundSet() end
-            },
-            bordertexture = {
-                order = 54,
-                type = "select",
-                name = L["Border Texture"],
-                desc = L["Texture used for the guide window border."],
-                values = function() local values = {}
-                    local list = LSM:List("border")
-                    local hashtable = LSM:HashTable("border")
-                    for i,handle in ipairs(list) do
-                        values[hashtable[handle]] = handle
-                    end
-                    return values end,
-                get = function(info)
-                    return WoWProDB.profile.bordertexture end,
-                set = function(info,val) WoWProDB.profile.bordertexture = val
-                    WoWPro.border = true
-                    WoWPro.BackgroundSet() end
-            },
-            border = {
-                order = 55,
-                type = "toggle",
-                name = L["Enable Border"],
-                desc = L["Enables/disables the border around the guide window."],
-                get = function(info) return WoWProDB.profile.border end,
-                set = function(info,val) WoWProDB.profile.border = val
-                    WoWPro.BackgroundSet() end
-            },
-            stickytexture = {
-                order = 56,
-                type = "select",
-                name = L["Sticky Background"],
-                desc = L["Texture used for sticky step background."],
-                values = function() local values = {}
-                    local list = LSM:List("background")
-                    local hashtable = LSM:HashTable("background")
-                    for i,handle in ipairs(list) do
-                        values[hashtable[handle]] = handle
-                    end
-                    return values end,
-                get = function(info)
-                    return WoWProDB.profile.stickytexture end,
-                set = function(info,val) WoWProDB.profile.stickytexture = val
-                    WoWPro.BackgroundSet(); WoWPro.RowColorSet() end
-            },
-            stickycolor = {
-                order = 57,
-                type = "color",
-                name = L["Sticky Step Color"],
-                desc = L["Background color for the sticky step frames."],
-                hasAlpha = true,
-                get = function(info) return WoWProDB.profile.stickycolor[1], WoWProDB.profile.stickycolor[2], WoWProDB.profile.stickycolor[3] ,WoWProDB.profile.stickycolor[4] end,
-                set = function(info,r,g,b,a)
-                    WoWProDB.profile.stickycolor = {r,g,b,a}
-                    WoWPro.BackgroundSet(); WoWPro.RowColorSet() end
-            },
-            blank6 = {
-                order = 60,
-                type = "description",
-                name = " ",
-            },
-            textheading = {
-                order = 61,
-                type = "header",
-                name = L["Text Formatting"],
-            },
-            stepfont = {
-                order = 62,
-                type = 'select',
-                dialogControl = 'LSM30_Font',
-                name = L["Step Font"],
-                desc = L["Font used for the main step text."],
-                values = LSM:HashTable("font"),
-                get = function(info) local values = {}
-                    local list = LSM:List("font")
-                    local hashtable = LSM:HashTable("font")
-                    for i,handle in ipairs(list) do
-                        values[hashtable[handle]] = handle
-                    end
-                    local hash = values[WoWProDB.profile.stepfont]
-                    return hash end,
-                set = function(info,val)
-                    local hashtable = LSM:HashTable("font")
-                    WoWProDB.profile.stepfont = hashtable[val]
-                    WoWPro.RowFontSet() end
-            },
-            steptextsize = {
-                order = 63,
-                type = "range",
-                name = L["Step Text Size"],
-                desc = L["Size of the main step text."],
-                min = 1, max = 30, step = 1,
-                get = function(info) return WoWProDB.profile.steptextsize end,
-                set = function(info,val) WoWProDB.profile.steptextsize = val
-                    WoWPro.RowFontSet()
-                    WoWPro.RowSizeSet() end
-            },
-            steptextcolor = {
-                order = 64,
-                type = "color",
-                name = L["Step Text Color"],
-                desc = L["Color of the main step text."],
-                width = "full",
-                get = function(info) return WoWProDB.profile.steptextcolor[1], WoWProDB.profile.steptextcolor[2], WoWProDB.profile.steptextcolor[3] end,
-                set = function(info,r,g,b)
-                    WoWProDB.profile.steptextcolor = {r,g,b}
-                    WoWPro.RowFontSet() end
-            },
-            notefont = {
-                order = 65,
-                type = 'select',
-                dialogControl = 'LSM30_Font',
-                name = L["Note Font"],
-                desc = L["Font used for the note text."],
-                values = LSM:HashTable("font"),
-                get = function(info) local values = {}
-                    local list = LSM:List("font")
-                    local hashtable = LSM:HashTable("font")
-                    for i,handle in ipairs(list) do
-                        values[hashtable[handle]] = handle
-                    end
-                    local hash = values[WoWProDB.profile.notefont]
-                    return hash end,
-                set = function(info,val)
-                    local hashtable = LSM:HashTable("font")
-                    WoWProDB.profile.notefont = hashtable[val]
-                    WoWPro.RowFontSet() end
-            },
-            notetextsize = {
-                order = 66,
-                type = "range",
-                name = L["Note Text Size"],
-                desc = L["Size of the note text."],
-                min = 1, max = 30, step = 1,
-                get = function(info) return WoWProDB.profile.notetextsize end,
-                set = function(info,val) WoWProDB.profile.notetextsize = val
-                    WoWPro.RowFontSet()
-                    WoWPro.RowSizeSet() end
-            },
-            notetextcolor = {
-                order = 67,
-                type = "color",
-                name = L["Note Text Color"],
-                desc = L["Color of the note text."],
-                width = "full",
-                get = function(info) return WoWProDB.profile.notetextcolor[1], WoWProDB.profile.notetextcolor[2], WoWProDB.profile.notetextcolor[3] end,
-                set = function(info,r,g,b)
-                    WoWProDB.profile.notetextcolor = {r,g,b}
-                    WoWPro.RowFontSet() end
-            },
-            trackfont = {
-                order = 68,
-                type = "select",
-                dialogControl = 'LSM30_Font',
-                name = L["Tracker Font"],
-                desc = L["Font used for the tracking text."],
-                values = LSM:HashTable("font"), -- pull in your font list from LSM
-                get = function(info) local values = {}
-                    local list = LSM:List("font")
-                    local hashtable = LSM:HashTable("font")
-                    for i,handle in ipairs(list) do
-                        values[hashtable[handle]] = handle
-                    end
-                    local hash = values[WoWProDB.profile.trackfont]
-                    return hash end,
-                set = function(info,val)
-                    local hashtable = LSM:HashTable("font")
-                    WoWProDB.profile.trackfont = hashtable[val]
-                    WoWPro.RowFontSet() end
-            },
-            tracktextsize = {
-                order = 69,
-                type = "range",
-                name = L["Tracker Text Size"],
-                desc = L["Size of the tracking text."],
-                min = 1, max = 30, step = 1,
-                get = function(info) return WoWProDB.profile.tracktextsize end,
-                set = function(info,val) WoWProDB.profile.tracktextsize = val
-                    WoWPro.RowFontSet()
-                    WoWPro.RowSizeSet() end
-            },
-            tracktextcolor = {
-                order = 70,
-                type = "color",
-                name = L["Tracker Text Color"],
-                desc = L["Color of the tracking text."],
-                width = "full",
-                get = function(info) return WoWProDB.profile.tracktextcolor[1], WoWProDB.profile.tracktextcolor[2], WoWProDB.profile.tracktextcolor[3] end,
-                set = function(info,r,g,b)
-                    WoWProDB.profile.tracktextcolor = {r,g,b}
-                    WoWPro.RowFontSet() end
-            },
-            titlefont = {
-                order = 71,
-                type = "select",
-                dialogControl = 'LSM30_Font',
-                name = L["Title Bar Font"],
-                desc = L["Font used on the title bar."],
-                values = LSM:HashTable("font"), -- pull in your font list from LSM
-                get = function(info) local values = {}
-                    local list = LSM:List("font")
-                    local hashtable = LSM:HashTable("font")
-                    for i,handle in ipairs(list) do
-                        values[hashtable[handle]] = handle
-                    end
-                    local hash = values[WoWProDB.profile.titlefont]
-                    return hash end,
-                set = function(info,val)
-                    local hashtable = LSM:HashTable("font")
-                    WoWProDB.profile.titlefont = hashtable[val]
-                    WoWPro:TitlebarSet() end
-            },
-            titletextsize = {
-                order = 72,
-                type = "range",
-                name = L["Title Bar Text Size"],
-                desc = L["Size of the title bar text."],
-                min = 1, max = 30, step = 1,
-                get = function(info) return WoWProDB.profile.titletextsize end,
-                set = function(info,val) WoWProDB.profile.titletextsize = val
-                    WoWPro:TitlebarSet() end
-            },
-            titletextcolor = {
-                order = 73,
-                type = "color",
-                name = L["Title Bar Text Color"],
-                desc = L["Color of the title bar text."],
-                width = "full",
-                get = function(info) return WoWProDB.profile.titletextcolor[1], WoWProDB.profile.titletextcolor[2], WoWProDB.profile.titletextcolor[3] end,
-                set = function(info,r,g,b)
-                    WoWProDB.profile.titletextcolor = {r,g,b}
-                    WoWPro:TitlebarSet() end
-            },
-            stickytitlefont = {
-                order = 74,
-                type = "select",
-                dialogControl = 'LSM30_Font',
-                name = L["'As you go:' Font"],
-                desc = L["Font used on the top of the sticky frame."],
-                values = LSM:HashTable("font"), -- pull in your font list from LSM
-                get = function(info) local values = {}
-                    local list = LSM:List("font")
-                    local hashtable = LSM:HashTable("font")
-                    for i,handle in ipairs(list) do
-                        values[hashtable[handle]] = handle
-                    end
-                    local hash = values[WoWProDB.profile.stickytitlefont]
-                    return hash end,
-                set = function(info,val)
-                    local hashtable = LSM:HashTable("font")
-                    WoWProDB.profile.stickytitlefont = hashtable[val]
-                    WoWPro.RowFontSet()
-                    WoWPro.RowSizeSet() end
-            },
-            stickytitletextsize = {
-                order = 75,
-                type = "range",
-                name = L["'As you go:' Text Size"],
-                desc = L["Size of the text on the top of the sticky frame."],
-                min = 1, max = 30, step = 1,
-                get = function(info) return WoWProDB.profile.stickytitletextsize end,
-                set = function(info,val) WoWProDB.profile.stickytitletextsize = val
-                    WoWPro.RowFontSet()
-                    WoWPro.RowSizeSet() end
-            },
-            stickytitletextcolor = {
-                order = 76,
-                type = "color",
-                name = L["'As you go:' Text Color"],
-                desc = L["Color of the text on the top of the sticky frame."],
-                width = "full",
-                get = function(info) return WoWProDB.profile.stickytitletextcolor[1], WoWProDB.profile.stickytitletextcolor[2], WoWProDB.profile.stickytitletextcolor[3] end,
-                set = function(info,r,g,b)
-                    WoWProDB.profile.stickytitletextcolor = {r,g,b}
-                    WoWPro.RowFontSet() end
-            },
-        }
-    }
-end
-
-local function createBlizzOptions()
-    config:RegisterOptionsTable("WoWPro-Bliz", {
-        name = L["WoW-Pro Guides"],
-        type = "group",
-        args = {
-            version = {
-                order = 1,
-                type = "description",
-                name = L["Version"]..": "..WoWPro.Version,
-            },
-            help = {
-                order = 2,
-                type = "description",
-                name = L["Account wide settings for WoW-Pro's guide addon."],
-            },
-            header1 = {
-                order = 3,
-                type = "header",
-                name = "Addon Enable and Debugging",
-            },
-            enable = {
-                order = 10,
-                type = "toggle",
-                name = L["Enable Addon"],
-                desc = L["Enables/Disables showing the WoW-Pro guide addons."],
-                get = function(info) return WoWProCharDB.Enabled end,
-                set = function(info,val)
-                        if WoWProCharDB.Enabled then
-                            WoWProCharDB.Enabled = false
-                            WoWPro:Disable()
-                        else
-                            WoWProCharDB.Enabled = true
-                            WoWPro:Enable()
-                        end
-                    end
-            },
-            enableDebug = {
-                order = 11,
-                type = "toggle",
-                name = L["Enable Debug"],
-                desc = L["Enables/Disables debug logging"],
-                get = function(info) return WoWPro.DebugLevel > 0 end,
-                set = function(info,val)
-                        if WoWPro.DebugLevel > 0 then
-                            WoWPro.DebugLevel = 0
-                        else
-                            WoWPro.DebugLevel = 1
-                        end
-                        WoWProCharDB.DebugLevel = WoWPro.DebugLevel
-                    end
-            },
-            header2 = {
-                order = 15,
-                type = "header",
-                name = "Automation",
-            },
-            autoSelect = {
-                order = 16,
-                type = "toggle",
-                name = L["Auto Select"],
-                desc = L["Enables/Disables automatically selecting quests/flights from NPCs"],
-                get = function(info) return WoWProCharDB.AutoSelect end,
-                set = function(info,val)
-                        if WoWProCharDB.AutoSelect == true then
-                            WoWProCharDB.AutoSelect = false
-                        else
-                            WoWProCharDB.AutoSelect = true
-                        end
-                    end
-            },
-            autoAccept = {
-                order = 17,
-                type = "toggle",
-                name = L["Auto Accept"],
-                desc = L["Enables/Disables automatically accepting quests from NPCs"],
-                get = function(info) return WoWProCharDB.AutoAccept end,
-                set = function(info,val)
-                        if WoWProCharDB.AutoAccept == true then
-                            WoWProCharDB.AutoAccept = false
-                        else
-                            WoWProCharDB.AutoAccept = true
-                        end
-                    end
-            },
-            autoTurnin = {
-                order = 18,
-                type = "toggle",
-                name = L["Auto Turnin"],
-                desc = L["Enables/Disables automatically turning in quests to NPCs"],
-                get = function(info) return WoWProCharDB.AutoTurnin end,
-                set = function(info,val)
-                        if WoWProCharDB.AutoTurnin == true then
-                            WoWProCharDB.AutoTurnin = false
-                        else
-                            WoWProCharDB.AutoTurnin = true
-                        end
-                    end
-            },
-            header3 = {
-                order = 20,
-                type = "header",
-                name = "Guide Modifiers",
-            },
-            petBattles = {
-                order = 21,
-                type = "toggle",
-                name = L["Enable Pet Battles"],
-                desc = L["Enables/Disables automatic pet battle team selection in some guides"],
-                get = function(info) return WoWProCharDB.EnablePetBattles end,
-                set = function(info,val)
-                        if WoWProCharDB.EnablePetBattles then
-                            WoWProCharDB.EnablePetBattles = false
-                        else
-                            WoWProCharDB.EnablePetBattles = true
-                        end
-                    end
-            },
-            doRares = {
-                order = 22,
-                type = "toggle",
-                name = L["Enable Rares"],
-                desc = L["Enables/Disables killing optional Rares in guides."],
-                get = function(info) return WoWProCharDB.EnableRares end,
-                set = function(info,val)
-                        if WoWProCharDB.EnableRares then
-                            WoWProCharDB.EnableRares = false
-                        else
-                            WoWProCharDB.EnableRares = true
-                        end
-                    end
-            },
-            doTreasures = {
-                order = 23,
-                type = "toggle",
-                name = L["Enable Treasures"],
-                desc = L["Enables/Disables treasure hunting steps in guides."],
-                get = function(info) return WoWProCharDB.EnableTreasures end,
-                set = function(info,val)
-                        if WoWProCharDB.EnableTreasures then
-                            WoWProCharDB.EnableTreasures = false
-                        else
-                            WoWProCharDB.EnableTreasures = true
-                        end
-                    end
-            },
-            doFlight = {
-                order = 24,
-                type = "toggle",
-                name = L["Skip Flights"],
-                desc = L["Skips most flight steps when you have flying in that zone."],
-                get = function(info) return WoWProCharDB.EnableFlight end,
-                set = function(info,val)
-                        if WoWProCharDB.EnableFlight then
-                            WoWProCharDB.EnableFlight = false
-                        else
-                            WoWProCharDB.EnableFlight = true
-                        end
-                    end
-            },
-            grank = {
-                order = 25,
-                type = "range",
-                name = L["Global Rank (Difficulty/Completeness)"],
-                desc = L["Governs how many steps will be skipped. Use 3 for the most completeness, 1 to skip all non-essential steps."],
-                min = 1, max = 3, step = 1,
-                get = function(info) return WoWProDB.profile.rank end,
-                set = function(info,val) WoWProDB.profile.rank = val
-                    if WoWProDB.char.currentguide and WoWProCharDB.Guide[WoWProDB.char.currentguide] then
-                        WoWProCharDB.Guide[WoWProDB.char.currentguide].skipped = {}
-                    end
-                    WoWPro.UpdateGuide("Config: GRank") end,
-                width = "double"
-            },
-            trank = {
-                order = 26,
-                type = "range",
-                name = L["Toon Rank (Difficulty/Completeness)"],
-                desc = L["Governs how many steps will be skipped. Use 3 for the most completeness, 1 to skip all non-essential steps."],
-                min = 1, max = 3, step = 1,
-                get = function(info) return WoWProCharDB.Rank[1] end,
-                set = function(info,val) WoWProCharDB.Rank[1] = val
-                    if WoWProDB.char.currentguide and WoWProCharDB.Guide[WoWProDB.char.currentguide] then
-                        WoWProCharDB.Guide[WoWProDB.char.currentguide].skipped = {}
-                    end
-                    WoWPro.UpdateGuide("Config: TRank") end,
-                width = "double"
-            },
-            header4 = {
-                order = 50,
-                type = "header",
-                name = "Master Addon Tools",
-            },
-            resetGuide = {
-                order = 51,
-                type = "execute",
-                name = L["Reset WoWPro Addons"],
-                desc = L["If a WoWPro addon is behaving oddly, this wipes all saved state across all characters. Log out and back in again to complete the reset."],
-                image = "Interface\\Addons\\WoWPro\\Textures\\inv_misc_enggizmos_27",
-                func =  function (info)
-                            WoWPro:RESET()
-                            _G.PlaySound(1026) -- Rabitt death
-                        end
-            },
-            resetLog = {
-                order = 52,
-                type = "execute",
-                name = L["Clear the log"],
-                desc = L["Wow-Pro's Debug Log"],
-                image = "Interface\\RaidFrame\\ReadyCheck-NotReady",
-                func =  function (info) WoWPro:LogClear("UI"); end
-            },
-            showLog = {
-                order = 53,
-                type = "execute",
-                name = L["Show the log"],
-                desc = L["Wow-Pro's Secret Debug Log"],
-                image = "Interface\\RaidFrame\\ReadyCheck-Ready",
-                func =  function (info) WoWPro:LogShow(); end
-            },
-            blank10 = {
-                order = 90,
-                type = "description",
-                name = " ",
-            },
-            aboutheader = {
-                order = 91,
-                type = "header",
-                name = "About WoW-Pro",
-            },
-            blank11 = {
-                order = 92,
-                type = "description",
-                name = " ",
-            },
-            about10 = {
-                order = 93,
-                type = "description",
-                fontSize = "medium",
-                name = "WoW-Pro is a addon collection by gamers, for gamers. The collection includes hundreds of free guides covering every facet of World of Warcraft."
-            },
-            blank12 = {
-                order = 94,
-                type = "description",
-                name = " ",
-            },
-            about14 = {
-                order = 99,
-                type = "description",
-                fontSize = "medium",
-                name =
-                    "Over the years WoW-Pro has grown into a huge, active community of gamers. "
-            },
-            blank18 = {
-                order = 100,
-                type = "description",
-                name = " ",
-            },
-            about15 = {
-                order = 101,
-                type = "description",
-                fontSize = "medium",
-                name =
-                    "The WoW-Pro addon has brought many of the guides we've built as a community into the game, "..
+local options = {
+    name = "Settings",
+    type = "group",
+    childGroups = "tab",
+    args = {
+        addonversion = {
+            name = "About",
+            order = 1,
+            type = "group",
+            args = {
+                version = {
+                    order = 1,
+                    type = "description",
+                    name = L["Version"]..": "..WoWPro.Version,
+                },
+                blank10 = {
+                    order = 90,
+                    type = "description",
+                    name = " ",
+                },
+                aboutheader = {
+                    order = 91,
+                    type = "header",
+                    name = "About WoW-Pro",
+                },
+                blank11 = {
+                    order = 92,
+                    type = "description",
+                    name = " ",
+                },
+                about10 = {
+                    order = 93,
+                    type = "description",
+                    fontSize = "medium",
+                    name = "WoW-Pro is a addon collection by gamers, for gamers. The collection includes hundreds of free guides covering every facet of World of Warcraft."
+                },
+                blank12 = {
+                    order = 94,
+                    type = "description",
+                    name = " ",
+                },
+                about14 = {
+                    order = 99,
+                    type = "description",
+                    fontSize = "medium",
+                    name = "Over the years WoW-Pro has grown into a huge, active community of gamers. "
+                },
+                blank18 = {
+                    order = 100,
+                    type = "description",
+                    name = " ",
+                },
+                about15 = {
+                    order = 101,
+                    type = "description",
+                    fontSize = "medium",
+                    name = "The WoW-Pro addon has brought many of the guides we've built as a community into the game, "..
                     "and built on them since WotLK to Classic(s) and Dragonflight. Drop by on Discord and say hello!"
-            },
-            blank19 = {
-                order = 102,
-                type = "description",
-                name = "",
-                image = "Interface/AddOns/WoWPro/Textures/Discord",
-                imageWidth = 32,
-                imageHeight = 32,
-                width = "half"
-            },
-            about16 = {
-                order = 103,
-                type = "input",
-                name = "Discord",
-                get = function () return "https://discord.gg/aarduK7"; end,
-                set = function () return "https://discord.gg/aarduK7"; end,
-                icon = "Interface\\AddOns\\WoWPro\\Textures\\Discord",
+                },
+                discordButton = {
+                    order = 1.2,
+                    name = ("Join Discord"), -- TODO locale
+                    type = "execute",
+                    width = "normal",
+                    func = function()
+                        local url = "https://discord.gg/aarduK7"
+                        StaticPopupDialogs["WoWPro_DiscordURL"] = {
+                            text = "Press Ctrl & C to copy this link and paste into your favorite Browser",
+                            button1 = OKAY,
+                            hasEditBox = true,
+                            hasWideEditBox = true,
+                            editBoxWidth = 350,
+                            OnShow = function(self, data)
+                                self.editBox:SetText(url)
+                                self.editBox:HighlightText()
+                            end,
+                            timeout = 0,
+                            exclusive = true,
+                            whileDead = true,
+                            hideOnEscape = true,
+                        }
+                        StaticPopup_Show("WoWPro_DiscordURL", url)
+                    end
+                },
             },
         },
-    })
-
-
-    dialog:SetDefaultSize("WoWPro-Bliz", 600, 400)
-    dialog:AddToBlizOptions("WoWPro-Bliz", "WoW-Pro")
-
-    -- Display Options
-    local display = CreateDisplayConfig()
-    config:RegisterOptionsTable("WoWPro-Display", display)
-    dialog:AddToBlizOptions("WoWPro-Display", display.name, "WoW-Pro")
-
-    -- Profile Options
-    config:RegisterOptionsTable("WoWPro-Profile", _G.LibStub("AceDBOptions-3.0"):GetOptionsTable(WoWProDB))
-    dialog:AddToBlizOptions("WoWPro-Profile", "WoW-Pro Profiles", "WoW-Pro")
-
-    -- Expert Options
-    local expert = {
-        name = L["WoW-Pro Expert"],
-        type = "group",
-        args = {
-            version = {
-                order = 1,
-                type = "description",
-                name = L["Version"]..": "..WoWPro.Version,
+        general = {
+            name = "General",
+            order = 1.5,
+            type = "group",
+            args = {
+                header1 = {
+                    order = 3,
+                    type = "header",
+                    name = "Addon Enable and Debugging",
+                },
+                enable = {
+                    order = 10,
+                    type = "toggle",
+                    name = L["Enable Addon"],
+                    desc = L["Enables/Disables showing the WoW-Pro guide addons."],
+                    get = function(info) return WoWProCharDB.Enabled end,
+                    set = function(info,val)
+                            if WoWProCharDB.Enabled then
+                                WoWProCharDB.Enabled = false
+                                WoWPro:Disable()
+                            else
+                                WoWProCharDB.Enabled = true
+                                WoWPro:Enable()
+                            end
+                        end
+                },
+                enableDebug = {
+                    order = 11,
+                    type = "toggle",
+                    name = L["Enable Debug"],
+                    desc = L["Enables/Disables debug logging"],
+                    get = function(info) return WoWPro.DebugLevel > 0 end,
+                    set = function(info,val)
+                            if WoWPro.DebugLevel > 0 then
+                                WoWPro.DebugLevel = 0
+                            else
+                                WoWPro.DebugLevel = 1
+                            end
+                            WoWProCharDB.DebugLevel = WoWPro.DebugLevel
+                        end
+                },
+                header2 = {
+                    order = 15,
+                    type = "header",
+                    name = "Automation",
+                },
+                autoSelect = {
+                    order = 16,
+                    type = "toggle",
+                    name = L["Auto Select"],
+                    desc = L["Enables/Disables automatically selecting quests/flights from NPCs"],
+                    get = function(info) return WoWProCharDB.AutoSelect end,
+                    set = function(info,val)
+                            if WoWProCharDB.AutoSelect == true then
+                                WoWProCharDB.AutoSelect = false
+                            else
+                                WoWProCharDB.AutoSelect = true
+                            end
+                        end
+                },
+                autoAccept = {
+                    order = 17,
+                    type = "toggle",
+                    name = L["Auto Accept"],
+                    desc = L["Enables/Disables automatically accepting quests from NPCs"],
+                    get = function(info) return WoWProCharDB.AutoAccept end,
+                    set = function(info,val)
+                            if WoWProCharDB.AutoAccept == true then
+                                WoWProCharDB.AutoAccept = false
+                            else
+                                WoWProCharDB.AutoAccept = true
+                            end
+                        end
+                },
+                autoTurnin = {
+                    order = 18,
+                    type = "toggle",
+                    name = L["Auto Turnin"],
+                    desc = L["Enables/Disables automatically turning in quests to NPCs"],
+                    get = function(info) return WoWProCharDB.AutoTurnin end,
+                    set = function(info,val)
+                            if WoWProCharDB.AutoTurnin == true then
+                                WoWProCharDB.AutoTurnin = false
+                            else
+                                WoWProCharDB.AutoTurnin = true
+                            end
+                        end
+                },
+                header3 = {
+                    order = 20,
+                    type = "header",
+                    name = "Guide Modifiers",
+                },
+                petBattles = {
+                    order = 21,
+                    type = "toggle",
+                    name = L["Enable Pet Battles"],
+                    desc = L["Enables/Disables automatic pet battle team selection in some guides"],
+                    get = function(info) return WoWProCharDB.EnablePetBattles end,
+                    set = function(info,val)
+                            if WoWProCharDB.EnablePetBattles then
+                                WoWProCharDB.EnablePetBattles = false
+                            else
+                                WoWProCharDB.EnablePetBattles = true
+                            end
+                        end
+                },
+                doRares = {
+                    order = 22,
+                    type = "toggle",
+                    name = L["Enable Rares"],
+                    desc = L["Enables/Disables killing optional Rares in guides."],
+                    get = function(info) return WoWProCharDB.EnableRares end,
+                    set = function(info,val)
+                            if WoWProCharDB.EnableRares then
+                                WoWProCharDB.EnableRares = false
+                            else
+                                WoWProCharDB.EnableRares = true
+                            end
+                        end
+                },
+                doTreasures = {
+                    order = 23,
+                    type = "toggle",
+                    name = L["Enable Treasures"],
+                    desc = L["Enables/Disables treasure hunting steps in guides."],
+                    get = function(info) return WoWProCharDB.EnableTreasures end,
+                    set = function(info,val)
+                            if WoWProCharDB.EnableTreasures then
+                                WoWProCharDB.EnableTreasures = false
+                            else
+                                WoWProCharDB.EnableTreasures = true
+                            end
+                        end
+                },
+                doFlight = {
+                    order = 24,
+                    type = "toggle",
+                    name = L["Skip Flights"],
+                    desc = L["Skips most flight steps when you have flying in that zone."],
+                    get = function(info) return WoWProCharDB.EnableFlight end,
+                    set = function(info,val)
+                            if WoWProCharDB.EnableFlight then
+                                WoWProCharDB.EnableFlight = false
+                            else
+                                WoWProCharDB.EnableFlight = true
+                            end
+                        end
+                },
+                grank = {
+                    order = 25,
+                    type = "range",
+                    name = L["Global Rank (Difficulty/Completeness)"],
+                    desc = L["Governs how many steps will be skipped. Use 3 for the most completeness, 1 to skip all non-essential steps."],
+                    min = 1, max = 3, step = 1,
+                    get = function(info) return WoWProDB.profile.rank end,
+                    set = function(info,val) WoWProDB.profile.rank = val
+                        if WoWProDB.char.currentguide and WoWProCharDB.Guide[WoWProDB.char.currentguide] then
+                            WoWProCharDB.Guide[WoWProDB.char.currentguide].skipped = {}
+                        end
+                        WoWPro.UpdateGuide("Config: GRank") end,
+                    width = "double"
+                },
+                trank = {
+                    order = 26,
+                    type = "range",
+                    name = L["Toon Rank (Difficulty/Completeness)"],
+                    desc = L["Governs how many steps will be skipped. Use 3 for the most completeness, 1 to skip all non-essential steps."],
+                    min = 1, max = 3, step = 1,
+                    get = function(info) return WoWProCharDB.Rank[1] end,
+                    set = function(info,val) WoWProCharDB.Rank[1] = val
+                        if WoWProDB.char.currentguide and WoWProCharDB.Guide[WoWProDB.char.currentguide] then
+                            WoWProCharDB.Guide[WoWProDB.char.currentguide].skipped = {}
+                        end
+                        WoWPro.UpdateGuide("Config: TRank") end,
+                    width = "double"
+                },
+                header4 = {
+                    order = 50,
+                    type = "header",
+                    name = "Master Addon Tools",
+                },
+                resetGuide = {
+                    order = 51,
+                    type = "execute",
+                    name = L["Reset WoWPro Addons"],
+                    desc = L["If a WoWPro addon is behaving oddly, this wipes all saved state across all characters. Log out and back in again to complete the reset."],
+                    image = "Interface\\Addons\\WoWPro\\Textures\\inv_misc_enggizmos_27",
+                    func =  function (info)
+                                WoWPro:RESET()
+                                _G.PlaySound(1026) -- Rabitt death
+                            end
+                },
+                resetLog = {
+                    order = 52,
+                    type = "execute",
+                    name = L["Clear the log"],
+                    desc = L["Wow-Pro's Debug Log"],
+                    image = "Interface\\RaidFrame\\ReadyCheck-NotReady",
+                    func =  function (info) WoWPro:LogClear("UI"); end
+                },
+                showLog = {
+                    order = 53,
+                    type = "execute",
+                    name = L["Show the log"],
+                    desc = L["Wow-Pro's Secret Debug Log"],
+                    image = "Interface\\RaidFrame\\ReadyCheck-Ready",
+                    func =  function (info) WoWPro:LogShow(); end
+                },
             },
-            help = {
-                order = 2,
-                type = "description",
-                name = L["Expert settings for WoW-Pro's addons."],
+        },
+        guideDisplay = {
+            name = "Guide Display",
+            order = 2,
+            type = "group",
+            args = {
+                desc = {
+                    order = 0,
+                    type = "description",
+                    name = L["On this page you can edit the way the guide frame looks."],
+                },
+                blank1 = {
+                    order = 1,
+                    type = "description",
+                    name = " ",
+                },
+                drag = {
+                    order = 2,
+                    type = "toggle",
+                    name = L["Enable Drag"],
+                    desc = L["Enables the guide window to be moved by clicking anywhere on it and dragging"],
+                    get = function(info) return WoWProDB.profile.drag end,
+                    set = function(info,val) WoWProDB.profile.drag = val
+                        WoWPro.DragSet() end,
+                },
+                padding = {
+                    order = 4,
+                    type = "range",
+                    name = L["Padding"],
+                    desc = L["The padding determines how much blank space is left between the guide text and the border of the guide frame."],
+                    min = 0, max = 20, step = 1,
+                    get = function(info) return WoWProDB.profile.pad end,
+                    set = function(info,val) WoWProDB.profile.pad = val
+                        WoWPro.PaddingSet(); WoWPro.RowSizeSet() end
+                },
+                spacing = {
+                    order = 5,
+                    type = "range",
+                    name = L["Spacing"],
+                    desc = L["Spacing determines how much blank space is left between lines in the guide text. "],
+                    min = 0, max = 10, step = 1,
+                    get = function(info) return WoWProDB.profile.space end,
+                    set = function(info,val) WoWProDB.profile.space = val
+                        WoWPro.RowSizeSet() end
+                },
+                hide = {
+                    order = 6,
+                    type = "toggle",
+                    name = L["Enable Instance Hiding"],
+                    desc = L["Enables/Disables hiding the active module when inside an instance (Dungeon, Arena ...), unless the guide wants you there!"],
+                    get = function(info) return WoWProCharDB.AutoHideInsideInstances ; end,
+                    set = function(info,val)
+                            if WoWProCharDB.AutoHideInsideInstances == true then WoWProCharDB.AutoHideInsideInstances=false; else WoWProCharDB.AutoHideInsideInstances=true; end
+                        end
+                },
+                notify = {
+                    order = 6.5,
+                    type = "toggle",
+                    name = L["Enable Instance Notify"],
+                    desc = L["Enables/Disables notifying when inside an instance (Dungeon, Arena ...), unless the guide wants you there!"],
+                    get = function(info) return WoWProCharDB.AutoHideInsideInstancesNotify ; end,
+                    set = function(info,val)
+                            if WoWProCharDB.AutoHideInsideInstancesNotify == true then WoWProCharDB.AutoHideInsideInstancesNotify=false; else WoWProCharDB.AutoHideInsideInstancesNotify=true; end
+                        end
+                },
+                combathide = {
+                    order = 7,
+                    type = "toggle",
+                    name = L["Enable Combat Hiding"],
+                    desc = L["Enables/Disables hiding the active module when you are in combat."],
+                    get = function(info) return WoWProCharDB.AutoHideInCombat ; end,
+                    set = function(info,val)
+                            if WoWProCharDB.AutoHideInCombat == true then WoWProCharDB.AutoHideInCombat=false; else WoWProCharDB.AutoHideInCombat=true; end
+                        end
+                },
+                noteshow = {
+                    order = 8,
+                    type = "toggle",
+                    name = L["Mouseover Notes"],
+                    desc = L["Show notes on mouseover instead of always displaying them."],
+                    get = function(info) return WoWProDB.profile.mousenotes end,
+                    set = function(info,val) WoWProDB.profile.mousenotes = val
+                        WoWPro.RowSizeSet() end
+                },
+                minimap = {
+                    order = 9,
+                    type = "toggle",
+                    name = L["Minimap Button"],
+                    desc = L["Show/hide WoW-Pro mini map button."],
+                    get = function(info) return not WoWProDB.profile.minimap.hide end,
+                    set = function(info,val) WoWProDB.profile.minimap.hide = not val
+                         WoWPro.MinimapSet() end
+                },
+                track = {
+                    order = 10,
+                    type = "toggle",
+                    name = L["Quest Tracking"],
+                    desc = L["Allows tracking of quests in the guide frame"],
+                    get = function(info) return WoWProDB.profile.track end,
+                    set = function(info,val) WoWProDB.profile.track = val
+                        WoWPro:UpdateGuide("Config: Quest Tracking") end
+                },
+                showcoords = {
+                    order = 11,
+                    type = "toggle",
+                    name = L["Show Coordinates"],
+                    desc = L["Shows the coordinates in the note text."],
+                    get = function(info) return WoWProDB.profile.showcoords end,
+                    set = function(info,val) WoWProDB.profile.showcoords = val
+                        WoWPro:UpdateGuide("Config: Show Coordinates") end
+                },
+                autoload = {
+                    order = 12,
+                    type = "toggle",
+                    name = L["Auto-Load Guide"],
+                    desc = L["Will automatically load the next guide when you complete one."],
+                    get = function(info) return WoWProDB.profile.autoload end,
+                    set = function(info,val) WoWProDB.profile.autoload = val end
+                },
+                blank2 = {
+                    order = 20,
+                    type = "description",
+                    name = " ",
+                },
+                guidescroll = {
+                    order = 21,
+                    type = "toggle",
+                    name = L["Scroll Mode"],
+                    desc = L["Displays full, scrollable guide in guide frame, instead of need-to-know info."],
+                    get = function(info) return WoWProDB.profile.guidescroll end,
+                    set = function(info,val) WoWProDB.profile.guidescroll = val
+                        WoWPro:TitlebarSet()
+                        WoWPro:UpdateGuide("Config: Scroll Mode") end
+                },
+                checksoundfile = {
+                    order = 22,
+                    type = "select",
+                    name = L["Step Completed Sound"],
+                    desc = L["Sound played when a guide step is completed"],
+                    values = function() local values = {}
+                        for k,v in pairs(soundfiles) do
+                            values[v] = k
+                        end
+                        return values end,
+                    get = function(info)
+                        return WoWProDB.profile.checksoundfile end,
+                    set = function(info,val) WoWProDB.profile.checksoundfile = val
+                        _G.PlaySoundFile(val) end,
+                    disabled = function(...) return not WoWProDB.profile.checksound end,
+                },
+                checksound = {
+                    order = 23,
+                    type = "toggle",
+                    name = L["Enable Sound"],
+                    desc = L["Plays a check-off sound when a guide step is completed."],
+                    get = function(info) return WoWProDB.profile.checksound end,
+                    set = function(info,val) WoWProDB.profile.checksound = val end
+                },
+                lefty = {
+                    order = 24,
+                    type = "toggle",
+                    name = L["Left Handed"],
+                    desc = L["Put Use and Target Icons on the right side of the guide window."],
+                    get = function(info) return WoWProDB.profile.leftside end,
+                    set = function(info,val) WoWProDB.profile.leftside = val end
+                },
+                blank3 = {
+                    order = 30,
+                    type = "description",
+                    name = " ",
+                },
+                resizeheading = {
+                    order = 31,
+                    type = "header",
+                    name = L["Resize Settings"],
+                },
+                resize = {
+                    order = 32,
+                    type = "toggle",
+                    name = L["Resize Handle"],
+                    desc = L["Enables the guide window to be resized using the resize handle in the lower right corner. \nTurns off auto resizing."],
+                    get = function(info) return WoWProDB.profile.resize end,
+                    set = function(info,val) WoWProDB.profile.resize = val
+                        if val then WoWProDB.profile.autoresize = false end
+                        WoWPro.ResizeSet() end
+                },
+                autoresize = {
+                    order = 33,
+                    type = "toggle",
+                    name = L["Auto Resize"],
+                    desc = L["Guide will automatically resize to the set number of steps. \nManual resize recommended for advanced users only. \nHides drag handle."],
+                    get = function(info) return WoWProDB.profile.autoresize end,
+                    set = function(info,val) WoWProDB.profile.autoresize = val
+                        if val then WoWProDB.profile.resize = false end
+                        WoWPro.ResizeSet(); WoWPro.RowSizeSet() end
+                },
+                numsteps = {
+                    order = 34,
+                    type = "range",
+                    name = L["Auto Resize: Number of Steps"],
+                    desc = L["Number of steps displayed in the guide window. \nThe window is automatically resized to show this number of steps. \nDoes not include sticky steps."],
+                    min = 1, max = 15, step = 1,
+                    get = function(info) return WoWProDB.profile.numsteps end,
+                    set = function(info,val) WoWProDB.profile.numsteps = val
+                        WoWPro.RowSizeSet() end,
+                    width = "double"
+                },
+                minresizeh = {
+                    order = 35,
+                    type = "range",
+                    name = L["Min Resize - Horiz"],
+                    desc = L["Minimum horizontal pixel size the guide window can be set to."],
+                    min = 50, max = 1000, step = 10,
+                    get = function(info) return WoWProDB.profile.hminresize end,
+                    set = function(info,val) WoWProDB.profile.hminresize = val
+                        WoWPro:ResizeSet(); WoWPro.RowSizeSet() end
+                },
+                minresizev = {
+                    order = 36,
+                    type = "range",
+                    name = L["Min Resize - Vert"],
+                    desc = L["Minimum vertical pixel size the guide window can be set to."],
+                    min = 50, max = 1000, step = 10,
+                    get = function(info) return WoWProDB.profile.vminresize end,
+                    set = function(info,val) WoWProDB.profile.vminresize = val
+                        WoWPro:ResizeSet(); WoWPro.RowSizeSet() end
+                },
+                blank4 = {
+                    order = 40,
+                    type = "description",
+                    name = " ",
+                },
+                titleheading = {
+                    order = 41,
+                    type = "header",
+                    name = L["Title Bar"],
+                },
+                titlebar = {
+                    order = 42,
+                    type = "toggle",
+                    name = L["Enable Title Bar"],
+                    desc = L["Enables/disables the title bar attached to the guide window."],
+                    get = function(info) return WoWProDB.profile.titlebar end,
+                    set = function(info,val) WoWProDB.profile.titlebar = val
+                        WoWPro.TitlebarSet(); WoWPro.PaddingSet(); WoWPro.RowSizeSet() end
+                },
+                titlecolor = {
+                    order = 43,
+                    type = "color",
+                    name = L["Title Bar Color"],
+                    desc = L["Background color for the title bar."],
+                    hasAlpha = true,
+                    get = function(info) return WoWProDB.profile.titlecolor[1], WoWProDB.profile.titlecolor[2], WoWProDB.profile.titlecolor[3] ,WoWProDB.profile.titlecolor[4] end,
+                    set = function(info,r,g,b,a)
+                        WoWProDB.profile.titlecolor = {r,g,b,a}
+                        WoWPro.TitlebarSet() end
+                },
+                blank5 = {
+                    order = 50,
+                    type = "description",
+                    name = " ",
+                },
+                bgheading = {
+                    order = 51,
+                    type = "header",
+                    name = L["Backgrounds"],
+                },
+                bgtexture = {
+                    order = 52,
+                    type = "select",
+                    name = L["Guide Window Background"],
+                    desc = L["Texture used for the guide window background."],
+                    values = function() local values = {}
+                        local list = LSM:List("background")
+                        local hashtable = LSM:HashTable("background")
+                        for i,handle in ipairs(list) do
+                            values[hashtable[handle]] = handle
+                        end
+                        return values end,
+                    get = function(info)
+                        return WoWProDB.profile.bgtexture end,
+                    set = function(info,val) WoWProDB.profile.bgtexture = val
+                        WoWPro.BackgroundSet() end
+                },
+                bgcolor = {
+                    order = 53,
+                    type = "color",
+                    name = L["Guide Window Color"],
+                    desc = L["Background color for the guide window"],
+                    hasAlpha = true,
+                    get = function(info) return WoWProDB.profile.bgcolor[1], WoWProDB.profile.bgcolor[2], WoWProDB.profile.bgcolor[3] ,WoWProDB.profile.bgcolor[4] end,
+                    set = function(info,r,g,b,a)
+                        WoWProDB.profile.bgcolor = {r,g,b,a}
+                        WoWPro.BackgroundSet() end
+                },
+                bordertexture = {
+                    order = 54,
+                    type = "select",
+                    name = L["Border Texture"],
+                    desc = L["Texture used for the guide window border."],
+                    values = function() local values = {}
+                        local list = LSM:List("border")
+                        local hashtable = LSM:HashTable("border")
+                        for i,handle in ipairs(list) do
+                            values[hashtable[handle]] = handle
+                        end
+                        return values end,
+                    get = function(info)
+                        return WoWProDB.profile.bordertexture end,
+                    set = function(info,val) WoWProDB.profile.bordertexture = val
+                        WoWPro.border = true
+                        WoWPro.BackgroundSet() end
+                },
+                border = {
+                    order = 55,
+                    type = "toggle",
+                    name = L["Enable Border"],
+                    desc = L["Enables/disables the border around the guide window."],
+                    get = function(info) return WoWProDB.profile.border end,
+                    set = function(info,val) WoWProDB.profile.border = val
+                        WoWPro.BackgroundSet() end
+                },
+                stickytexture = {
+                    order = 56,
+                    type = "select",
+                    name = L["Sticky Background"],
+                    desc = L["Texture used for sticky step background."],
+                    values = function() local values = {}
+                        local list = LSM:List("background")
+                        local hashtable = LSM:HashTable("background")
+                        for i,handle in ipairs(list) do
+                            values[hashtable[handle]] = handle
+                        end
+                        return values end,
+                    get = function(info)
+                        return WoWProDB.profile.stickytexture end,
+                    set = function(info,val) WoWProDB.profile.stickytexture = val
+                        WoWPro.BackgroundSet(); WoWPro.RowColorSet() end
+                },
+                stickycolor = {
+                    order = 57,
+                    type = "color",
+                    name = L["Sticky Step Color"],
+                    desc = L["Background color for the sticky step frames."],
+                    hasAlpha = true,
+                    get = function(info) return WoWProDB.profile.stickycolor[1], WoWProDB.profile.stickycolor[2], WoWProDB.profile.stickycolor[3] ,WoWProDB.profile.stickycolor[4] end,
+                    set = function(info,r,g,b,a)
+                        WoWProDB.profile.stickycolor = {r,g,b,a}
+                        WoWPro.BackgroundSet(); WoWPro.RowColorSet() end
+                },
+                blank6 = {
+                    order = 60,
+                    type = "description",
+                    name = " ",
+                },
+                textheading = {
+                    order = 61,
+                    type = "header",
+                    name = L["Text Formatting"],
+                },
+                stepfont = {
+                    order = 62,
+                    type = 'select',
+                    dialogControl = 'LSM30_Font',
+                    name = L["Step Font"],
+                    desc = L["Font used for the main step text."],
+                    values = LSM:HashTable("font"),
+                    get = function(info) local values = {}
+                        local list = LSM:List("font")
+                        local hashtable = LSM:HashTable("font")
+                        for i,handle in ipairs(list) do
+                            values[hashtable[handle]] = handle
+                        end
+                        local hash = values[WoWProDB.profile.stepfont]
+                        return hash end,
+                    set = function(info,val)
+                        local hashtable = LSM:HashTable("font")
+                        WoWProDB.profile.stepfont = hashtable[val]
+                        WoWPro.RowFontSet() end
+                },
+                steptextsize = {
+                    order = 63,
+                    type = "range",
+                    name = L["Step Text Size"],
+                    desc = L["Size of the main step text."],
+                    min = 1, max = 30, step = 1,
+                    get = function(info) return WoWProDB.profile.steptextsize end,
+                    set = function(info,val) WoWProDB.profile.steptextsize = val
+                        WoWPro.RowFontSet()
+                        WoWPro.RowSizeSet() end
+                },
+                steptextcolor = {
+                    order = 64,
+                    type = "color",
+                    name = L["Step Text Color"],
+                    desc = L["Color of the main step text."],
+                    width = "full",
+                    get = function(info) return WoWProDB.profile.steptextcolor[1], WoWProDB.profile.steptextcolor[2], WoWProDB.profile.steptextcolor[3] end,
+                    set = function(info,r,g,b)
+                        WoWProDB.profile.steptextcolor = {r,g,b}
+                        WoWPro.RowFontSet() end
+                },
+                notefont = {
+                    order = 65,
+                    type = 'select',
+                    dialogControl = 'LSM30_Font',
+                    name = L["Note Font"],
+                    desc = L["Font used for the note text."],
+                    values = LSM:HashTable("font"),
+                    get = function(info) local values = {}
+                        local list = LSM:List("font")
+                        local hashtable = LSM:HashTable("font")
+                        for i,handle in ipairs(list) do
+                            values[hashtable[handle]] = handle
+                        end
+                        local hash = values[WoWProDB.profile.notefont]
+                        return hash end,
+                    set = function(info,val)
+                        local hashtable = LSM:HashTable("font")
+                        WoWProDB.profile.notefont = hashtable[val]
+                        WoWPro.RowFontSet() end
+                },
+                notetextsize = {
+                    order = 66,
+                    type = "range",
+                    name = L["Note Text Size"],
+                    desc = L["Size of the note text."],
+                    min = 1, max = 30, step = 1,
+                    get = function(info) return WoWProDB.profile.notetextsize end,
+                    set = function(info,val) WoWProDB.profile.notetextsize = val
+                        WoWPro.RowFontSet()
+                        WoWPro.RowSizeSet() end
+                },
+                notetextcolor = {
+                    order = 67,
+                    type = "color",
+                    name = L["Note Text Color"],
+                    desc = L["Color of the note text."],
+                    width = "full",
+                    get = function(info) return WoWProDB.profile.notetextcolor[1], WoWProDB.profile.notetextcolor[2], WoWProDB.profile.notetextcolor[3] end,
+                    set = function(info,r,g,b)
+                        WoWProDB.profile.notetextcolor = {r,g,b}
+                        WoWPro.RowFontSet() end
+                },
+                trackfont = {
+                    order = 68,
+                    type = "select",
+                    dialogControl = 'LSM30_Font',
+                    name = L["Tracker Font"],
+                    desc = L["Font used for the tracking text."],
+                    values = LSM:HashTable("font"), -- pull in your font list from LSM
+                    get = function(info) local values = {}
+                        local list = LSM:List("font")
+                        local hashtable = LSM:HashTable("font")
+                        for i,handle in ipairs(list) do
+                            values[hashtable[handle]] = handle
+                        end
+                        local hash = values[WoWProDB.profile.trackfont]
+                        return hash end,
+                    set = function(info,val)
+                        local hashtable = LSM:HashTable("font")
+                        WoWProDB.profile.trackfont = hashtable[val]
+                        WoWPro.RowFontSet() end
+                },
+                tracktextsize = {
+                    order = 69,
+                    type = "range",
+                    name = L["Tracker Text Size"],
+                    desc = L["Size of the tracking text."],
+                    min = 1, max = 30, step = 1,
+                    get = function(info) return WoWProDB.profile.tracktextsize end,
+                    set = function(info,val) WoWProDB.profile.tracktextsize = val
+                        WoWPro.RowFontSet()
+                        WoWPro.RowSizeSet() end
+                },
+                tracktextcolor = {
+                    order = 70,
+                    type = "color",
+                    name = L["Tracker Text Color"],
+                    desc = L["Color of the tracking text."],
+                    width = "full",
+                    get = function(info) return WoWProDB.profile.tracktextcolor[1], WoWProDB.profile.tracktextcolor[2], WoWProDB.profile.tracktextcolor[3] end,
+                    set = function(info,r,g,b)
+                        WoWProDB.profile.tracktextcolor = {r,g,b}
+                        WoWPro.RowFontSet() end
+                },
+                titlefont = {
+                    order = 71,
+                    type = "select",
+                    dialogControl = 'LSM30_Font',
+                    name = L["Title Bar Font"],
+                    desc = L["Font used on the title bar."],
+                    values = LSM:HashTable("font"), -- pull in your font list from LSM
+                    get = function(info) local values = {}
+                        local list = LSM:List("font")
+                        local hashtable = LSM:HashTable("font")
+                        for i,handle in ipairs(list) do
+                            values[hashtable[handle]] = handle
+                        end
+                        local hash = values[WoWProDB.profile.titlefont]
+                        return hash end,
+                    set = function(info,val)
+                        local hashtable = LSM:HashTable("font")
+                        WoWProDB.profile.titlefont = hashtable[val]
+                        WoWPro:TitlebarSet() end
+                },
+                titletextsize = {
+                    order = 72,
+                    type = "range",
+                    name = L["Title Bar Text Size"],
+                    desc = L["Size of the title bar text."],
+                    min = 1, max = 30, step = 1,
+                    get = function(info) return WoWProDB.profile.titletextsize end,
+                    set = function(info,val) WoWProDB.profile.titletextsize = val
+                        WoWPro:TitlebarSet() end
+                },
+                titletextcolor = {
+                    order = 73,
+                    type = "color",
+                    name = L["Title Bar Text Color"],
+                    desc = L["Color of the title bar text."],
+                    width = "full",
+                    get = function(info) return WoWProDB.profile.titletextcolor[1], WoWProDB.profile.titletextcolor[2], WoWProDB.profile.titletextcolor[3] end,
+                    set = function(info,r,g,b)
+                        WoWProDB.profile.titletextcolor = {r,g,b}
+                        WoWPro:TitlebarSet() end
+                },
+                stickytitlefont = {
+                    order = 74,
+                    type = "select",
+                    dialogControl = 'LSM30_Font',
+                    name = L["'As you go:' Font"],
+                    desc = L["Font used on the top of the sticky frame."],
+                    values = LSM:HashTable("font"), -- pull in your font list from LSM
+                    get = function(info) local values = {}
+                        local list = LSM:List("font")
+                        local hashtable = LSM:HashTable("font")
+                        for i,handle in ipairs(list) do
+                            values[hashtable[handle]] = handle
+                        end
+                        local hash = values[WoWProDB.profile.stickytitlefont]
+                        return hash end,
+                    set = function(info,val)
+                        local hashtable = LSM:HashTable("font")
+                        WoWProDB.profile.stickytitlefont = hashtable[val]
+                        WoWPro.RowFontSet()
+                        WoWPro.RowSizeSet() end
+                },
+                stickytitletextsize = {
+                    order = 75,
+                    type = "range",
+                    name = L["'As you go:' Text Size"],
+                    desc = L["Size of the text on the top of the sticky frame."],
+                    min = 1, max = 30, step = 1,
+                    get = function(info) return WoWProDB.profile.stickytitletextsize end,
+                    set = function(info,val) WoWProDB.profile.stickytitletextsize = val
+                        WoWPro.RowFontSet()
+                        WoWPro.RowSizeSet() end
+                },
+                stickytitletextcolor = {
+                    order = 76,
+                    type = "color",
+                    name = L["'As you go:' Text Color"],
+                    desc = L["Color of the text on the top of the sticky frame."],
+                    width = "full",
+                    get = function(info) return WoWProDB.profile.stickytitletextcolor[1], WoWProDB.profile.stickytitletextcolor[2], WoWProDB.profile.stickytitletextcolor[3] end,
+                    set = function(info,r,g,b)
+                        WoWProDB.profile.stickytitletextcolor = {r,g,b}
+                        WoWPro.RowFontSet() end
+                    
+                },   
             },
-            blank = {
-                order = 3,
-                type = "description",
-                name = " ",
+        },
+        guideList = {
+            name = "Guide List",
+            order = 3,
+            type = "group",
+            args = {
+                -- Add your options for the "Guide List" category here
             },
-            debugClasses = {
-                order = 4,
-                type = "toggle",
-                name = L["Debug Classes"],
-                desc = L["Enables/Disables loading of all class guides"],
-                get = function(info) return (WoWPro.DebugLevel > 0) and WoWPro.DebugClasses end,
-                set = function(info,val)
+        },
+        currentGuide = {
+            name = "Current Guide",
+            order = 4,
+            type = "group",
+            args = {
+                -- Add your options for the "Current Guide" category here
+            },
+        },
+        profiles = {
+            name = "Profiles",
+            order = 5,
+            type = "group",
+            args = {
+                -- Add your options for the "Current Guide" category here
+            },
+        },
+        expert = {
+            name = "Expert",
+            order = 6,
+            type = "group",
+            args = {
+                version = {
+                    order = 1,
+                    type = "description",
+                    name = L["Version"]..": "..WoWPro.Version,
+                },
+                help = {
+                    order = 2,
+                    type = "description",
+                    name = L["(We Recomend Only Advanced Users Touch These Settings)"],
+                },
+                blank = {
+                    order = 3,
+                    type = "description",
+                    name = " ",
+                },
+                debugClasses = {
+                    order = 4,
+                    type = "toggle",
+                    name = L["Debug Classes"],
+                    desc = L["Enables/Disables loading of all class guides"],
+                    get = function(info) return (WoWPro.DebugLevel > 0) and WoWPro.DebugClasses end,
+                    set = function(info,val)
                         if WoWPro.DebugClasses then
                             WoWPro.DebugClasses = false
                         else
@@ -945,120 +962,337 @@ local function createBlizzOptions()
                         end
                         WoWProCharDB.DebugClasses = WoWPro.DebugClasses
                     end
-            },
-            EnableGrailQuestline = {
-                order = 5.0,
-                type = "toggle",
-                name = L["Grail Quest Lines"],
-                desc = L["Enables/Disables Grail Quest Line Integration"],
-                get = function(info) return WoWProCharDB.EnableGrailQuestline end,
-                set = function(info,val)
+                },
+        
+                EnableGrailQuestline = {
+                    order = 5.0,
+                    type = "toggle",
+                    name = L["Grail Quest Lines"],
+                    desc = L["Enables/Disables Grail Quest Line Integration"],
+                    get = function(info) return WoWProCharDB.EnableGrailQuestline end,
+                    set = function(info,val)
                         if WoWProCharDB.EnableGrailQuestline then
                             WoWProCharDB.EnableGrailQuestline = false
                         else
                             WoWProCharDB.EnableGrailQuestline = true
                         end
                     end
-            },
-            EnableGrailCheckPrereq = {
-                order = 5.1,
-                type = "toggle",
-                name = L["Grail Check PRE"],
-                desc = L["Enables/Disables Grail Quest Prerequistite Quest Checking"],
-                get = function(info) return WoWProCharDB.EnableGrailCheckPrereq end,
-                set = function(info,val)
+                },
+        
+                EnableGrailCheckPrereq = {
+                    order = 5.1,
+                    type = "toggle",
+                    name = L["Grail Check PRE"],
+                    desc = L["Enables/Disables Grail Quest Prerequistite Quest Checking"],
+                    get = function(info) return WoWProCharDB.EnableGrailCheckPrereq end,
+                    set = function(info,val)
                         if WoWProCharDB.EnableGrailCheckPrereq then
                             WoWProCharDB.EnableGrailCheckPrereq = false
                         else
                             WoWProCharDB.EnableGrailCheckPrereq = true
                         end
                     end
-            },
-            EnableGrailBreadcrumbs = {
-                order = 5.2,
-                type = "toggle",
-                name = L["Grail Check LEAD"],
-                desc = L["Enables/Disables Grail Quest Breadcrumb Quest Checking"],
-                get = function(info) return WoWProCharDB.EnableGrailBreadcrumbs end,
-                set = function(info,val)
+                },
+        
+                EnableGrailBreadcrumbs = {
+                    order = 5.2,
+                    type = "toggle",
+                    name = L["Grail Check LEAD"],
+                    desc = L["Enables/Disables Grail Quest Breadcrumb Quest Checking"],
+                    get = function(info) return WoWProCharDB.EnableGrailBreadcrumbs end,
+                    set = function(info,val)
                         if WoWProCharDB.EnableGrailBreadcrumbs then
                             WoWProCharDB.EnableGrailBreadcrumbs = false
                         else
                             WoWProCharDB.EnableGrailBreadcrumbs = true
                         end
                     end
-            },
-            EnableGrailQuestName = {
-                order = 5.3,
-                type = "toggle",
-                name = L["Grail Quest Name Check"],
-                desc = L["Enables/Disables Grail Quest Quest Name Checking"],
-                get = function(info) return WoWProCharDB.EnableGrailQuestName end,
-                set = function(info,val)
-                        if WoWProCharDB.EnableGrailQuestName then
-                            WoWProCharDB.EnableGrailQuestName = false
-                        else
-                            WoWProCharDB.EnableGrailQuestName = true
+                },
+                EnableGrailQuestName = {
+                    order = 5.3,
+                    type = "toggle",
+                    name = L["Grail Quest Name Check"],
+                    desc = L["Enables/Disables Grail Quest Quest Name Checking"],
+                    get = function(info) return WoWProCharDB.EnableGrailQuestName end,
+                    set = function(info,val)
+                            if WoWProCharDB.EnableGrailQuestName then
+                                WoWProCharDB.EnableGrailQuestName = false
+                            else
+                                WoWProCharDB.EnableGrailQuestName = true
+                            end
                         end
-                    end
-            },
-            EnableGrailQuestLevel = {
-                order = 5.4,
-                type = "toggle",
-                name = L["Grail Quest Level Check"],
-                desc = L["Enables/Disables Grail Quest Quest Level Checking"],
-                get = function(info) return WoWProCharDB.EnableGrailQuestLevel end,
-                set = function(info,val)
-                        if WoWProCharDB.EnableGrailQuestLevel then
-                            WoWProCharDB.EnableGrailQuestLevel = false
-                        else
-                            WoWProCharDB.EnableGrailQuestLevel = true
+                },
+                EnableGrailQuestLevel = {
+                    order = 5.4,
+                    type = "toggle",
+                    name = L["Grail Quest Level Check"],
+                    desc = L["Enables/Disables Grail Quest Quest Level Checking"],
+                    get = function(info) return WoWProCharDB.EnableGrailQuestLevel end,
+                    set = function(info,val)
+                            if WoWProCharDB.EnableGrailQuestLevel then
+                                WoWProCharDB.EnableGrailQuestLevel = false
+                            else
+                                WoWProCharDB.EnableGrailQuestLevel = true
+                            end
                         end
-                    end
-            },
-            EnableGrailQuestObsolete = {
-                order = 5.5,
-                type = "toggle",
-                name = L["Grail Obsolete Quest Check"],
-                desc = L["Enables/Disables Grail Quest Quest Obsolete Checking"],
-                get = function(info) return WoWProCharDB.EnableGrailQuestObsolete end,
-                set = function(info,val)
-                        if WoWProCharDB.EnableGrailQuestObsolete then
-                            WoWProCharDB.EnableGrailQuestObsolete = false
-                        else
-                            WoWProCharDB.EnableGrailQuestObsolete = true
+                },
+                EnableGrailQuestObsolete = {
+                    order = 5.5,
+                    type = "toggle",
+                    name = L["Grail Obsolete Quest Check"],
+                    desc = L["Enables/Disables Grail Quest Quest Obsolete Checking"],
+                    get = function(info) return WoWProCharDB.EnableGrailQuestObsolete end,
+                    set = function(info,val)
+                            if WoWProCharDB.EnableGrailQuestObsolete then
+                                WoWProCharDB.EnableGrailQuestObsolete = false
+                            else
+                                WoWProCharDB.EnableGrailQuestObsolete = true
+                            end
                         end
-                    end
-            },
-
-            checkGuides = {
-                order = 6,
-                type = "execute",
-                name = L["Run the Guide Checker"],
-                desc = L["Load every available guide and check for errors."],
-                image = "Interface\\RaidFrame\\ReadyCheck-Waiting",
-                func =  function (info)
-                            WoWPro:LogClear("CheckGuides");
-                            WoWPro:LoadAllGuides()
-                        end
-            },
-            QuestEngineDelay = {
-                order = 10,
-                type = "range",
-                name = L["Quest Engine Delay"],
-                desc = L["The amount of time to wait for the WoW client to update it's state."],
-                min = 0.1, max = 0.75, step = .05,
-                get = function(info) return WoWProDB.global.QuestEngineDelay end,
-                set = function(info,val) WoWProDB.global.QuestEngineDelay = val end
+                },
+    
+                checkGuides = {
+                    order = 6,
+                    type = "execute",
+                    name = L["Run the Guide Checker"],
+                    desc = L["Load every available guide and check for errors."],
+                    image = "Interface\\RaidFrame\\ReadyCheck-Waiting",
+                    func =  function (info)
+                                WoWPro:LogClear("CheckGuides");
+                                WoWPro:LoadAllGuides()
+                            end
+                },
+                QuestEngineDelay = {
+                    order = 10,
+                    type = "range",
+                    name = L["Quest Engine Delay"],
+                    desc = L["The amount of time to wait for the WoW client to update it's state."],
+                    min = 0.1, max = 0.75, step = .05,
+                    get = function(info) return WoWProDB.global.QuestEngineDelay end,
+                    set = function(info,val) WoWProDB.global.QuestEngineDelay = val end
+                },
             },
         },
-    }
-    config:RegisterOptionsTable("WoWPro-Expert", expert)
-    dialog:AddToBlizOptions("WoWPro-Expert", expert.name, "WoW-Pro")
-end
+        achievements = {
+            name = "Achievements",
+            order = 7,
+            type = "group",
+            args = {
+                help = {
+                    order = 0,
+                    type = "description",
+                    name = L["Settings for the WoW-Pro addon's Achievements module."],
+                },
+                blank = {
+                    order = 1,
+                    type = "description",
+                    name = " ",
+                },
+                enable = {
+                    order = 2,
+                    type = "toggle",
+                    name = L["Enable Module"],
+                    desc = L["Enables/Disables the Achievements module of the WoW-Pro guide addon."],
+                    width = "full",
+                    get = function(info) return WoWPro.Achievements:IsEnabled() end,
+                    set = function(info,val)
+                            if WoWPro.Achievements:IsEnabled() then WoWPro.Achievements:Disable() else WoWPro.Achievements:Enable() end
+                        end
+                },
+                arank = {
+                    order = 3,
+                    type = "range",
+                    name = L["Rank (Difficulty/Completeness)"],
+                    desc = L["Governs how many steps will be skipped. Use 3 for the most completeness, 1 to skip all non-essential steps."],
+                    min = 1, max = 3, step = 1,
+                    get = function(info) return WoWProDB.profile.rank end,
+                    set = function(info,val) WoWProDB.profile.rank = val
+                        WoWPro.UpdateGuide("Config: Rank") end,
+                    width = "double"
+                },
+                blank2 = {
+                    order = 4,
+                    type = "description",
+                    name = " ",
+                },
+                helpheader = {
+                    order = 5,
+                    type = "header",
+                    name = "WoW-Pro Achievements Help",
+                },
+                blank3 = {
+                    order = 6,
+                    type = "description",
+                    name = " ",
+                }
+            },
+        },
+        dailies = {
+            name = "Dailies",
+            order = 8,
+            type = "group",
+            args = {
+                help = {
+                    order = 0,
+                    type = "description",
+                    name = L["Settings for the WoW-Pro addon's Dailies module."],
+                },
+                blank = {
+                    order = 1,
+                    type = "description",
+                    name = " ",
+                },
+                enable = {
+                    order = 2,
+                    type = "toggle",
+                    name = L["Enable Module"],
+                    desc = L["Enables/Disables the dailies module of the WoW-Pro guide addon."],
+                    width = "full",
+                    get = function(info) return WoWPro.Dailies:IsEnabled() end,
+                    set = function(info,val)
+                            if WoWPro.Dailies:IsEnabled() then WoWPro.Dailies:Disable() else WoWPro.Dailies:Enable() end
+                        end
+                },
+                arank = {
+                    order = 3,
+                    type = "range",
+                    name = L["Rank (Difficulty/Completeness)"],
+                    desc = L["Governs how many steps will be skipped. Use 3 for the most completeness, 1 to skip all non-essential steps."],
+                    min = 1, max = 3, step = 1,
+                    get = function(info) return WoWProDB.profile.rank end,
+                    set = function(info,val) WoWProDB.profile.rank = val
+                        WoWPro.UpdateGuide("Config: Rank") end,
+                    width = "double"
+                },
+                blank2 = {
+                    order = 4,
+                    type = "description",
+                    name = " ",
+                },
+                helpheader = {
+                    order = 5,
+                    type = "header",
+                    name = "WoW-Pro Dailies Help",
+                },
+                blank3 = {
+                    order = 6,
+                    type = "description",
+                    name = " ",
+                }
+            },
+        },
+        levelling = {
+            name = "Levelling",
+            order = 9,
+            type = "group",
+            args = {
+                help = {
+                    order = 0,
+                    type = "description",
+                    name = L["Settings for the WoW-Pro addon's leveling module."],
+                },
+                blank = {
+                    order = 1,
+                    type = "description",
+                    name = " ",
+                },
+                enable = {
+                    order = 2,
+                    type = "toggle",
+                    name = L["Enable Module"],
+                    desc = L["Enables/Disables the leveling module of the WoW-Pro guide addon."],
+                    width = "full",
+                    get = function(info) return WoWPro.Leveling:IsEnabled() end,
+                    set = function(info,val)
+                            if WoWPro.Leveling:IsEnabled() then WoWPro.Leveling:Disable() else WoWPro.Leveling:Enable() end
+                        end
+                },
+                arank = {
+                    order = 3,
+                    type = "range",
+                    name = L["Rank (Difficulty/Completeness)"],
+                    desc = L["Governs how many steps will be skipped. Use 3 for the most completeness, 1 to skip all non-essential steps."],
+                    min = 1, max = 3, step = 1,
+                    get = function(info) return WoWProDB.profile.rank end,
+                    set = function(info,val) WoWProDB.profile.rank = val
+                        WoWPro.UpdateGuide("Config: Rank") end,
+                    width = "double"
+                },
+                blank2 = {
+                    order = 4,
+                    type = "description",
+                    name = " ",
+                },
+                helpheader = {
+                    order = 5,
+                    type = "header",
+                    name = "WoW-Pro Leveling Help",
+                },
+                blank3 = {
+                    order = 6,
+                    type = "description",
+                    name = " ",
+                },
+            },
+        },
+        worldevents = {
+            name = "World Events",
+            order = 10,
+            type = "group",
+            args = {
+                help = {
+                    order = 0,
+                    type = "description",
+                    name = L["Settings for the WoW-Pro addon's WorldEvents module."],
+                },
+                blank = {
+                    order = 1,
+                    type = "description",
+                    name = " ",
+                },
+                enable = {
+                    order = 2,
+                    type = "toggle",
+                    name = L["Enable Module"],
+                    desc = L["Enables/Disables the WorldEvents module of the WoW-Pro guide addon."],
+                    width = "full",
+                    get = function(info) return WoWPro.WorldEvents:IsEnabled() end,
+                    set = function(info,val)
+                            if WoWPro.WorldEvents:IsEnabled() then WoWPro.WorldEvents:Disable() else WoWPro.WorldEvents:Enable() end
+                        end
+                },
+                arank = {
+                    order = 3,
+                    type = "range",
+                    name = L["Rank (Difficulty/Completeness)"],
+                    desc = L["Governs how many steps will be skipped. Use 3 for the most completeness, 1 to skip all non-essential steps."],
+                    min = 1, max = 3, step = 1,
+                    get = function(info) return WoWProDB.profile.rank end,
+                    set = function(info,val) WoWProDB.profile.rank = val
+                        WoWPro.UpdateGuide("Config: Rank") end,
+                    width = "double"
+                },
+                blank2 = {
+                    order = 4,
+                    type = "description",
+                    name = " ",
+                },
+                helpheader = {
+                    order = 5,
+                    type = "header",
+                    name = "WoW-Pro WorldEvents Help",
+                },
+                blank3 = {
+                    order = 6,
+                    type = "description",
+                    name = " ",
+                },
+            },
+        },
+    },
+}
+-- Register your options table with AceConfig
+AceConfig:RegisterOptionsTable("WoWPro", options)
 
-function WoWPro.CreateConfig()
-    createBlizzOptions()
-    _G.InterfaceOptions_AddCategory(WoWPro.GuideList)
-    _G.InterfaceOptions_AddCategory(WoWPro.CurrentGuideFrame)
-end
+-- Add the options table to the Blizzard Interface Options
+AceConfigDialog:AddToBlizOptions("WoWPro", "WoWPro")

--- a/WoWPro/WoWPro_Config.lua
+++ b/WoWPro/WoWPro_Config.lua
@@ -2,6 +2,8 @@ local L = WoWPro_Locale
 local AceConfig = LibStub("AceConfig-3.0")
 local AceConfigDialog = LibStub("AceConfigDialog-3.0")
 local LSM = _G.LibStub("LibSharedMedia-3.0")
+local LDB = LibStub("LibDataBroker-1.1")
+local icon = LibStub("LibDBIcon-1.0")
 
 local MediaType_BORDER = LSM.MediaType.BORDER
 LSM:Register(MediaType_BORDER, "Eli Border", [[Interface\AddOns\WoWPro\Textures\Eli-Edge.tga]])
@@ -900,6 +902,7 @@ local options = {
                     set = function(info,r,g,b)
                         WoWProDB.profile.stickytitletextcolor = {r,g,b}
                         WoWPro.RowFontSet() end
+
                 },
             },
         },
@@ -962,6 +965,7 @@ local options = {
                         WoWProCharDB.DebugClasses = WoWPro.DebugClasses
                     end
                 },
+
                 EnableGrailQuestline = {
                     order = 5.0,
                     type = "toggle",
@@ -976,6 +980,7 @@ local options = {
                         end
                     end
                 },
+
                 EnableGrailCheckPrereq = {
                     order = 5.1,
                     type = "toggle",
@@ -990,6 +995,7 @@ local options = {
                         end
                     end
                 },
+
                 EnableGrailBreadcrumbs = {
                     order = 5.2,
                     type = "toggle",
@@ -1046,6 +1052,7 @@ local options = {
                             end
                         end
                 },
+
                 checkGuides = {
                     order = 6,
                     type = "execute",
@@ -1286,6 +1293,43 @@ local options = {
         },
     },
 }
+
+function WoWPro:OpenGuideListTab()
+LibStub("AceConfigDialog-3.0"):SelectGroup("WoWPro", "guideList")
+end
+
+-- Create a DataBroker launcher
+local WoWProLauncher = LDB:NewDataObject("WoWPro", {
+    type = "launcher",
+    icon = "Interface\\AddOns\\WoWPro\\Textures\\Achievement_WorldEvent_Brewmaster",
+    OnClick = function(clickedframe, button)
+        if button == "LeftButton" then
+            -- Enable or disable the addon
+            if WoWPro:IsEnabled() then
+                WoWPro:Disable()
+            else
+                WoWPro:Enable()
+            end
+        elseif button == "RightButton" then
+            -- Open the guide display tab
+            InterfaceOptionsFrame_OpenToCategory("WoWPro")
+            InterfaceOptionsFrame_OpenToCategory("WoWPro") -- call twice to actually open the frame
+            WoWPro:OpenGuideListTab()
+        end
+    end,
+    OnTooltipShow = function(tt)
+        tt:AddLine("WoWPro")
+        tt:AddLine("Left click to enable/disable.")
+        tt:AddLine("Right click to open the guide display tab.")
+    end,
+})
+
+-- Register the DataBroker launcher with LibDBIcon
+function WoWPro:OnInitialize()
+    self.db = LibStub("AceDB-3.0"):New("WoWProDB", defaults, true)
+    icon:Register("WoWPro", WoWProLauncher, self.db.profile.minimap)
+end
+
 -- Register your options table with AceConfig
 AceConfig:RegisterOptionsTable("WoWPro", options)
 

--- a/WoWPro/WoWPro_Config.lua
+++ b/WoWPro/WoWPro_Config.lua
@@ -103,7 +103,9 @@ local options = {
                     width = "normal",
                     func = function()
                         local url = "https://discord.gg/aarduK7"
-                        StaticPopupDialogs["WoWPro_DiscordURL"] = {
+                        local OKAY = _G.OKAY or "Okay"
+                        local myDialogs = _G.StaticPopupDialogs or {}
+                        myDialogs["WoWPro_DiscordURL"] = {
                             text = "Press Ctrl & C to copy this link and paste into your favorite Browser",
                             button1 = OKAY,
                             hasEditBox = true,
@@ -118,6 +120,8 @@ local options = {
                             whileDead = true,
                             hideOnEscape = true,
                         }
+                        _G.StaticPopupDialogs = myDialogs
+                        local StaticPopup_Show = _G.StaticPopup_Show or function() end
                         StaticPopup_Show("WoWPro_DiscordURL", url)
                     end
                 },
@@ -473,6 +477,7 @@ local options = {
                     name = L["Step Completed Sound"],
                     desc = L["Sound played when a guide step is completed"],
                     values = function() local values = {}
+                        local pairs = _G.pairs or function() end
                         for k,v in pairs(soundfiles) do
                             values[v] = k
                         end
@@ -605,13 +610,16 @@ local options = {
                     type = "select",
                     name = L["Guide Window Background"],
                     desc = L["Texture used for the guide window background."],
-                    values = function() local values = {}
+                    values = function()
+                        local values = {}
+                        local ipairs = _G.ipairs or function() end
                         local list = LSM:List("background")
                         local hashtable = LSM:HashTable("background")
                         for i,handle in ipairs(list) do
                             values[hashtable[handle]] = handle
                         end
-                        return values end,
+                        return values
+                    end,
                     get = function(info)
                         return WoWProDB.profile.bgtexture end,
                     set = function(info,val) WoWProDB.profile.bgtexture = val
@@ -634,6 +642,7 @@ local options = {
                     name = L["Border Texture"],
                     desc = L["Texture used for the guide window border."],
                     values = function() local values = {}
+                        local ipairs = _G.ipairs or function() end
                         local list = LSM:List("border")
                         local hashtable = LSM:HashTable("border")
                         for i,handle in ipairs(list) do
@@ -701,6 +710,7 @@ local options = {
                     desc = L["Font used for the main step text."],
                     values = LSM:HashTable("font"),
                     get = function(info) local values = {}
+                        local ipairs = _G.ipairs or function() end
                         local list = LSM:List("font")
                         local hashtable = LSM:HashTable("font")
                         for i,handle in ipairs(list) do
@@ -745,6 +755,7 @@ local options = {
                     get = function(info) local values = {}
                         local list = LSM:List("font")
                         local hashtable = LSM:HashTable("font")
+                        local ipairs = _G.ipairs or function() end
                         for i,handle in ipairs(list) do
                             values[hashtable[handle]] = handle
                         end
@@ -787,6 +798,7 @@ local options = {
                     get = function(info) local values = {}
                         local list = LSM:List("font")
                         local hashtable = LSM:HashTable("font")
+                        local ipairs = _G.ipairs or function() end
                         for i,handle in ipairs(list) do
                             values[hashtable[handle]] = handle
                         end
@@ -829,6 +841,7 @@ local options = {
                     get = function(info) local values = {}
                         local list = LSM:List("font")
                         local hashtable = LSM:HashTable("font")
+                        local ipairs = _G.ipairs or function() end
                         for i,handle in ipairs(list) do
                             values[hashtable[handle]] = handle
                         end
@@ -870,6 +883,7 @@ local options = {
                     get = function(info) local values = {}
                         local list = LSM:List("font")
                         local hashtable = LSM:HashTable("font")
+                        local ipairs = _G.ipairs or function() end
                         for i,handle in ipairs(list) do
                             values[hashtable[handle]] = handle
                         end
@@ -965,7 +979,6 @@ local options = {
                         WoWProCharDB.DebugClasses = WoWPro.DebugClasses
                     end
                 },
-
                 EnableGrailQuestline = {
                     order = 5.0,
                     type = "toggle",
@@ -980,7 +993,6 @@ local options = {
                         end
                     end
                 },
-
                 EnableGrailCheckPrereq = {
                     order = 5.1,
                     type = "toggle",
@@ -995,7 +1007,6 @@ local options = {
                         end
                     end
                 },
-
                 EnableGrailBreadcrumbs = {
                     order = 5.2,
                     type = "toggle",
@@ -1052,7 +1063,6 @@ local options = {
                             end
                         end
                 },
-
                 checkGuides = {
                     order = 6,
                     type = "execute",
@@ -1293,7 +1303,6 @@ local options = {
         },
     },
 }
-
 function WoWPro:OpenGuideListTab()
 LibStub("AceConfigDialog-3.0"):SelectGroup("WoWPro", "guideList")
 end
@@ -1302,28 +1311,36 @@ end
 local WoWProLauncher = LDB:NewDataObject("WoWPro", {
     type = "launcher",
     icon = "Interface\\AddOns\\WoWPro\\Textures\\Achievement_WorldEvent_Brewmaster",
-    OnClick = function(clickedframe, button)
-        if button == "LeftButton" then
-            -- Enable or disable the addon
-            if WoWPro:IsEnabled() then
-                WoWPro:Disable()
-            else
-                WoWPro:Enable()
-            end
-        elseif button == "RightButton" then
-            -- Open the guide display tab
-            InterfaceOptionsFrame_OpenToCategory("WoWPro")
-            InterfaceOptionsFrame_OpenToCategory("WoWPro") -- call twice to actually open the frame
-            WoWPro:OpenGuideListTab()
+OnClick = function(clickedframe, button)
+    local InterfaceOptionsFrame_OpenToCategory = _G.InterfaceOptionsFrame_OpenToCategory or function() end
+    if button == "LeftButton" then
+        -- Enable or disable the addon
+        if WoWPro:IsEnabled() then
+            WoWPro:Disable()
+        else
+            WoWPro:Enable()
         end
-    end,
+    elseif button == "RightButton" then
+        -- Open the guide display tab
+        InterfaceOptionsFrame_OpenToCategory("WoWPro")
+        InterfaceOptionsFrame_OpenToCategory("WoWPro") -- call twice to actually open the frame
+        WoWPro:OpenGuideListTab()
+    end
+end,
     OnTooltipShow = function(tt)
         tt:AddLine("WoWPro")
         tt:AddLine("Left click to enable/disable.")
         tt:AddLine("Right click to open the guide display tab.")
     end,
 })
-
+-- Define defaults
+local defaults = {
+    profile = {
+        minimap = {
+            hide = false,
+        },
+    },
+}
 -- Register the DataBroker launcher with LibDBIcon
 function WoWPro:OnInitialize()
     self.db = LibStub("AceDB-3.0"):New("WoWProDB", defaults, true)

--- a/WoWPro/WoWPro_Config.lua
+++ b/WoWPro/WoWPro_Config.lua
@@ -900,8 +900,7 @@ local options = {
                     set = function(info,r,g,b)
                         WoWProDB.profile.stickytitletextcolor = {r,g,b}
                         WoWPro.RowFontSet() end
-                    
-                },   
+                },
             },
         },
         guideList = {
@@ -963,7 +962,6 @@ local options = {
                         WoWProCharDB.DebugClasses = WoWPro.DebugClasses
                     end
                 },
-        
                 EnableGrailQuestline = {
                     order = 5.0,
                     type = "toggle",
@@ -978,7 +976,6 @@ local options = {
                         end
                     end
                 },
-        
                 EnableGrailCheckPrereq = {
                     order = 5.1,
                     type = "toggle",
@@ -993,7 +990,6 @@ local options = {
                         end
                     end
                 },
-        
                 EnableGrailBreadcrumbs = {
                     order = 5.2,
                     type = "toggle",
@@ -1050,7 +1046,6 @@ local options = {
                             end
                         end
                 },
-    
                 checkGuides = {
                     order = 6,
                     type = "execute",


### PR DESCRIPTION
with an about tab displaying discord link and addon version. Still needs magic Ludo to look at this if he can't fix current config page.

Up to you which PR you go with (Tabbed or list Version or none at all)

![image](https://github.com/Ludovicus-Maior/WoW-Pro-Guides/assets/6922184/30051226-06d7-496d-a3f1-84f6c6fb4711)
![image](https://github.com/Ludovicus-Maior/WoW-Pro-Guides/assets/6922184/c3bff873-08d8-4707-a63e-ddb66a685bd3)
![image](https://github.com/Ludovicus-Maior/WoW-Pro-Guides/assets/6922184/2f2b2217-95e9-4be9-8ca9-b55c28e8b036)
![image](https://github.com/Ludovicus-Maior/WoW-Pro-Guides/assets/6922184/e07dd735-93e4-42c2-8781-7be64e7d11aa)
![image](https://github.com/Ludovicus-Maior/WoW-Pro-Guides/assets/6922184/577822be-1abf-4bd0-b268-c45d37724f19)

Dailies, levelling and World events displaying too