### PR TITLE
Suggested tweaks from Furydin

### DIFF
--- a/WoWPro/WoWPro_Broker.lua
+++ b/WoWPro/WoWPro_Broker.lua
@@ -1537,7 +1537,7 @@ if step then
             elseif emote then
                 mtext = "/target "..tar.."\n/"..emote
             else
-                mtext = "/cleartarget\n/target "..tar.."\n"
+                mtext = "/cleartarget[dead]\n/target "..tar.."\n"
                 mtext = mtext .. "/run if GetRaidTargetIndex('target') ~= 8 and not UnitIsDead('target') then SetRaidTarget('target', 8) end"
             end
             currentRow.targetbutton:SetAttribute("macrotext", mtext)

--- a/WoWPro/WoWPro_Widgets.lua
+++ b/WoWPro/WoWPro_Widgets.lua
@@ -147,7 +147,6 @@ function WoWPro:CreateItemButton(parent, id)
     itemicon:SetTexture("Interface\\Icons\\INV_Misc_Bag_08")
     itemicon:SetAllPoints(itembutton)
 
-    itembutton:RegisterForClicks("anyDown","anyUp")
     itembutton:Hide()
 
     return itembutton, itemicon, itemcooldown


### PR DESCRIPTION
Disable mouse click detection for itembutton to prevent double-tapping.

Add [DEAD] to target button to specifically avoid targeting DoA targets if others are out of range.