### PR TITLE
Cata Header correction

### DIFF
--- a/WoWPro_Dailies/Classic_Cata/Alliance/Crack_TolBarad.lua
+++ b/WoWPro_Dailies/Classic_Cata/Alliance/Crack_TolBarad.lua
@@ -1,33 +1,12 @@
 
 -- WoWPro Guides by "The WoW-Pro Community" are licensed under a Creative Commons Attribution-NonCommercial-NoDerivs 3.0 Unported License.
 -- Based on a work at github.com.
--- Permissions beyond the scope of this license may be available at http://www.wow-pro.com/License.
+-- Permissions beyond the scope of this license may be available at http://github.com/Ludovicus-Maior/WoW-Pro-Guides/blob/main/License.md.
 
--- URL: http://wow-pro.com/wiki/alliance_baradin_wardens_reputation_dailies
--- Date: 2012-08-07 21:17
--- Who: Ludovicus Maior
--- Log: [Watch Out For Splinters!] with the bang!
-
--- URL: http://wow-pro.com/node/3414/revisions/24877/view
--- Date: 2011-12-29 02:21
--- Who: Crackerhead22
-
--- URL: http://wow-pro.com/node/3414/revisions/24876/view
--- Date: 2011-12-29 02:19
--- Who: Crackerhead22
--- Log: Split Tol Barad Peninsula and Tol Barad into two guides.
-
--- URL: http://wow-pro.com/node/3414/revisions/24679/view
--- Date: 2011-07-11 22:47
--- Who: Ludovicus Maior
--- Log: Fix  C [Cursed Shackels] and coords for turnin on Sergeant Parker.
-
--- URL: http://wow-pro.com/node/3414/revisions/24646/view
--- Date: 2011-06-30 18:56
--- Who: Ludovicus Maior
--- Log: Initial Create
-
-WoWPro.Dailies:RegisterGuide("CraToBarA", "Tol Barad", "Tol Barad Guide", "Cata", "Crackerhead22", "Alliance", function()
+local guide = WoWPro:RegisterGuide("CraToBarA",'Dailies', "Tol Barad", "Crackerhead22", "Alliance", "Cata")
+WoWPro:GuideLevels(guide ,35,60)
+WoWPro.Dailies:GuideFaction(guide,1177) --  "Tol Barad Guide"
+WoWPro:GuideSteps(guide, function()
 return [[
 
 R Tol Barad Peninsula|M|73.21,18.37|Z|Stormwind City|N|Click on the Portal to Tol Barad in Stormwind.|

--- a/WoWPro_Dailies/Classic_Cata/Alliance/Crack_TolBaradPen.lua
+++ b/WoWPro_Dailies/Classic_Cata/Alliance/Crack_TolBaradPen.lua
@@ -1,33 +1,12 @@
 
 -- WoWPro Guides by "The WoW-Pro Community" are licensed under a Creative Commons Attribution-NonCommercial-NoDerivs 3.0 Unported License.
 -- Based on a work at github.com.
--- Permissions beyond the scope of this license may be available at http://www.wow-pro.com/License.
+-- Permissions beyond the scope of this license may be available at http://github.com/Ludovicus-Maior/WoW-Pro-Guides/blob/main/License.md.
 
--- URL: http://wow-pro.com/wiki/alliance_baradin_wardens_reputation_dailies
--- Date: 2012-08-07 21:17
--- Who: Ludovicus Maior
--- Log: [Watch Out For Splinters!] with the bang!
-
--- URL: http://wow-pro.com/node/3414/revisions/24877/view
--- Date: 2011-12-29 02:21
--- Who: Crackerhead22
-
--- URL: http://wow-pro.com/node/3414/revisions/24876/view
--- Date: 2011-12-29 02:19
--- Who: Crackerhead22
--- Log: Split Tol Barad Peninsula and Tol Barad into two guides.
-
--- URL: http://wow-pro.com/node/3414/revisions/24679/view
--- Date: 2011-07-11 22:47
--- Who: Ludovicus Maior
--- Log: Fix  C [Cursed Shackels] and coords for turnin on Sergeant Parker.
-
--- URL: http://wow-pro.com/node/3414/revisions/24646/view
--- Date: 2011-06-30 18:56
--- Who: Ludovicus Maior
--- Log: Initial Create
-
-WoWPro.Dailies:RegisterGuide("CraToBarPA", "Tol Barad Peninsula", "Tol Barad Peninsula Guide", "Cata", "Crackerhead22", "Alliance", function()
+local guide = WoWPro:RegisterGuide("CraToBarPA", "Dailies", "Tol Barad Peninsula", "Crackerhead22", "Alliance", "Cata")
+WoWPro:GuideLevels(guide ,35,60)
+WoWPro.Dailies:GuideFaction(guide,1177) --  "Tol Barad Guide"
+WoWPro:GuideSteps(guide, function()
 return [[
 
 R Tol Barad Peninsula|M|73.21,18.37|Z|Stormwind City|N|Click on the Portal to Tol Barad in Stormwind.|

--- a/WoWPro_Dailies/Classic_Cata/Alliance/Ludovicus_ArgTour.lua
+++ b/WoWPro_Dailies/Classic_Cata/Alliance/Ludovicus_ArgTour.lua
@@ -1,10 +1,14 @@
 
 -- WoWPro Guides by "The WoW-Pro Community" are licensed under a Creative Commons Attribution-NonCommercial-NoDerivs 3.0 Unported License.
 -- Based on a work at github.com.
--- Permissions beyond the scope of this license may be available at http://www.wow-pro.com/License.
+-- Permissions beyond the scope of this license may be available at http://github.com/Ludovicus-Maior/WoW-Pro-Guides/blob/main/License.md.
 
-WoWPro.Dailies:RegisterGuide("LudoArgTour", "Icecrown", "Argent Tournament", "Lich", "Ludovicus", "Alliance", function()
+local guide = WoWPro:RegisterGuide("LudoArgTour",'Dailies', "Icecrown", "Ludovicus", "Alliance", "Cata")
+WoWPro:GuideLevels(guide ,25,60)
+WoWPro.Dailies:GuideFaction(guide,1094) --  "Argent Tournament"
+WoWPro:GuideSteps(guide, function()
 return [[
+
 N The Argent Tournament|N|Quests for the The Argent Tournament, for your faction, and MAYBE for the others too!|
 ; Setup Quests
 A The Argent Tournament|QID|13667|M|69.6,22.8|N|From Justicar Mariel Trueheart.|

--- a/WoWPro_Dailies/Classic_Cata/Alliance/Ludovicus_Icecrown.lua
+++ b/WoWPro_Dailies/Classic_Cata/Alliance/Ludovicus_Icecrown.lua
@@ -1,39 +1,14 @@
 
 -- WoWPro Guides by "The WoW-Pro Community" are licensed under a Creative Commons Attribution-NonCommercial-NoDerivs 3.0 Unported License.
 -- Based on a work at github.com.
--- Permissions beyond the scope of this license may be available at http://www.wow-pro.com/License.
+-- Permissions beyond the scope of this license may be available at http://github.com/Ludovicus-Maior/WoW-Pro-Guides/blob/main/License.md.
 
--- URL: http://wow-pro.com/wiki/icecrown_dalies
--- Date: 2012-05-27 18:29
--- Who: Ludovicus Maior
-
--- URL: http://wow-pro.com/node/3405/revisions/24984/view
--- Date: 2012-05-27 18:28
--- Who: Ludovicus Maior
-
--- URL: http://wow-pro.com/node/3405/revisions/24972/view
--- Date: 2012-03-14 21:17
--- Who: Ludovicus Maior
-
--- URL: http://wow-pro.com/node/3405/revisions/24971/view
--- Date: 2012-03-14 21:16
--- Who: Ludovicus Maior
-
--- URL: http://wow-pro.com/node/3405/revisions/24970/view
--- Date: 2012-03-03 16:22
--- Who: Ludovicus Maior
-
--- URL: http://wow-pro.com/node/3405/revisions/24969/view
--- Date: 2012-03-03 16:21
--- Who: Ludovicus Maior
--- Log: Split up guides.
-
--- URL: http://wow-pro.com/node/3405/revisions/24628/view
--- Date: 2011-06-29 21:12
--- Who: Ludovicus Maior
-
-WoWPro.Dailies:RegisterGuide("LudoIceDaily", "Icecrown", "Money", "Lich", "Ludovicus", "Alliance", function()
+local guide = WoWPro:RegisterGuide("LudoIceDaily",'Dailies', "Icecrown", "Ludovicus", "Alliance", "Cata")
+WoWPro:GuideLevels(guide ,25,60)
+WoWPro.Dailies:GuideNameAndCategory(guide,"Icecrown Dailies","Money")
+WoWPro:GuideSteps(guide, function()
 return [[
+
 N Gold and Experience|N|Quests that give no rep, but do yield gold.|
 
 A Drag and Drop|QID|13323|N|From Thassarian, he's standing on the left "wing" of the Skybreaker.|

--- a/WoWPro_Dailies/Classic_Cata/Alliance/Ludovicus_ValExp.lua
+++ b/WoWPro_Dailies/Classic_Cata/Alliance/Ludovicus_ValExp.lua
@@ -1,39 +1,14 @@
 
 -- WoWPro Guides by "The WoW-Pro Community" are licensed under a Creative Commons Attribution-NonCommercial-NoDerivs 3.0 Unported License.
 -- Based on a work at github.com.
--- Permissions beyond the scope of this license may be available at http://www.wow-pro.com/License.
+-- Permissions beyond the scope of this license may be available at http://github.com/Ludovicus-Maior/WoW-Pro-Guides/blob/main/License.md.
 
--- URL: http://wow-pro.com/wiki/icecrown_dalies
--- Date: 2012-05-27 18:29
--- Who: Ludovicus Maior
-
--- URL: http://wow-pro.com/node/3405/revisions/24984/view
--- Date: 2012-05-27 18:28
--- Who: Ludovicus Maior
-
--- URL: http://wow-pro.com/node/3405/revisions/24972/view
--- Date: 2012-03-14 21:17
--- Who: Ludovicus Maior
-
--- URL: http://wow-pro.com/node/3405/revisions/24971/view
--- Date: 2012-03-14 21:16
--- Who: Ludovicus Maior
-
--- URL: http://wow-pro.com/node/3405/revisions/24970/view
--- Date: 2012-03-03 16:22
--- Who: Ludovicus Maior
-
--- URL: http://wow-pro.com/node/3405/revisions/24969/view
--- Date: 2012-03-03 16:21
--- Who: Ludovicus Maior
--- Log: Split up guides.
-
--- URL: http://wow-pro.com/node/3405/revisions/24628/view
--- Date: 2011-06-29 21:12
--- Who: Ludovicus Maior
-
-WoWPro.Dailies:RegisterGuide("LudoValExp", "Northrend", "Valiance Expedition", "Lich", "Ludovicus", "Alliance", function()
+local guide = WoWPro:RegisterGuide("LudoValExp",'Dailies', "Northrend", "Ludovicus", "Alliance", "Cata")
+WoWPro:GuideLevels(guide ,10,60)
+WoWPro.Dailies:GuideFaction(guide,1050) --  "Valiance Expedition"
+WoWPro:GuideSteps(guide, function()
 return [[
+
 N Valiance Expedition|N|The Howling Fjord Valiance Expedition Reputation Daily.|
 
 A Break the Blockade |QID|11153|M|29.0,41.9|Z|Howling Fjord|N|From Bombardier Petrov.|

--- a/WoWPro_Dailies/Classic_Cata/Alliance/PilgrimsBounty.lua
+++ b/WoWPro_Dailies/Classic_Cata/Alliance/PilgrimsBounty.lua
@@ -1,20 +1,15 @@
 
 -- WoWPro Guides by "The WoW-Pro Community" are licensed under a Creative Commons Attribution-NonCommercial-NoDerivs 3.0 Unported License.
 -- Based on a work at github.com.
--- Permissions beyond the scope of this license may be available at http://www.wow-pro.com/License.
+-- Permissions beyond the scope of this license may be available at http://github.com/Ludovicus-Maior/WoW-Pro-Guides/blob/main/License.md.
 
--- URL: http://wow-pro.com/wiki/pilgrimsbountydalies_alliance_and_horde
--- Date: 2012-01-19 00:02
--- Who: Ludovicus Maior
--- Log: Correct node numbers
-
--- URL: http://wow-pro.com/node/3456/revisions/24896/view
--- Date: 2012-01-19 00:00
--- Who: Ludovicus Maior
--- Log: Sync to GIT
-
-WoWPro.Dailies:RegisterGuide("LudoPilgrimDailiesA","Pilgrim's Bounty","Pilgrim's Bounty","WE", "Ludovicus", "Alliance", function()
+local guide = WoWPro:RegisterGuide("LudoPilgrimDailiesA",'Dailies',"Pilgrim's Bounty", "Ludovicus", "Alliance", "Cata")
+WoWPro:GuideLevels(guide ,1,60)
+WoWPro.Dailies:GuideNameAndCategory(guide,"Pilgrim's Bounty", "Holidays")
+WoWPro:GuideIcon(guide,"ACH",3596)
+WoWPro:GuideSteps(guide, function()
 return [[
+
 N Pilgrim's Bounty Start|N|Get thee to Stormwind City Gates.|
 A She Says Potato|QID|14055|M|33.88,50.80|Z|Elwynn Forest|N|From Jasper Moore, Stormwind City Gates.|
 A We're Out of Cranberry Chutney Again?|QID|14053|M|33.72,50.64|Z|Elwynn Forest|N|From Ellen Moore.|

--- a/WoWPro_Dailies/Classic_Cata/Alliance/Twists_Wildhammer.lua
+++ b/WoWPro_Dailies/Classic_Cata/Alliance/Twists_Wildhammer.lua
@@ -1,18 +1,12 @@
 
 -- WoWPro Guides by "The WoW-Pro Community" are licensed under a Creative Commons Attribution-NonCommercial-NoDerivs 3.0 Unported License.
 -- Based on a work at github.com.
--- Permissions beyond the scope of this license may be available at http://www.wow-pro.com/License.
+-- Permissions beyond the scope of this license may be available at http://github.com/Ludovicus-Maior/WoW-Pro-Guides/blob/main/License.md.
 
--- URL: http://wow-pro.com/wiki/alliance_wildhammer_dalies_twilight_highlands
--- Date: 2011-07-11 22:20
--- Who: Ludovicus Maior
--- Log: Add a flight point home.
-
--- URL: http://wow-pro.com/node/3415/revisions/24647/view
--- Date: 2011-06-30 19:01
--- Who: Ludovicus Maior
-
-WoWPro.Dailies:RegisterGuide("TwiTwiWil", "Twilight Highlands", "Wildhammer", "Cata", "Twists", "Alliance", function()
+local guide = WoWPro:RegisterGuide("TwiTwiWil",'Dailies', "Twilight Highlands", "Twists", "Alliance", "Cata")
+WoWPro:GuideLevels(guide ,30,60)
+WoWPro.Dailies:GuideFaction(guide,1174) --  "Wildhammer"
+WoWPro:GuideSteps(guide, function()
 return [[
 
 A Fight Like a Wildhammer|QID|28861|M|49.76,29.23|N|From Low Shaman Blundy.|

--- a/WoWPro_Dailies/Classic_Cata/Horde/Crack_TolBarad.lua
+++ b/WoWPro_Dailies/Classic_Cata/Horde/Crack_TolBarad.lua
@@ -1,22 +1,12 @@
 
 -- WoWPro Guides by "The WoW-Pro Community" are licensed under a Creative Commons Attribution-NonCommercial-NoDerivs 3.0 Unported License.
 -- Based on a work at github.com.
--- Permissions beyond the scope of this license may be available at http://www.wow-pro.com/License.
+-- Permissions beyond the scope of this license may be available at http://github.com/Ludovicus-Maior/WoW-Pro-Guides/blob/main/License.md.
 
--- URL: http://wow-pro.com/wiki/horde_hellsream039s_reach_reputation_dailies
--- Date: 2011-12-29 02:26
--- Who: Crackerhead22
-
--- URL: http://wow-pro.com/node/3416/revisions/24878/view
--- Date: 2011-12-29 02:25
--- Who: Crackerhead22
--- Log: Split Tol Barad Peninsula and Tol Barad guides.
-
--- URL: http://wow-pro.com/node/3416/revisions/24648/view
--- Date: 2011-06-30 19:05
--- Who: Ludovicus Maior
-
-WoWPro.Dailies:RegisterGuide("CraToBarH", "Tol Barad", "Tol Barad Guide", "Cata", "Crackerhead22", "Horde", function()
+local guide = WoWPro:RegisterGuide("CraToBarH",'Dailies', "Tol Barad", "Crackerhead22", "Horde", "Cata")
+WoWPro:GuideLevels(guide ,35,60)
+WoWPro.Dailies:GuideFaction(guide,1178) --  "Hellscream's Reach"
+WoWPro:GuideSteps(guide, function()
 return [[
 
 R Tol Barad Peninsula|M|47.41,39.3|Z|Orgimmar|N|Click on the Portal to Tol Barad in Orgimmar.|

--- a/WoWPro_Dailies/Classic_Cata/Horde/Crack_TolBaradPen.lua
+++ b/WoWPro_Dailies/Classic_Cata/Horde/Crack_TolBaradPen.lua
@@ -1,22 +1,12 @@
 
 -- WoWPro Guides by "The WoW-Pro Community" are licensed under a Creative Commons Attribution-NonCommercial-NoDerivs 3.0 Unported License.
 -- Based on a work at github.com.
--- Permissions beyond the scope of this license may be available at http://www.wow-pro.com/License.
+-- Permissions beyond the scope of this license may be available at http://github.com/Ludovicus-Maior/WoW-Pro-Guides/blob/main/License.md.
 
--- URL: http://wow-pro.com/wiki/horde_hellsream039s_reach_reputation_dailies
--- Date: 2011-12-29 02:26
--- Who: Crackerhead22
-
--- URL: http://wow-pro.com/node/3416/revisions/24878/view
--- Date: 2011-12-29 02:25
--- Who: Crackerhead22
--- Log: Split Tol Barad Peninsula and Tol Barad guides.
-
--- URL: http://wow-pro.com/node/3416/revisions/24648/view
--- Date: 2011-06-30 19:05
--- Who: Ludovicus Maior
-
-WoWPro.Dailies:RegisterGuide("CraToBarPH", "Tol Barad Peninsula", "Tol Barad Peninsula Guide", "Cata", "Crackerhead22", "Horde", function()
+local guide = WoWPro:RegisterGuide("CraToBarPH",'Dailies', "Tol Barad Peninsula", "Crackerhead22", "Horde", "Cata")
+WoWPro:GuideLevels(guide ,35,60)
+WoWPro.Dailies:GuideFaction(guide,1178) --  "Hellscream's Reach"
+WoWPro:GuideSteps(guide, function()
 return [[
 
 R Tol Barad Peninsula|M|47.41,39.3|Z|Orgimmar|N|Click on the Portal to Tol Barad in Orgimmar.|

--- a/WoWPro_Dailies/Classic_Cata/Horde/PilgrimsBounty.lua
+++ b/WoWPro_Dailies/Classic_Cata/Horde/PilgrimsBounty.lua
@@ -1,20 +1,15 @@
 
 -- WoWPro Guides by "The WoW-Pro Community" are licensed under a Creative Commons Attribution-NonCommercial-NoDerivs 3.0 Unported License.
 -- Based on a work at github.com.
--- Permissions beyond the scope of this license may be available at http://www.wow-pro.com/License.
+-- Permissions beyond the scope of this license may be available at http://github.com/Ludovicus-Maior/WoW-Pro-Guides/blob/main/License.md.
 
--- URL: http://wow-pro.com/wiki/pilgrimsbountydalies_alliance_and_horde
--- Date: 2012-01-19 00:02
--- Who: Ludovicus Maior
--- Log: Correct node numbers
-
--- URL: http://wow-pro.com/node/3456/revisions/24896/view
--- Date: 2012-01-19 00:00
--- Who: Ludovicus Maior
--- Log: Sync to GIT
-
-WoWPro.Dailies:RegisterGuide("LudoPilgrimDailiesH","Pilgrim's Bounty","Pilgrim's Bounty","WE", "Ludovicus", "Horde", function()
+local guide = WoWPro:RegisterGuide("LudoPilgrimDailiesH",'Dailies',"Pilgrim's Bounty", "Ludovicus", "Horde", "Cata")
+WoWPro:GuideLevels(guide ,1,60)
+WoWPro.Dailies:GuideNameAndCategory(guide,"Pilgrim's Bounty", "Holidays")
+WoWPro:GuideIcon(guide,"ACH",3597)
+WoWPro:GuideSteps(guide, function()
 return [[
+
 N Pilgrim's Bounty Start|N|Get thee to Orgrimmar city gates..|
 A Can't Get Enough Turkey|QID|14061|M|46.37,13.85|Z|Durotar|N|From Ondani Greatmill, near Orgrimmar city gates.|
 A Don't Forget The Stuffing!|QID|14062|M|46.37,13.85|Z|Durotar|N|From Ondani Greatmill, near Orgrimmar city gates.|

--- a/WoWPro_Dailies/Classic_Cata/Neutral/Cracker_Frenzy.lua
+++ b/WoWPro_Dailies/Classic_Cata/Neutral/Cracker_Frenzy.lua
@@ -1,10 +1,14 @@
 
 -- WoWPro Guides by "The WoW-Pro Community" are licensed under a Creative Commons Attribution-NonCommercial-NoDerivs 3.0 Unported License.
 -- Based on a work at github.com.
--- Permissions beyond the scope of this license may be available at http://www.wow-pro.com/License.
+-- Permissions beyond the scope of this license may be available at http://github.com/Ludovicus-Maior/WoW-Pro-Guides/blob/main/License.md.
 
-WoWPro.Dailies:RegisterGuide("CraShoFre", "Sholazar Basin", "Frenzyheart Tribe", "WTLK", "Crackerhead22", "Neutral", function()
+local guide = WoWPro:RegisterGuide("CraShoFre",'Dailies', "Sholazar Basin", "Crackerhead22", "Neutral", "Cata")
+WoWPro:GuideLevels(guide,74,77,76.5)
+WoWPro.Dailies:GuideFaction(guide,1104) --  "Frenzyheart Tribe"
+WoWPro:GuideSteps(guide, function()
 return [[
+
 
 R Frenzyheart Hill|M|55.79,68.18|N|Head to Sholazar Basin and go to Frenzyheart Hill.|
 

--- a/WoWPro_Dailies/Classic_Cata/Neutral/Cracker_Oracles.lua
+++ b/WoWPro_Dailies/Classic_Cata/Neutral/Cracker_Oracles.lua
@@ -1,18 +1,12 @@
 
 -- WoWPro Guides by "The WoW-Pro Community" are licensed under a Creative Commons Attribution-NonCommercial-NoDerivs 3.0 Unported License.
 -- Based on a work at github.com.
--- Permissions beyond the scope of this license may be available at http://www.wow-pro.com/License.
+-- Permissions beyond the scope of this license may be available at http://github.com/Ludovicus-Maior/WoW-Pro-Guides/blob/main/License.md.
 
--- URL: http://wow-pro.com/wiki/neutral_oracles_reputation_dalies_sholazar_basin
--- Date: 2012-05-27 18:35
--- Who: Ludovicus Maior
--- Log: Fixed some coordinates.
-
--- URL: http://wow-pro.com/node/3418/revisions/24650/view
--- Date: 2011-06-30 19:10
--- Who: Ludovicus Maior
-
-WoWPro.Dailies:RegisterGuide("CraShoOra", "Sholazar Basin", "The Oracles Reputation", "WTLK", "Crackerhead22", "Neutral", function()
+local guide = WoWPro:RegisterGuide("CraShoOra",'Dailies', "Sholazar Basin", "Crackerhead22", "Neutral", "Cata")
+WoWPro:GuideLevels(guide,76,77,76.5)
+WoWPro.Dailies:GuideFaction(guide,1105) --  "The Oracles Reputation"
+WoWPro:GuideSteps(guide, function()
 return [[
 
 R Rainspeaker Canopy|M|54.49,56.14|N|Head to Sholazar Basin and go to the Rainspeaker Canopy.|

--- a/WoWPro_Dailies/Classic_Cata/Neutral/Est_Firelands.lua
+++ b/WoWPro_Dailies/Classic_Cata/Neutral/Est_Firelands.lua
@@ -1,75 +1,12 @@
 
 -- WoWPro Guides by "The WoW-Pro Community" are licensed under a Creative Commons Attribution-NonCommercial-NoDerivs 3.0 Unported License.
 -- Based on a work at github.com.
--- Permissions beyond the scope of this license may be available at http://www.wow-pro.com/License.
+-- Permissions beyond the scope of this license may be available at http://github.com/Ludovicus-Maior/WoW-Pro-Guides/blob/main/License.md.
 
--- URL: http://wow-pro.com/wiki/neutral_firelands_invasion_daily_guide
--- Date: 2012-06-30 20:52
--- Who: Ludovicus Maior
--- Log: Relocate [Well Armed] and [Aid of the Ancients] for better quest flow.
-
--- URL: http://wow-pro.com/node/3469/revisions/25004/view
--- Date: 2012-06-08 14:22
--- Who: Ludovicus Maior
--- Log: Got rid of unneeded |O| tags and warnings.
---	Nonlinear quest unlocks have been working reliably.
-
--- URL: http://wow-pro.com/node/3469/revisions/24999/view
--- Date: 2012-05-27 22:59
--- Who: Ludovicus Maior
--- Log: Edits to guide having played it to the Shadow Wardens fork.
-
--- URL: http://wow-pro.com/node/3469/revisions/24977/view
--- Date: 2012-05-19 01:16
--- Who: Ludovicus Maior
--- Log: Fixed Links....
-
--- URL: http://wow-pro.com/node/3469/revisions/24961/view
--- Date: 2012-02-16 12:57
--- Who: Estelyen
--- Log: Forgot an ACH tag, added now
-
--- URL: http://wow-pro.com/node/3469/revisions/24960/view
--- Date: 2012-02-15 12:28
--- Who: Estelyen
-
--- URL: http://wow-pro.com/node/3469/revisions/24959/view
--- Date: 2012-02-15 12:18
--- Who: Estelyen
-
--- URL: http://wow-pro.com/node/3469/revisions/24958/view
--- Date: 2012-02-15 12:02
--- Who: Estelyen
--- Log: Fixed a sticky step not being unstickied
-
--- URL: http://wow-pro.com/node/3469/revisions/24957/view
--- Date: 2012-02-15 11:33
--- Who: Estelyen
--- Log: Final revision with last additions before a complete test from step 1 with a new char commences.
-
--- URL: http://wow-pro.com/node/3469/revisions/24953/view
--- Date: 2012-02-13 21:36
--- Who: Ludovicus Maior
-
--- URL: http://wow-pro.com/node/3469/revisions/24952/view
--- Date: 2012-02-13 20:42
--- Who: Ludovicus Maior
-
--- URL: http://wow-pro.com/node/3469/revisions/24951/view
--- Date: 2012-02-13 20:40
--- Who: Ludovicus Maior
-
--- URL: http://wow-pro.com/node/3469/revisions/24950/view
--- Date: 2012-02-13 10:50
--- Who: Estelyen
--- Log: -Updated version (though still work in progress)
---	-Unrelated quests removed
-
--- URL: http://wow-pro.com/node/3469/revisions/24948/view
--- Date: 2012-02-13 01:00
--- Who: Ludovicus Maior
-
-WoWPro.Dailies:RegisterGuide("EstFirelands", "Mount Hyjal", "Firelands Invasion", "Cata", "Estelyen", "Neutral", function()
+local guide = WoWPro:RegisterGuide("EstFirelands",'Dailies', "Mount Hyjal", "Estelyen", "Neutral", "Cata")
+WoWPro:GuideLevels(guide,85,85,85)
+WoWPro.Dailies:GuideFaction(guide,1158) --  "Firelands Invasion, Guardians of Hyjal"
+WoWPro:GuideSteps(guide, function()
 return [[
 
 A Guardians of Hyjal: Firelands Invasion!|QID|29388|FACTION|Horde|LEAD|29145|N|You need to have completed all the quests in Mount Hyjal up to Aessina's Miracle and be Level 85 to start the Firelands Invasion. If you fulfill these requirements, get this Quest from your nearest Warchief's Command Board.|Z|Orgrimmar|

--- a/WoWPro_Dailies/Classic_Cata/Neutral/Jiyambi_Therazane.lua
+++ b/WoWPro_Dailies/Classic_Cata/Neutral/Jiyambi_Therazane.lua
@@ -1,23 +1,12 @@
 
 -- WoWPro Guides by "The WoW-Pro Community" are licensed under a Creative Commons Attribution-NonCommercial-NoDerivs 3.0 Unported License.
 -- Based on a work at github.com.
--- Permissions beyond the scope of this license may be available at http://www.wow-pro.com/License.
+-- Permissions beyond the scope of this license may be available at http://github.com/Ludovicus-Maior/WoW-Pro-Guides/blob/main/License.md.
 
--- URL: http://wow-pro.com/wiki/neutral_therazane_reputation_dalies_deepholm
--- Date: 2012-05-27 18:40
--- Who: Ludovicus Maior
--- Log: Added REP tags, a few coord fixes and redirected a quest to the right NPC.
-
--- URL: http://wow-pro.com/node/3419/revisions/24678/view
--- Date: 2011-07-11 22:39
--- Who: Ludovicus Maior
--- Log: Removing REP tag.
-
--- URL: http://wow-pro.com/node/3419/revisions/24651/view
--- Date: 2011-06-30 19:13
--- Who: Ludovicus Maior
-
-WoWPro.Dailies:RegisterGuide("JiyDeeTher", "Deepholm", "Therazane Reputation", "Cata", "Jiyambi", "Neutral", function()
+local guide = WoWPro:RegisterGuide("JiyDeeTher",'Dailies', "Deepholm", "Jiyambi", "Neutral", "Cata")
+WoWPro:GuideLevels(guide,81,81,81)
+WoWPro.Dailies:GuideFaction(guide,1171) --  "Therazane Reputation"
+WoWPro:GuideSteps(guide, function()
 return [[
 
 N Deepholm Quests|QID|26709|N|You must have completed the quests in Deepholm in order to unlock these dailies. The best way to get this done is to use the WoW-Pro Leveling guide for Deepholm.|

--- a/WoWPro_Dailies/Classic_Cata/Neutral/Ludo_Anglers.lua
+++ b/WoWPro_Dailies/Classic_Cata/Neutral/Ludo_Anglers.lua
@@ -1,27 +1,12 @@
 
 -- WoWPro Guides by "The WoW-Pro Community" are licensed under a Creative Commons Attribution-NonCommercial-NoDerivs 3.0 Unported License.
 -- Based on a work at github.com.
--- Permissions beyond the scope of this license may be available at http://www.wow-pro.com/License.
+-- Permissions beyond the scope of this license may be available at http://github.com/Ludovicus-Maior/WoW-Pro-Guides/blob/main/License.md.
 
--- URL: http://wow-pro.com/wiki/anglers_reputation
--- Date: 2012-11-08 19:08
--- Who: Ludovicus Maior
--- Log: Coord Corrections.
-
--- URL: http://wow-pro.com/node/3509/revisions/25187/view
--- Date: 2012-11-08 17:44
--- Who: Ludovicus Maior
--- Log: OK, First complete draft.  Time to test!
-
--- URL: http://wow-pro.com/node/3509/revisions/25186/view
--- Date: 2012-11-08 15:42
--- Who: Ludovicus Maior
-
--- URL: http://wow-pro.com/node/3509/revisions/25120/view
--- Date: 2012-10-07 22:40
--- Who: Ludovicus Maior
-
-WoWPro.Dailies:RegisterGuide("LudoAnglers", "Krasarang Wilds", "The Anglers Reputation", "MoP", "Ludovicus", "Neutral", function()
+local guide = WoWPro:RegisterGuide("LudoAnglers",'Dailies', "Krasarang Wilds", "Ludovicus", "Neutral", "Cata")
+WoWPro:GuideLevels(guide,35,35,35)
+WoWPro.Dailies:GuideFaction(guide,1302) --  "The Anglers Reputation"
+WoWPro:GuideSteps(guide, function()
 return [[
 
 ; Leadin quests, 'cause I'm OCD

--- a/WoWPro_Dailies/Classic_Cata/Neutral/Ludo_ArgCrusade.lua
+++ b/WoWPro_Dailies/Classic_Cata/Neutral/Ludo_ArgCrusade.lua
@@ -1,20 +1,14 @@
 
 -- WoWPro Guides by "The WoW-Pro Community" are licensed under a Creative Commons Attribution-NonCommercial-NoDerivs 3.0 Unported License.
 -- Based on a work at github.com.
--- Permissions beyond the scope of this license may be available at http://www.wow-pro.com/License.
+-- Permissions beyond the scope of this license may be available at http://github.com/Ludovicus-Maior/WoW-Pro-Guides/blob/main/License.md.
 
--- URL: http://wow-pro.com/wiki/argent_crusade_and_argent_dawn_reputation_dalies
--- Date: 2012-09-25 00:23
--- Who: Ludovicus Maior
--- Log: Wrong separators in [Captain Grondel's Task]
-
--- URL: http://wow-pro.com/node/3479/revisions/24998/view
--- Date: 2012-05-27 22:30
--- Who: Ludovicus Maior
--- Log: INitial Versions
-
-WoWPro.Dailies:RegisterGuide("LudoArgCrusade", "Icecrown", "Argent Crusade", "Lich", "Ludovicus", "Neutral", function()
+local guide = WoWPro:RegisterGuide("LudoArgCrusade",'Dailies', "Icecrown", "Ludovicus", "Neutral", "Cata")
+WoWPro:GuideLevels(guide,74,77,74.2)
+WoWPro.Dailies:GuideFaction(guide,1106) --  "Argent Crusade"
+WoWPro:GuideSteps(guide, function()
 return [[
+
 N Argent Crusade|N|The Argent Crusade Reputation Dalies.|
 
 A Slaves to Saronite|QID|13300|FACTION|Alliance|N|To Absalan the Pious. He patrols around on the Deck of the Skybreaker.|

--- a/WoWPro_Dailies/Classic_Cata/Neutral/Ludo_ArgDawn.lua
+++ b/WoWPro_Dailies/Classic_Cata/Neutral/Ludo_ArgDawn.lua
@@ -1,20 +1,14 @@
 
 -- WoWPro Guides by "The WoW-Pro Community" are licensed under a Creative Commons Attribution-NonCommercial-NoDerivs 3.0 Unported License.
 -- Based on a work at github.com.
--- Permissions beyond the scope of this license may be available at http://www.wow-pro.com/License.
+-- Permissions beyond the scope of this license may be available at http://github.com/Ludovicus-Maior/WoW-Pro-Guides/blob/main/License.md.
 
--- URL: http://wow-pro.com/wiki/argent_crusade_and_argent_dawn_reputation_dalies
--- Date: 2012-09-25 00:23
--- Who: Ludovicus Maior
--- Log: Wrong separators in [Captain Grondel's Task]
-
--- URL: http://wow-pro.com/node/3479/revisions/24998/view
--- Date: 2012-05-27 22:30
--- Who: Ludovicus Maior
--- Log: INitial Versions
-
-WoWPro.Dailies:RegisterGuide("LudoArgDawn", "Eastern Plaguelands", "Argent Dawn", "BC", "Ludovicus", "Neutral", function()
+local guide = WoWPro:RegisterGuide("LudoArgDawn",'Dailies', "Eastern Plaguelands", "Ludovicus", "Neutral", "Cata")
+WoWPro:GuideLevels(guide,1,90,45.000000)
+WoWPro.Dailies:GuideFaction(guide,529) --  "Argent Dawn"
+WoWPro:GuideSteps(guide, function()
 return [[
+
 N Argent Dawn|N|The Argent Dawn Reputation Dungeon quests.  Can be soloed repeatedly for a fast grind!|
 F Light's Hope Chapel|N|Fly to the chapel.|
 h Light's Hope Chapel|M|75.64,52.40|N|Set your hearth here to get out of the dungeons fast.|

--- a/WoWPro_Dailies/Classic_Cata/Neutral/Ludo_DalCook.lua
+++ b/WoWPro_Dailies/Classic_Cata/Neutral/Ludo_DalCook.lua
@@ -1,9 +1,12 @@
 
 -- WoWPro Guides by "The WoW-Pro Community" are licensed under a Creative Commons Attribution-NonCommercial-NoDerivs 3.0 Unported License.
 -- Based on a work at github.com.
--- Permissions beyond the scope of this license may be available at http://www.wow-pro.com/License.
+-- Permissions beyond the scope of this license may be available at http://github.com/Ludovicus-Maior/WoW-Pro-Guides/blob/main/License.md.
 
-WoWPro.Dailies:RegisterGuide("LudoDalCook", "Dalaran", "Dalaran Cooking", "Lich", "Ludovicus", "Neutral", function()
+local guide = WoWPro:RegisterGuide("LudoDalCook",'Dailies', "Dalaran", "Ludovicus", "Neutral", "Cata")
+WoWPro:GuideLevels(guide,10,10,10)
+WoWPro.Dailies:GuideNameAndCategory(guide,"Dalaran Cooking", "Professions")
+WoWPro:GuideSteps(guide, function()
 return [[
 
 A One of Five|QID|13103;13101;13100;13107;13102|FACTION|Alliance|M|40.4,65.8|N|From Katherine Lee.|

--- a/WoWPro_Dailies/Classic_Cata/Neutral/Ludo_DalFish.lua
+++ b/WoWPro_Dailies/Classic_Cata/Neutral/Ludo_DalFish.lua
@@ -1,10 +1,14 @@
 
 -- WoWPro Guides by "The WoW-Pro Community" are licensed under a Creative Commons Attribution-NonCommercial-NoDerivs 3.0 Unported License.
 -- Based on a work at github.com.
--- Permissions beyond the scope of this license may be available at http://www.wow-pro.com/License.
+-- Permissions beyond the scope of this license may be available at http://github.com/Ludovicus-Maior/WoW-Pro-Guides/blob/main/License.md.
 
-WoWPro.Dailies:RegisterGuide("LudoDalFish", "Dalaran", "Dalaran Fishing", "Lich", "Ludovicus", "Neutral", function()
+local guide = WoWPro:RegisterGuide("LudoDalFish",'Dailies', "Dalaran City@Dalaran", "Ludovicus", "Neutral", "Cata")
+WoWPro:GuideLevels(guide,10,10,10)
+WoWPro.Dailies:GuideNameAndCategory(guide,"Dalaran Fishing", "Professions")
+WoWPro:GuideSteps(guide, function()
 return [[
+
 
 A One of Five|QID|13832;13833;13834;13836|M|52.6,64.8|N|From Marcia Chase|
 

--- a/WoWPro_Dailies/Classic_Cata/Neutral/Ludo_EbonBlade.lua
+++ b/WoWPro_Dailies/Classic_Cata/Neutral/Ludo_EbonBlade.lua
@@ -1,39 +1,14 @@
 
 -- WoWPro Guides by "The WoW-Pro Community" are licensed under a Creative Commons Attribution-NonCommercial-NoDerivs 3.0 Unported License.
 -- Based on a work at github.com.
--- Permissions beyond the scope of this license may be available at http://www.wow-pro.com/License.
+-- Permissions beyond the scope of this license may be available at http://github.com/Ludovicus-Maior/WoW-Pro-Guides/blob/main/License.md.
 
--- URL: http://wow-pro.com/wiki/icecrown_dalies
--- Date: 2012-05-27 18:29
--- Who: Ludovicus Maior
-
--- URL: http://wow-pro.com/node/3405/revisions/24984/view
--- Date: 2012-05-27 18:28
--- Who: Ludovicus Maior
-
--- URL: http://wow-pro.com/node/3405/revisions/24972/view
--- Date: 2012-03-14 21:17
--- Who: Ludovicus Maior
-
--- URL: http://wow-pro.com/node/3405/revisions/24971/view
--- Date: 2012-03-14 21:16
--- Who: Ludovicus Maior
-
--- URL: http://wow-pro.com/node/3405/revisions/24970/view
--- Date: 2012-03-03 16:22
--- Who: Ludovicus Maior
-
--- URL: http://wow-pro.com/node/3405/revisions/24969/view
--- Date: 2012-03-03 16:21
--- Who: Ludovicus Maior
--- Log: Split up guides.
-
--- URL: http://wow-pro.com/node/3405/revisions/24628/view
--- Date: 2011-06-29 21:12
--- Who: Ludovicus Maior
-
-WoWPro.Dailies:RegisterGuide("LudoEbonBlade", "Icecrown", "Ebon Blade", "Lich", "Ludovicus", "Neutral", function()
+local guide = WoWPro:RegisterGuide("LudoEbonBlade",'Dailies', "Icecrown", "Ludovicus", "Neutral", "Cata")
+WoWPro:GuideLevels(guide,1,90,45.000000)
+WoWPro.Dailies:GuideFaction(guide,1098) --  "Knights of the Ebon Blade"
+WoWPro:GuideSteps(guide, function()
 return [[
+
 N Knights of the Ebon Blade|N|The Knights of the Ebon Blade Reputation Dalies.|
 A Reading the Bones|QID|13093|M|32.50,42.95|N|If you have 15 Vrykul Bones, give them to the The Bone Witch.|
 A From Their Corpses, Rise!|QID|12813|M|19.67,48.38|N|From Setaal Darkmender.|

--- a/WoWPro_Dailies/Classic_Cata/Neutral/Ludo_Hodir.lua
+++ b/WoWPro_Dailies/Classic_Cata/Neutral/Ludo_Hodir.lua
@@ -1,9 +1,12 @@
 
 -- WoWPro Guides by "The WoW-Pro Community" are licensed under a Creative Commons Attribution-NonCommercial-NoDerivs 3.0 Unported License.
 -- Based on a work at github.com.
--- Permissions beyond the scope of this license may be available at http://www.wow-pro.com/License.
+-- Permissions beyond the scope of this license may be available at http://github.com/Ludovicus-Maior/WoW-Pro-Guides/blob/main/License.md.
 
-WoWPro.Dailies:RegisterGuide("LudoHodir", "The Storm Peaks", "The Sons of Hodir", "Lich", "Ludovicus", "Neutral", function()
+local guide = WoWPro:RegisterGuide("LudoHodir",'Dailies', "The Storm Peaks", "Ludovicus", "Neutral", "Cata")
+WoWPro:GuideLevels(guide,77,77,77)
+WoWPro.Dailies:GuideFaction(guide,1119) --  "The Sons of Hodir"
+WoWPro:GuideSteps(guide, function()
 return [[
 
 A Hot and Cold|QID|12981|M|63.13,62.95|N|From Fjorn's Anvil|

--- a/WoWPro_Dailies/Classic_Cata/Neutral/Ludo_Kaluak.lua
+++ b/WoWPro_Dailies/Classic_Cata/Neutral/Ludo_Kaluak.lua
@@ -1,10 +1,14 @@
 
 -- WoWPro Guides by "The WoW-Pro Community" are licensed under a Creative Commons Attribution-NonCommercial-NoDerivs 3.0 Unported License.
 -- Based on a work at github.com.
--- Permissions beyond the scope of this license may be available at http://www.wow-pro.com/License.
+-- Permissions beyond the scope of this license may be available at http://github.com/Ludovicus-Maior/WoW-Pro-Guides/blob/main/License.md.
 
-WoWPro.Dailies:RegisterGuide("LudoKaluak", "Northrend", "The Kalu'ak", "Lich", "Ludovicus", "Neutral", function()
+local guide = WoWPro:RegisterGuide("LudoKaluak",'Dailies', "Northrend", "Ludovicus", "Neutral", "Cata")
+WoWPro:GuideLevels(guide,68,71,69.3)
+WoWPro.Dailies:GuideFaction(guide,1073) --  "The Kalu'ak"
+WoWPro:GuideSteps(guide, function()
 return [[
+
 
 A The Way to His Heart...|QID|11472|PRE|11469|M|24.6,58.86|Z|Howling Fjord|N|From Anuniaqin in Kamagua, Howling Fjord. (L69)|
 l The Way to His Heart...|QID|11472|M|27,71|Z|Howling Fjord|N|Use the net in the pools of Tasty Reef Fish. 10 is what you need.|U|40946|L|34127 10|

--- a/WoWPro_Dailies/Classic_Cata/Neutral/Ludo_NetherDrake.lua
+++ b/WoWPro_Dailies/Classic_Cata/Neutral/Ludo_NetherDrake.lua
@@ -1,18 +1,12 @@
 
 -- WoWPro Guides by "The WoW-Pro Community" are licensed under a Creative Commons Attribution-NonCommercial-NoDerivs 3.0 Unported License.
 -- Based on a work at github.com.
--- Permissions beyond the scope of this license may be available at http://www.wow-pro.com/License.
+-- Permissions beyond the scope of this license may be available at http://github.com/Ludovicus-Maior/WoW-Pro-Guides/blob/main/License.md.
 
--- URL: http://wow-pro.com/wiki/neutral_netherdrake
--- Date: 2012-01-18 23:30
--- Who: Ludovicus Maior
-
--- URL: http://wow-pro.com/node/3455/revisions/24893/view
--- Date: 2012-01-18 23:29
--- Who: Ludovicus Maior
--- Log: Initial Version
-
-WoWPro.Dailies:RegisterGuide("LudoDrake", "Shadowmoon Valley", "Netherwing", "BC", "Ludovicus", "Neutral", function()
+local guide = WoWPro:RegisterGuide("LudoDrake",'Dailies', "Shadowmoon Valley", "Ludovicus", "Neutral", "Cata")
+WoWPro:GuideLevels(guide,70,70,70)
+WoWPro.Dailies:GuideFaction(guide,1015) --  "Netherwing"
+WoWPro:GuideSteps(guide, function()
 return [[
 
 N The next few quests|QID|10804|N|Require you to be level 70 and have a flying mount.|

--- a/WoWPro_Dailies/Classic_Cata/Neutral/Ludo_Skyguard.lua
+++ b/WoWPro_Dailies/Classic_Cata/Neutral/Ludo_Skyguard.lua
@@ -1,19 +1,12 @@
 
 -- WoWPro Guides by "The WoW-Pro Community" are licensed under a Creative Commons Attribution-NonCommercial-NoDerivs 3.0 Unported License.
 -- Based on a work at github.com.
--- Permissions beyond the scope of this license may be available at http://www.wow-pro.com/License.
+-- Permissions beyond the scope of this license may be available at http://github.com/Ludovicus-Maior/WoW-Pro-Guides/blob/main/License.md.
 
--- URL: http://wow-pro.com/wiki/skyguard_dalies
--- Date: 2012-01-19 00:04
--- Who: Ludovicus Maior
--- Log: Correct node numbers.
-
--- URL: http://wow-pro.com/node/3457/revisions/24898/view
--- Date: 2012-01-19 00:04
--- Who: Ludovicus Maior
--- Log: Sync to GIT
-
-WoWPro.Dailies:RegisterGuide("LudoSkyguard", "Terokkar Forest", "Sha'tari Skyguard", "BC", "Ludovicus", "Neutral", function()
+local guide = WoWPro:RegisterGuide("LudoSkyguard",'Dailies', "Terokkar Forest", "Ludovicus", "Neutral", "Cata")
+WoWPro:GuideLevels(guide,70,70,70)
+WoWPro.Dailies:GuideFaction(guide,1031) --  "Sha'tari Skyguard"
+WoWPro:GuideSteps(guide, function()
 return [[
 
 A Threat from Above|QID|11096|M|64,42|Z|Shattrath City|N|From Yuula in Shattrath City|

--- a/WoWPro_Dailies/Classic_Cata/Neutral/Ludo_Wyrmrest.lua
+++ b/WoWPro_Dailies/Classic_Cata/Neutral/Ludo_Wyrmrest.lua
@@ -1,9 +1,12 @@
 
 -- WoWPro Guides by "The WoW-Pro Community" are licensed under a Creative Commons Attribution-NonCommercial-NoDerivs 3.0 Unported License.
 -- Based on a work at github.com.
--- Permissions beyond the scope of this license may be available at http://www.wow-pro.com/License.
+-- Permissions beyond the scope of this license may be available at http://github.com/Ludovicus-Maior/WoW-Pro-Guides/blob/main/License.md.
 
-WoWPro.Dailies:RegisterGuide("LudoWyrmrest", "Borean Tundra", "The Wyrmrest Accord", "Lich", "Ludovicus", "Neutral", function()
+local guide = WoWPro:RegisterGuide("LudoWyrmrest",'Dailies', "Borean Tundra", "Ludovicus", "Neutral", "Cata")
+WoWPro:GuideLevels(guide,10,50)
+WoWPro.Dailies:GuideFaction(guide,1091) --  "The Wyrmrest Accord"
+WoWPro:GuideSteps(guide, function()
 return [[
 
 F Transitus Shield|M|33.31,34.53|Z|Borean Tundra|

--- a/WoWPro_Dailies/Classic_Cata/Neutral/Twists_Ramkahen.lua
+++ b/WoWPro_Dailies/Classic_Cata/Neutral/Twists_Ramkahen.lua
@@ -1,9 +1,12 @@
 
 -- WoWPro Guides by "The WoW-Pro Community" are licensed under a Creative Commons Attribution-NonCommercial-NoDerivs 3.0 Unported License.
 -- Based on a work at github.com.
--- Permissions beyond the scope of this license may be available at http://www.wow-pro.com/License.
+-- Permissions beyond the scope of this license may be available at http://github.com/Ludovicus-Maior/WoW-Pro-Guides/blob/main/License.md.
 
-WoWPro.Dailies:RegisterGuide("TwiUldRam", "Uldum", "Ramkahen Reputation", "Cata", "Twists", "Neutral", function()
+local guide = WoWPro:RegisterGuide("TwiUldRam",'Dailies', "Uldum", "Twists", "Neutral", "Cata")
+WoWPro:GuideLevels(guide,81,83,82)
+WoWPro.Dailies:GuideFaction(guide,1173) --  "Ramkahen Reputation"
+WoWPro:GuideSteps(guide, function()
 return [[
 
 N Uldum Quests|QID|26709|N|You must have completed the quests in Uldum in order to unlock these dailies. The best way to get this done is to use the WoW-Pro Leveling guide for Uldum.|

--- a/WoWPro_Dailies/Classic_Cata/Neutral/Twists_ShattSun.lua
+++ b/WoWPro_Dailies/Classic_Cata/Neutral/Twists_ShattSun.lua
@@ -1,20 +1,13 @@
 
 -- WoWPro Guides by "The WoW-Pro Community" are licensed under a Creative Commons Attribution-NonCommercial-NoDerivs 3.0 Unported License.
 -- Based on a work at github.com.
--- Permissions beyond the scope of this license may be available at http://www.wow-pro.com/License.
+-- Permissions beyond the scope of this license may be available at http://github.com/Ludovicus-Maior/WoW-Pro-Guides/blob/main/License.md.
 
--- URL: http://wow-pro.com/wiki/neutral_shattered_sun_dailies
--- Date: 2012-05-18 20:15
--- Who: Ludovicus Maior
--- Log: Fixed inner links for edit and comments.
-
--- URL: http://wow-pro.com/node/3470/revisions/24956/view
--- Date: 2012-02-14 00:58
--- Who: Ludovicus Maior
-
-WoWPro.Dailies:RegisterGuide("TwiShattSun", "Isle of Quel'Danas", "Shattered Sun Offensive", "BC", "Twists", "Neutral", function()
+local guide = WoWPro:RegisterGuide("TwiShattSun",'Dailies', "Isle of Quel'Danas", "Twists", "Neutral", "Cata")
+WoWPro:GuideLevels(guide,70,70,70)
+WoWPro.Dailies:GuideFaction(guide,1077) --  "Shattered Sun Offensive"
+WoWPro:GuideSteps(guide, function()
 return [[
-
 N State of the Realm|N|This guide assumes that all of the Shattered Sun Offensive are in the final phase.  If you are on a new server, this guide will not do.|
 
 A Enter, the Deceiver...|QID|11550|LEAD|11526|M|53.60,43.67|Z|Shattrath City|O|N|From General Tiras'alan|


### PR DESCRIPTION
All of the Cata Daily guides have been updated to fix "WoWPro/WoWPro.lua:1199: attempt to index local 'guide' (a string value)" error.

"Cata" needs to be added as the last variable (It's normally '4')

The Achieve, Profession, and World Event guides will need this done as well. The headers are not modernized with the correct License.