### PR TITLE
Fix bug in Scenario Criteria handling

### DIFF
--- a/WoWPro/WoWPro_CompatUtil.lua
+++ b/WoWPro/WoWPro_CompatUtil.lua
@@ -271,7 +271,7 @@ function WoWPro.C_ScenarioInfo_GetCriteriaInfo(criteriaIndex)
            completed = completed,
            quantity = quantity,
            -- isFormatted
-           failed =- criteriaFailed,
+           failed = criteriaFailed,
            assetID = assetID,
            flags = flags,
            criteriaType = criteriaType,


### PR DESCRIPTION
Fix for a bug (typo) in the Scenario Critera compat function that was causing LUA errors in Remix Scenarios.