### PR TITLE
Track Progress bar %age for use with QO steps

### DIFF
--- a/WoWPro/WoWPro_Broker.lua
+++ b/WoWPro/WoWPro_Broker.lua
@@ -3580,7 +3580,7 @@ function WoWPro.PopulateQuestLog()
                     leaderBoard[objIndex] = objectives[objIndex].text
                     ocompleted[objIndex] = objectives[objIndex].finished
                     if objectives[objIndex].type == "progressbar" then
-                        ncompleted[objIndex] = _G.GetQuestProgressBarPercent(questInfo.questID)
+                        ncompleted[objIndex] = floor(_G.GetQuestProgressBarPercent(questInfo.questID))
                     else
                         ncompleted[objIndex] = objectives[objIndex].numFulfilled
                     end

--- a/WoWPro/WoWPro_Broker.lua
+++ b/WoWPro/WoWPro_Broker.lua
@@ -3579,7 +3579,11 @@ function WoWPro.PopulateQuestLog()
                 for objIndex = 1, #objectives do
                     leaderBoard[objIndex] = objectives[objIndex].text
                     ocompleted[objIndex] = objectives[objIndex].finished
-                    ncompleted[objIndex] = objectives[objIndex].numFulfilled
+                    if objectives[objIndex].type == "progressbar" then
+                        ncompleted[objIndex] = _G.GetQuestProgressBarPercent(questInfo.questID)
+                    else
+                        ncompleted[objIndex] = objectives[objIndex].numFulfilled
+                    end
                 end
             else
                 leaderBoard = nil


### PR DESCRIPTION
This will allow the |QO|1<10| tags to use the progress bar % in the same way as a normal x/y step.