### PR TITLE
More fixes

### DIFF
--- a/WoWPro_Leveling/Retail/Neutral/TWW_AzjKahet.lua
+++ b/WoWPro_Leveling/Retail/Neutral/TWW_AzjKahet.lua
@@ -84,7 +84,6 @@ T Of Pacts and Patrons|QID|84682|M|55.33,41.20|Z|2255;Azj-Kahet|N|To Y'tekhi.|
 T Making the Underworld Go Round|QID|84664|PRE|84682|M|55.78,43.74|Z|2255;Azj-Kahet|N|To Linny Leadfinger.|
 A Strange Bats|QID|83321|M|55.76,43.66|Z|2255;Azj-Kahet|N|From Linny Leadfinger.|RANK|2|
 A Advance to Faerin|QID|82248|M|55.86,43.80|Z|2255;Azj-Kahet|N|From Widow Arak'nai.|LVL|80|LEAD|81929|RANK|2|; This quest requires Level 80 - It's a breadcrub for "To Arathi's End(QID 81945)"
-A Advance to Faerin|QID|82248|M|55.86,43.80|Z|2255;Azj-Kahet|N|From Widow Arak'nai.|PRE|83543|LEAD|81929|RANK|2|; Also available at any level in Adventure mode
 C The Weaver's Gift|QID|78233|M|58.97,19.96|Z|2255;Azj-Kahet|QO|1|NC|N|Weaver's gift located.|
 T The Weaver's Gift|QID|78233|M|59.32,19.37|Z|2255;Azj-Kahet|N|To Faerin Lothar.|
 T Advance to Faerin|QID|82248|M|59.32,19.37|Z|2255;Azj-Kahet|N|To Faerin Lothar.|LEAD|81929|

--- a/WoWPro_Leveling/Retail/Neutral/TWW_TRD.lua
+++ b/WoWPro_Leveling/Retail/Neutral/TWW_TRD.lua
@@ -168,7 +168,7 @@ A A Wrench in the Works|QID|80079|PRE|80082|M|47.11,33.19|Z|2214; The Ringing De
 C A Wrench in the Works|QID|80079|M|47.26,32.07|QO|1|Z|2214; The Ringing Deeps|N|Grievance heard.|CHAT|
 C An Opportunity to Relax|QID|82952|M|47.49,32.51|QO|1<4|Z|2214; The Ringing Deeps|N|Another worker, another flyer.|H|
 C An Opportunity to Relax|QID|82952|M|47.51,33.18|QO|1<5|Z|2214; The Ringing Deeps|N|And a flyer for you.|H|
-C An Opportunity to Relax|QID|82952|M|48.83,34.07|QO|1|Z|2214; The Ringing Deeps|N|Up the stairs to find the last tired worker and you have finally used up all your flyers.|H|
+C An Opportunity to Relax|QID|82952|M|47.95,32.15|QO|1|Z|2214; The Ringing Deeps|N|Up the stairs to find the last tired worker and you have finally used up all your flyers.|H|
 A Kobold Kleanup|QID|80058|PRE|80082|M|47.78,35.33|Z|2214; The Ringing Deeps|N|From Fourman Grimes.|RANK|2|
 A New Home, New Candle!|QID|81999|PRE|80082|M|47.76,35.35|Z|2214; The Ringing Deeps|N|From Janky.|RANK|2|
 ;A Everyday I'm Snufflin'|QID|79343|PRE|80082|M|47.71,35.26|Z|2214; The Ringing Deeps|N|From Gnawbles.|RANK|2|-THIS STARTS FROM A GROUND SPAWN I PICKED UP IN DORN


### PR DESCRIPTION
- Ringing Deeps
  - Opportuiunity to Relax Coord fix
  
  - Azj Kahet
    - Advance to Faerin isn't always available on Adventure mode