### PR TITLE
Tidy Up Guide Names

### DIFF
--- a/WoWPro_Profession/Vanilla/Alchemy_Classic_VAN.lua
+++ b/WoWPro_Profession/Vanilla/Alchemy_Classic_VAN.lua
@@ -1,10 +1,10 @@
 -- WoWPro Guides by "The WoW-Pro Community" are licensed under a Creative Commons Attribution-NonCommercial-NoDerivs 3.0 Unported License.
 -- Based on a work at  https://github.com/Ludovicus-Maior/WoW-Pro-Guides .
 -- The license is available at https://github.com/Ludovicus-Maior/WoW-Pro-Guides/blob/main/License.md  .
-local guide = WoWPro:RegisterGuide("BlancAlchemy_Classic","Profession","Alchemy_Classic", "WoWPro Team", "Neutral",1)
+local guide = WoWPro:RegisterGuide("Alchemy","Profession","Alchemy", "WoWPro Team", "Neutral",1)
 WoWPro:GuideIcon(guide,"PRO",171)
 WoWPro:GuideLevels(guide)
-WoWPro:GuideName(guide, "Alchemy_Classic")
+WoWPro:GuideName(guide, "Alchemy")
 WoWPro:GuideNickname(guide, "ALC_Classic")
 WoWPro:GuideSteps(guide, function()
 return [[

--- a/WoWPro_Profession/Vanilla/Blacksmithing_Classic_VAN.lua
+++ b/WoWPro_Profession/Vanilla/Blacksmithing_Classic_VAN.lua
@@ -1,10 +1,10 @@
 -- WoWPro Guides by "The WoW-Pro Community" are licensed under a Creative Commons Attribution-NonCommercial-NoDerivs 3.0 Unported License.
 -- Based on a work at  https://github.com/Ludovicus-Maior/WoW-Pro-Guides .
 -- The license is available at https://github.com/Ludovicus-Maior/WoW-Pro-Guides/blob/main/License.md  .
-local guide = WoWPro:RegisterGuide("BlancBSM_Classic","Profession","Blacksmithing_Classic", "WoWPro Team", "Neutral",1)
+local guide = WoWPro:RegisterGuide("Blacksmithing","Profession","Blacksmithing", "WoWPro Team", "Neutral",1)
 WoWPro:GuideIcon(guide,"PRO",164)
 WoWPro:GuideLevels(guide)
-WoWPro:GuideName(guide, "Blacksmithing_Classic")
+WoWPro:GuideName(guide, "Blacksmithing")
 WoWPro:GuideNickname(guide, "BSM_Classic")
 WoWPro:GuideSteps(guide, function()
 return [[

--- a/WoWPro_Profession/Vanilla/Enchanting_Classic_VAN.lua
+++ b/WoWPro_Profession/Vanilla/Enchanting_Classic_VAN.lua
@@ -1,10 +1,10 @@
 -- WoWPro Guides by "The WoW-Pro Community" are licensed under a Creative Commons Attribution-NonCommercial-NoDerivs 3.0 Unported License.
 -- Based on a work at  https://github.com/Ludovicus-Maior/WoW-Pro-Guides .
 -- The license is available at https://github.com/Ludovicus-Maior/WoW-Pro-Guides/blob/main/License.md  .
-local guide = WoWPro:RegisterGuide("BlancENCH_Classic", "Profession", "Enchanting_Classic", "WoWPro Team", "Neutral",1)
+local guide = WoWPro:RegisterGuide("Enchanting", "Profession", "Enchanting", "WoWPro Team", "Neutral",1)
 WoWPro:GuideIcon(guide,"PRO",333)
 WoWPro:GuideLevels(guide)
-WoWPro:GuideName(guide, "Enchanting_Classic")
+WoWPro:GuideName(guide, "Enchanting")
 WoWPro:GuideNickname(guide, "ENCH_Classic")
 WoWPro:GuideSteps(guide, function()
 return [[

--- a/WoWPro_Profession/Vanilla/Engineering_Classic_VAN.lua
+++ b/WoWPro_Profession/Vanilla/Engineering_Classic_VAN.lua
@@ -1,10 +1,10 @@
 -- WoWPro Guides by "The WoW-Pro Community" are licensed under a Creative Commons Attribution-NonCommercial-NoDerivs 3.0 Unported License.
 -- Based on a work at  https://github.com/Ludovicus-Maior/WoW-Pro-Guides .
 -- The license is available at https://github.com/Ludovicus-Maior/WoW-Pro-Guides/blob/main/License.md  .
-local guide = WoWPro:RegisterGuide("BlancEngineering_Classic", "Profession", "Engineering_Classic", "WoWPro Team", "Neutral", 1)
+local guide = WoWPro:RegisterGuide("Engineering", "Profession", "Engineering", "WoWPro Team", "Neutral", 1)
 WoWPro:GuideIcon(guide,"PRO",202)
 WoWPro:GuideLevels(guide)
-WoWPro:GuideName(guide, "Engineering_Classic")
+WoWPro:GuideName(guide, "Engineering")
 WoWPro:GuideSteps(guide, function()
 return [[
 ;  Guide structures:

--- a/WoWPro_Profession/Vanilla/First_Aid_Classic_VAN.lua
+++ b/WoWPro_Profession/Vanilla/First_Aid_Classic_VAN.lua
@@ -1,10 +1,10 @@
 -- WoWPro Guides by "The WoW-Pro Community" are licensed under a Creative Commons Attribution-NonCommercial-NoDerivs 3.0 Unported License.
 -- Based on a work at  https://github.com/Ludovicus-Maior/WoW-Pro-Guides .
 -- The license is available at https://github.com/Ludovicus-Maior/WoW-Pro-Guides/blob/main/License.md  .
-local guide = WoWPro:RegisterGuide("FirstAid_Cliassic_VAN", "Profession", "First Aid", "WoWPro Team", "Neutral", 1)
+local guide = WoWPro:RegisterGuide("First Aid", "Profession", "First Aid", "WoWPro Team", "Neutral", 1)
 WoWPro:GuideIcon(guide,"PRO",129)
 WoWPro:GuideLevels(guide)
-WoWPro:GuideName(guide, "First Aid Classic")
+WoWPro:GuideName(guide, "First Aid")
 WoWPro:GuideSteps(guide, function()
 return [[
 ;  Guide structures:

--- a/WoWPro_Profession/Vanilla/Leatherworking_Classic_VAN.lua
+++ b/WoWPro_Profession/Vanilla/Leatherworking_Classic_VAN.lua
@@ -1,10 +1,10 @@
 -- WoWPro Guides by "The WoW-Pro Community" are licensed under a Creative Commons Attribution-NonCommercial-NoDerivs 3.0 Unported License.
 -- Based on a work at  https://github.com/Ludovicus-Maior/WoW-Pro-Guides .
 -- The license is available at https://github.com/Ludovicus-Maior/WoW-Pro-Guides/blob/main/License.md  .
-local guide = WoWPro:RegisterGuide("BlancLeather_CLASSIC", "Profession", "Leatherworking_Classic", "WoWPro Team", "Neutral", 1)
+local guide = WoWPro:RegisterGuide("Leatherworking", "Profession", "Leatherworking", "WoWPro Team", "Neutral", 1)
 WoWPro:GuideIcon(guide,"PRO",165)
 WoWPro:GuideLevels(guide)
-WoWPro:GuideName(guide, "Leatherworking Classic")
+WoWPro:GuideName(guide, "Leatherworking")
 WoWPro:GuideSteps(guide, function()
 return [[
 ;  Guide structures:

--- a/WoWPro_Profession/Vanilla/Tailoring_Classic_VAN.lua
+++ b/WoWPro_Profession/Vanilla/Tailoring_Classic_VAN.lua
@@ -1,10 +1,10 @@
 -- WoWPro Guides by "The WoW-Pro Community" are licensed under a Creative Commons Attribution-NonCommercial-NoDerivs 3.0 Unported License.
 -- Based on a work at  https://github.com/Ludovicus-Maior/WoW-Pro-Guides .
 -- The license is available at https://github.com/Ludovicus-Maior/WoW-Pro-Guides/blob/main/License.md  .
-local guide = WoWPro:RegisterGuide("BlancTLR_Classic","Profession","Tailoring_Classic", "WoWPro Team", "Neutral",1)
+local guide = WoWPro:RegisterGuide("Tailoring","Profession","Tailoring", "WoWPro Team", "Neutral",1)
 WoWPro:GuideIcon(guide,"PRO",197)
 WoWPro:GuideLevels(guide)
-WoWPro:GuideName(guide, "Tailoring_Classic")
+WoWPro:GuideName(guide, "Tailoring)
 WoWPro:GuideNickname(guide, "TLR_Classic")
 WoWPro:GuideSteps(guide, function()
 return [[

--- a/WoWPro_Profession/Vanilla/Tailoring_Classic_VAN.lua
+++ b/WoWPro_Profession/Vanilla/Tailoring_Classic_VAN.lua
@@ -4,7 +4,7 @@
 local guide = WoWPro:RegisterGuide("Tailoring","Profession","Tailoring", "WoWPro Team", "Neutral",1)
 WoWPro:GuideIcon(guide,"PRO",197)
 WoWPro:GuideLevels(guide)
-WoWPro:GuideName(guide, "Tailoring)
+WoWPro:GuideName(guide, "Tailoring")
 WoWPro:GuideNickname(guide, "TLR_Classic")
 WoWPro:GuideSteps(guide, function()
 return [[


### PR DESCRIPTION
Remove the _CLASSIC from showing in easy menu

![image](https://github.com/Ludovicus-Maior/WoW-Pro-Guides/assets/6922184/0a80d185-c860-485d-9b97-00b6742543aa)
