### PR TITLE
Backwards compatibility for classic clients

### DIFF
--- a/WoWPro_Dailies/WoWPro_Dailies.lua
+++ b/WoWPro_Dailies/WoWPro_Dailies.lua
@@ -54,7 +54,7 @@ end
 local function get_faction_name(factionId)
     if _G.GetFactionInfoByID then
         return _G.GetFactionInfoByID(factionId)
-    else 
+    else
         local factionInfo = _G.C_Reputation.GetFactionDataByID(factionId)
         if factionInfo then
             return factionInfo.name

--- a/WoWPro_Dailies/WoWPro_Dailies.lua
+++ b/WoWPro_Dailies/WoWPro_Dailies.lua
@@ -50,6 +50,19 @@ function WoWPro.Dailies:RegisterGuide(guide)
     WoWPro:NoCache(guide)
 end
 
+-- Handle Wow API differences between Classic and modern game versions.
+local function get_faction_name(factionId)
+    if _G.GetFactionInfoByID then
+        return _G.GetFactionInfoByID(factionId)
+    else 
+        local factionInfo = _G.C_Reputation.GetFactionDataByID(factionId)
+        if factionInfo then
+            return factionInfo.name
+        end
+    end
+    return nil
+end
+
 function WoWPro.Dailies:GuideFaction(guide,faction, hfaction)
     if not hfaction then
         guide.faction = tonumber(faction)
@@ -60,10 +73,7 @@ function WoWPro.Dailies:GuideFaction(guide,faction, hfaction)
             guide.faction = tonumber(hfaction)
         end
     end
-    local factionInfo = _G.C_Reputation.GetFactionDataByID(guide.faction)
-    if factionInfo then
-        guide.name = factionInfo.name
-    end
+    guide.name = get_faction_name(guide.faction)
     guide.category = "Dailies"
 end
 

--- a/WoWPro_Recorder/WoWPro_Recorder.toc
+++ b/WoWPro_Recorder/WoWPro_Recorder.toc
@@ -1,4 +1,4 @@
-## Interface: 100207
+## Interface: 110000
 ## Title: |cffFF9900WoW-|r|cff46921APro|r Recorder
 ## Notes: Record and edit guides for use with the WoW-Pro Addon
 ## Author: Jiyambi


### PR DESCRIPTION
- Update Toc on Recorder as it's fully functional on 11.0.
- Added a backwards compatibility  logic to the faction name function as the new _G.C_Reputation.GetFactionDataByID isn't available on Classic and we need to continue to use the old function for those clients.