### PR TITLE
Migrate Deprecated API calls to 11.0.0 equivalents

### DIFF
--- a/WoWPro/WoWPro_Broker.lua
+++ b/WoWPro/WoWPro_Broker.lua
@@ -3087,7 +3087,7 @@ function WoWPro.NextStep(guideIndex, rowIndex)
                         if (flyFlip) then
                             why = ("Skipping because flight spell is not known=%s"):format(tostring(not not spellKnown))
                         else
-                            why = ("Skipping because flight spell [%s] is known=%s"):format(spellKnown, tostring(not not spellKnown))
+                            why = ("Skipping because flight spell [%s] is known=%s"):format(spellName, tostring(not not spellKnown))
                         end
                         WoWPro.CompleteStep(guideIndex, why)
                         skip = true

--- a/WoWPro/WoWPro_Broker.lua
+++ b/WoWPro/WoWPro_Broker.lua
@@ -2963,13 +2963,14 @@ function WoWPro.NextStep(guideIndex, rowIndex)
             -- Warning: not all spells are detectable by this method.  Blizzard is not consistent!
             -- This tests for Spells you can put on a button, essentially.
             local spellName
+            local spellKnown
             if WoWPro.spell and WoWPro.spell[guideIndex] then
                 local _, spellID, spellFlip = (";"):split(WoWPro.spell[guideIndex])
                 local spellInfo = WoWPro.C_Spell_GetSpellInfo(tonumber(spellID))
                 if spellInfo then
                     spellName = spellInfo.name
                 end
-                local spellKnown = _G.IsPlayerSpell(spellID)
+                spellKnown = _G.IsPlayerSpell(spellID)
                 -- Testing if RUNE tag valid (Rune spells use different API than regular spells)
                 if WoWPro.rune and WoWPro.rune[guideIndex] and WoWPro.CLASSIC and _G.C_Seasons then
                     local seasonrealm = _G.C_Seasons.HasActiveSeason()
@@ -3018,8 +3019,6 @@ function WoWPro.NextStep(guideIndex, rowIndex)
                 if WoWProCharDB.EnableFlight or stepAction == "R" or stepAction == "N" then
                     local expansion = WoWPro.fly[guideIndex]
                     local spellInfo
-                    local spellName
-                    local spellKnown
                     local canFly
                     local mSkill
                     local eSkill

--- a/WoWPro/WoWPro_Broker.lua
+++ b/WoWPro/WoWPro_Broker.lua
@@ -2962,13 +2962,14 @@ function WoWPro.NextStep(guideIndex, rowIndex)
             -- Skipping spells if known.
             -- Warning: not all spells are detectable by this method.  Blizzard is not consistent!
             -- This tests for Spells you can put on a button, essentially.
+            local spellName
             if WoWPro.spell and WoWPro.spell[guideIndex] then
                 local _, spellID, spellFlip = (";"):split(WoWPro.spell[guideIndex])
                 local spellInfo = WoWPro.C_Spell_GetSpellInfo(tonumber(spellID))
                 if spellInfo then
                     local spellName = spellInfo.name
                 end
-                local spellKnown = IsPlayerSpell(spellID)
+                local spellKnown = _G.IsPlayerSpell(spellID)
                 -- Testing if RUNE tag valid (Rune spells use different API than regular spells)
                 if WoWPro.rune and WoWPro.rune[guideIndex] and WoWPro.CLASSIC and _G.C_Seasons then
                     local seasonrealm = _G.C_Seasons.HasActiveSeason()
@@ -3020,14 +3021,16 @@ function WoWPro.NextStep(guideIndex, rowIndex)
                     local spellName
                     local spellKnown
                     local canFly
+                    local mSkill
+                    local eSkill
                     local flyFlip = false
                     if (expansion:sub(1, 1) == "-") then
                         expansion = expansion:sub(2)
                         flyFlip = true
                     end
                     spellInfo = WoWPro.C_Spell_GetSpellInfo(34090)
-                    if spellInfo then 
-                        local eSkill = spellInfo.name
+                    if spellInfo then
+                        eSkill = spellInfo.name
                     end
 					if WoWPro.WRATH then
 						if WoWProCharDB.Tradeskills[762] and WoWProCharDB.Tradeskills[762].skillLvl >= 225 then
@@ -3038,15 +3041,15 @@ function WoWPro.NextStep(guideIndex, rowIndex)
 							spellName = "Flying"
 						elseif expansion == "WOTLK" and canFly then
                             spellInfo = WoWPro.C_Spell_GetSpellInfo(54197)
-                            if spellInfo then 
-                                spellname = spellInfo
+                            if spellInfo then
+                                spellName = spellInfo
                             end
 							spellKnown = IsPlayerSpell(54197)
 						end
 					else
                         spellInfo = WoWPro.C_Spell_GetSpellInfo(90265)
                         if spellInfo then
-						    local mSkill = spellInfo.name
+						    mSkill = spellInfo.name
                         end
 						if _G.IsPlayerSpell(34090) then
 							canFly = true

--- a/WoWPro/WoWPro_Broker.lua
+++ b/WoWPro/WoWPro_Broker.lua
@@ -2964,8 +2964,11 @@ function WoWPro.NextStep(guideIndex, rowIndex)
             -- This tests for Spells you can put on a button, essentially.
             if WoWPro.spell and WoWPro.spell[guideIndex] then
                 local _, spellID, spellFlip = (";"):split(WoWPro.spell[guideIndex])
-                local spellName = _G.GetSpellInfo(tonumber(spellID))
-                local spellKnown = _G.GetSpellInfo(spellName)
+                local spellInfo = WoWPro.C_Spell_GetSpellInfo(tonumber(spellID))
+                if spellInfo then
+                    local spellName = spellInfo.name
+                end
+                local spellKnown = IsPlayerSpell(spellID)
                 -- Testing if RUNE tag valid (Rune spells use different API than regular spells)
                 if WoWPro.rune and WoWPro.rune[guideIndex] and WoWPro.CLASSIC and _G.C_Seasons then
                     local seasonrealm = _G.C_Seasons.HasActiveSeason()
@@ -3013,6 +3016,7 @@ function WoWPro.NextStep(guideIndex, rowIndex)
             if WoWPro.fly and WoWPro.fly[guideIndex] and WoWPro.Client >= 3 then
                 if WoWProCharDB.EnableFlight or stepAction == "R" or stepAction == "N" then
                     local expansion = WoWPro.fly[guideIndex]
+                    local spellInfo
                     local spellName
                     local spellKnown
                     local canFly
@@ -3021,7 +3025,10 @@ function WoWPro.NextStep(guideIndex, rowIndex)
                         expansion = expansion:sub(2)
                         flyFlip = true
                     end
-					local eSkill = _G.GetSpellInfo(34090)
+                    spellInfo = WoWPro.C_Spell_GetSpellInfo(34090)
+                    if spellInfo then 
+                        local eSkill = spellInfo.name
+                    end
 					if WoWPro.WRATH then
 						if WoWProCharDB.Tradeskills[762] and WoWProCharDB.Tradeskills[762].skillLvl >= 225 then
 							canFly = true
@@ -3030,24 +3037,36 @@ function WoWPro.NextStep(guideIndex, rowIndex)
 							spellKnown = true
 							spellName = "Flying"
 						elseif expansion == "WOTLK" and canFly then
-							spellName = _G.GetSpellInfo(54197)
-							spellKnown = _G.GetSpellInfo(spellName)
+                            spellInfo = WoWPro.C_Spell_GetSpellInfo(54197)
+                            if spellInfo then 
+                                spellname = spellInfo
+                            end
+							spellKnown = IsPlayerSpell(54197)
 						end
 					else
-						local mSkill = _G.GetSpellInfo(90265)
-						if _G.GetSpellInfo(eSkill) then
+                        spellInfo = WoWPro.C_Spell_GetSpellInfo(90265)
+                        if spellInfo then
+						    local mSkill = spellInfo.name
+                        end
+						if _G.IsPlayerSpell(34090) then
 							canFly = true
 							spellName = eSkill
-						elseif _G.GetSpellInfo(mSkill) then
+						elseif _G.IsPlayerSpell(90265) then
 							canFly = true
 							spellName = mSkill
 						end
 
 						if expansion == "SHADOWLANDS" and canFly then
-							spellName = _G.GetSpellInfo(352177)
+                            spellInfo = WoWPro.C_Spell_GetSpellInfo(352177)
+                            if spellInfo then
+                                spellName = spellInfo.name
+                            end
 							spellKnown = _G.C_QuestLog.IsQuestFlaggedCompleted(63893)
 						elseif expansion == "SHADOWLANDS9.2" and canFly then
-							spellName = _G.GetSpellInfo(366736)
+                            spellInfo = WoWPro.C_Spell_GetSpellInfo(366736)
+							if spellInfo then
+                                spellName = spellInfo.name
+                            end
 							spellKnown = _G.C_QuestLog.IsQuestFlaggedCompleted(65539)
 						elseif expansion == "BFA" and canFly then
 							spellKnown = true
@@ -3060,6 +3079,7 @@ function WoWPro.NextStep(guideIndex, rowIndex)
 						end
 					end
 
+
                     if flyFlip then spellKnown = not spellKnown end
                     WoWPro:dbp("Checking fly step %s [%s] for %s: Nomen %s, Known %s",stepAction,step,WoWPro.fly[guideIndex],tostring(spellName),tostring(spellKnown))
                     if spellKnown then
@@ -3067,7 +3087,7 @@ function WoWPro.NextStep(guideIndex, rowIndex)
                         if (flyFlip) then
                             why = ("Skipping because flight spell is not known=%s"):format(tostring(not not spellKnown))
                         else
-                            why = ("Skipping because flight spell [%s] is known=%s"):format(spellName, tostring(not not spellKnown))
+                            why = ("Skipping because flight spell [%s] is known=%s"):format(spellKnown, tostring(not not spellKnown))
                         end
                         WoWPro.CompleteStep(guideIndex, why)
                         skip = true

--- a/WoWPro/WoWPro_Broker.lua
+++ b/WoWPro/WoWPro_Broker.lua
@@ -3079,7 +3079,6 @@ function WoWPro.NextStep(guideIndex, rowIndex)
 						end
 					end
 
-
                     if flyFlip then spellKnown = not spellKnown end
                     WoWPro:dbp("Checking fly step %s [%s] for %s: Nomen %s, Known %s",stepAction,step,WoWPro.fly[guideIndex],tostring(spellName),tostring(spellKnown))
                     if spellKnown then

--- a/WoWPro/WoWPro_Broker.lua
+++ b/WoWPro/WoWPro_Broker.lua
@@ -2993,7 +2993,7 @@ function WoWPro.NextStep(guideIndex, rowIndex)
                 if spellFlip then spellKnown = not spellKnown end
                 WoWPro:dbp("Checking spell step %s [%s] for %s: Nomen %s, Known %s",stepAction,step,WoWPro.spell[guideIndex],tostring(spellName),tostring(spellKnown))
                 if spellKnown then
-                    local why = ("Skipping because spell [%s] is known=%s"):format(spellName, tostring(not not spellKnown))
+                    local why = ("Skipping because spell [%s] is known=%s"):format(tostring(spellName), tostring(not not spellKnown))
                     WoWPro.CompleteStep(guideIndex, why)
                     skip = true
                     WoWPro:dbp(why)

--- a/WoWPro/WoWPro_Broker.lua
+++ b/WoWPro/WoWPro_Broker.lua
@@ -2967,7 +2967,7 @@ function WoWPro.NextStep(guideIndex, rowIndex)
                 local _, spellID, spellFlip = (";"):split(WoWPro.spell[guideIndex])
                 local spellInfo = WoWPro.C_Spell_GetSpellInfo(tonumber(spellID))
                 if spellInfo then
-                    local spellName = spellInfo.name
+                    spellName = spellInfo.name
                 end
                 local spellKnown = _G.IsPlayerSpell(spellID)
                 -- Testing if RUNE tag valid (Rune spells use different API than regular spells)
@@ -3044,7 +3044,7 @@ function WoWPro.NextStep(guideIndex, rowIndex)
                             if spellInfo then
                                 spellName = spellInfo
                             end
-							spellKnown = IsPlayerSpell(54197)
+							spellKnown = _G.IsPlayerSpell(54197)
 						end
 					else
                         spellInfo = WoWPro.C_Spell_GetSpellInfo(90265)

--- a/WoWPro/WoWPro_Broker.lua
+++ b/WoWPro/WoWPro_Broker.lua
@@ -884,7 +884,7 @@ function WoWPro.TrashItem(use, step)
         for slot=1,slots do
             local id=_G.C_Container.GetContainerItemID(bag,slot)
             if id == use then
-                local itemName = _G.GetItemInfo(id)
+                local itemName = WoWPro.C_Item_GetItemInfo(id)
                 local dialog = _G.StaticPopup_Show("WOWPRO_DELETE_ITEM", itemName)
                 dialog.data = { step = step, itemName = itemName}
                 dialog.data2 = {bag = bag, slot = slot}
@@ -931,8 +931,8 @@ end
 
 function WoWPro.SelectItemToUse(use, debug)
     if not use:find("^", 1, true)  then
-        WoWPro:dbp("SelectItemToUse(%q): single, %q", use, _G.GetItemInfo(use) or "NIL")
-        return _G.GetItemInfo(use), use
+        WoWPro:dbp("SelectItemToUse(%q): single, %q", use, WoWPro.C_Item_GetItemInfo(use) or "NIL")
+        return WoWPro.C_Item_GetItemInfo(use), use
     end
     local value = QidMapReduce(use,false,"^","|",function (item) return (_G.GetItemCount(item) > 0) and item end, "SelectItemToUse", debug or quids_debug)
     WoWPro:dbp("SelectItemToUse(%q): Value=%s", use, tostring(value))
@@ -1304,7 +1304,7 @@ if step then
         -- Item Button --
         if action == "H" and not use then use = WoWPro.SelectHearthstone() end
 
-        if action == "*" and use and _G.GetItemInfo(use) then
+        if action == "*" and use and WoWPro.C_Item_GetItemInfo then
             currentRow.itembutton:Show()
             currentRow.itemicon:SetTexture(_G.GetItemIcon(use))
             currentRow.itembutton:SetAttribute("type1", "click1")

--- a/WoWPro/WoWPro_CompatUtil.lua
+++ b/WoWPro/WoWPro_CompatUtil.lua
@@ -249,3 +249,12 @@ function WoWPro.C_Spell_GetSpellInfo(spellID)
         }
     end
 end
+
+--[[C_Item.GetItemInfo]]
+function WoWPro.C_Item_GetItemInfo(itemID)
+    if WoWPro.RETAIL then
+        return _G.C_Item.GetItemInfo(itemID)
+    else
+        return GetItemInfo(itemID)
+    end
+end    

--- a/WoWPro/WoWPro_CompatUtil.lua
+++ b/WoWPro/WoWPro_CompatUtil.lua
@@ -232,3 +232,20 @@ function WoWPro.C_Reputation_GetFactionDataByID(factionID)
     end
 end
 
+--[[C_Spell.GetGetSpellInfo]]
+function WoWPro.C_Spell_GetSpellInfo(spellID)
+    if WoWPro.RETAIL then
+        return _G.C_Spell.GetSpellInfo(spellID)
+    else
+        name, rank, icon, castTime, minRange, maxRange, spellID, originalIcon = GetSpellInfo(spell)
+        return{
+           castTime = castTime,
+           name = name,
+           minRange = minRange,
+           originalIconID = originalIcon,
+           iconID = icon,
+           maxRange = maxRange,
+           spellID = spellID
+        }
+    end
+end

--- a/WoWPro/WoWPro_CompatUtil.lua
+++ b/WoWPro/WoWPro_CompatUtil.lua
@@ -210,7 +210,7 @@ function WoWPro.C_Reputation_GetFactionDataByID(factionID)
     if WoWPro.RETAIL then
         return _G.C_Reputation.GetFactionDataByID(factionID)
     else
-        local name, description, standingID, barMin, barMax, barValue, atWarWith, canToggleAtWar, isHeader, isCollapsed, hasRep, isWatched, isChild, factionID, hasBonusRepGain, canBeLFGBonus = _G.GetFactionInfoByID(factionID)
+        local name, description, _, _, _, _, atWarWith, canToggleAtWar, _, isCollapsed, _, isWatched, isChild, _, hasBonusRepGain, _ = _G.GetFactionInfoByID(factionID)
         return {
             hasBonusRepGain = hasBonusRepGain,
             description = description,
@@ -221,11 +221,11 @@ function WoWPro.C_Reputation_GetFactionDataByID(factionID)
             isWatched = isWatched,
             isCollapsed = isCollapsed,
             canToggleAtWar = canToggleAtWar,
-            nextReactionThreshold,
+            -- nextReactionThreshold,
             factionID = factionID,
             name = name,
-            currentStanding,
-            isAccountWide,
+            --currentStanding,
+            --isAccountWide,
             isChild = isChild,
             -- reaction
         }
@@ -237,7 +237,7 @@ function WoWPro.C_Spell_GetSpellInfo(spellID)
     if WoWPro.RETAIL then
         return _G.C_Spell.GetSpellInfo(spellID)
     else
-        local name, rank, icon, castTime, minRange, maxRange, spellID, originalIcon = _G.GetSpellInfo(spell)
+        local name, rank, icon, castTime, minRange, maxRange, _, originalIcon = _G.GetSpellInfo(spellID)
         return{
            castTime = castTime,
            name = name,

--- a/WoWPro/WoWPro_CompatUtil.lua
+++ b/WoWPro/WoWPro_CompatUtil.lua
@@ -237,7 +237,7 @@ function WoWPro.C_Spell_GetSpellInfo(spellID)
     if WoWPro.RETAIL then
         return _G.C_Spell.GetSpellInfo(spellID)
     else
-        local name, rank, icon, castTime, minRange, maxRange, _, originalIcon = _G.GetSpellInfo(spellID)
+        local name, _, icon, castTime, minRange, maxRange, _, originalIcon = _G.GetSpellInfo(spellID)
         return{
            castTime = castTime,
            name = name,
@@ -257,4 +257,4 @@ function WoWPro.C_Item_GetItemInfo(itemID)
     else
         return _G.GetItemInfo(itemID)
     end
-end 
+end

--- a/WoWPro/WoWPro_CompatUtil.lua
+++ b/WoWPro/WoWPro_CompatUtil.lua
@@ -232,7 +232,7 @@ function WoWPro.C_Reputation_GetFactionDataByID(factionID)
     end
 end
 
---[[C_Spell.GetGetSpellInfo]]
+--[[C_Spell.GetSpellInfo]]
 function WoWPro.C_Spell_GetSpellInfo(spellID)
     if WoWPro.RETAIL then
         return _G.C_Spell.GetSpellInfo(spellID)

--- a/WoWPro/WoWPro_CompatUtil.lua
+++ b/WoWPro/WoWPro_CompatUtil.lua
@@ -204,3 +204,31 @@ function WoWPro.GetItemCooldown(itemID)
         return unpack({_G.C_Container.GetItemCooldown(itemID)})
     end
 end
+
+--[[C_Reputation.GetFactionDataByID]]
+function WoWPro.C_Reputation_GetFactionDataByID(factionID)
+    if WoWPro.RETAIL then
+        return _G.C_Reputation.GetFactionDataByID(factionID)
+    else
+        name, description, standingID, barMin, barMax, barValue, atWarWith, canToggleAtWar, isHeader, isCollapsed, hasRep, isWatched, isChild, factionID, hasBonusRepGain, canBeLFGBonus = GetFactionInfoByID(factionID)
+        return {
+            hasBonusRepGain = hasBonusRepGain,
+            description = description,
+            -- isHeaderWithRep
+            -- isHeaderCurrentReactionThreshold
+            -- canSetInactive
+            atWarWith = atWarWith,
+            isWatched = isWatched,
+            isCollapsed = isCollapsed,
+            canToggleAtWar = canToggleAtWar,
+            nextReactionThreshold,
+            factionID = factionID,
+            name = name,
+            currentStanding,
+            isAccountWide,
+            isChild = isChild,
+            -- reaction
+        }
+    end
+end
+

--- a/WoWPro/WoWPro_CompatUtil.lua
+++ b/WoWPro/WoWPro_CompatUtil.lua
@@ -210,7 +210,7 @@ function WoWPro.C_Reputation_GetFactionDataByID(factionID)
     if WoWPro.RETAIL then
         return _G.C_Reputation.GetFactionDataByID(factionID)
     else
-        name, description, standingID, barMin, barMax, barValue, atWarWith, canToggleAtWar, isHeader, isCollapsed, hasRep, isWatched, isChild, factionID, hasBonusRepGain, canBeLFGBonus = GetFactionInfoByID(factionID)
+        local name, description, standingID, barMin, barMax, barValue, atWarWith, canToggleAtWar, isHeader, isCollapsed, hasRep, isWatched, isChild, factionID, hasBonusRepGain, canBeLFGBonus = _G.GetFactionInfoByID(factionID)
         return {
             hasBonusRepGain = hasBonusRepGain,
             description = description,
@@ -237,7 +237,7 @@ function WoWPro.C_Spell_GetSpellInfo(spellID)
     if WoWPro.RETAIL then
         return _G.C_Spell.GetSpellInfo(spellID)
     else
-        name, rank, icon, castTime, minRange, maxRange, spellID, originalIcon = GetSpellInfo(spell)
+        local name, rank, icon, castTime, minRange, maxRange, spellID, originalIcon = _G.GetSpellInfo(spell)
         return{
            castTime = castTime,
            name = name,
@@ -255,6 +255,6 @@ function WoWPro.C_Item_GetItemInfo(itemID)
     if WoWPro.RETAIL then
         return _G.C_Item.GetItemInfo(itemID)
     else
-        return GetItemInfo(itemID)
+        return _G.GetItemInfo(itemID)
     end
-end    
+end 

--- a/WoWPro_Dailies/WoWPro_Dailies.lua
+++ b/WoWPro_Dailies/WoWPro_Dailies.lua
@@ -50,19 +50,6 @@ function WoWPro.Dailies:RegisterGuide(guide)
     WoWPro:NoCache(guide)
 end
 
--- Handle Wow API differences between Classic and modern game versions.
-local function get_faction_name(factionId)
-    if _G.GetFactionInfoByID then
-        return _G.GetFactionInfoByID(factionId)
-    else
-        local factionInfo = _G.C_Reputation.GetFactionDataByID(factionId)
-        if factionInfo then
-            return factionInfo.name
-        end
-    end
-    return nil
-end
-
 function WoWPro.Dailies:GuideFaction(guide,faction, hfaction)
     if not hfaction then
         guide.faction = tonumber(faction)
@@ -73,7 +60,10 @@ function WoWPro.Dailies:GuideFaction(guide,faction, hfaction)
             guide.faction = tonumber(hfaction)
         end
     end
-    guide.name = get_faction_name(guide.faction)
+    local factionInfo = WoWPro.C_Reputation_GetFactionDataByID(guide.faction)
+    if factionInfo then
+        guide.name = factionInfo.name
+    end
     guide.category = "Dailies"
 end
 


### PR DESCRIPTION
- Refactor Faction Check logic into CompatUtil
- Migrated GetItemInfo to C_Item.GetItemInfo
- Migrated GetSpellInfo to C_Spell.GetSpellInfo and IsPlayerSpell

C_Spell.getSpellInfo always returns a result even if the spell is not known by the player so I've switched to using IsPlayerSpell instead. 

The addon now runs error free in both 11.0.0 and Classic version of the client. Sadly C_Spell.GetSpellInfo isn't present in 10.2.7 so this change isn't backwards compatible with the current live version of the modern client (tho it could be made to be so if we want to).


