### PR TITLE
Disable Addons for LUA error debugging

### DIFF
--- a/WoWPro/WoWPro.lua
+++ b/WoWPro/WoWPro.lua
@@ -364,6 +364,7 @@ function WoWPro:OnInitialize()
     WoWProDB.global.Achievements = WoWProDB.global.Achievements or {}
     WoWProDB.global.NpcFauxQuests = WoWProDB.global.NpcFauxQuests or {}
     WoWProDB.global.QuestEngineDelay = WoWProDB.global.QuestEngineDelay or 0.25
+    WoWProCharDB.disabledAddons = WoWProCharDB.disabledAddons or {}
 
     WoWProCharDB.EnableGrail = nil
     if WoWProCharDB.AutoSelect == nil then

--- a/WoWPro/WoWPro_Command.lua
+++ b/WoWPro/WoWPro_Command.lua
@@ -122,6 +122,44 @@ local function handler(msg, editbox)
             end
         end
         _G.ChatFrame1:AddMessage("Blizzard API stored in: <World of Warcraft>/WTF/Account/<#>/SavedVariables/WoWPro.lua")
+    elseif ltoken == "disable-addons" then
+        local keepEnabled = {
+            "WoWPro",
+            "WoWPro_Leveling",
+            "BugSack",
+            "!BugGrabber",
+            "TomTom",
+        }
+    
+        WoWProCharDB.disabledAddons = {}
+    
+        local function isAddonKept(name)
+            for _, addon in ipairs(keepEnabled) do
+                if name == addon then
+                    return true
+                end
+            end
+            return false
+        end
+    
+        for i = 1, C_AddOns.GetNumAddOns() do
+            local name, _, _, enabled = C_AddOns.GetAddOnInfo(i)
+    
+            if enabled and not isAddonKept(name) then
+                C_AddOns.DisableAddOn(name)
+                table.insert(WoWProCharDB.disabledAddons, name)
+            end
+        end
+    
+        ReloadUI()
+    
+        for _, name in ipairs(WoWProCharDB.disabledAddons) do
+            C_AddOns.EnableAddOn(name)
+        end
+    
+        WoWProCharDB.disabledAddons = {}
+        ReloadUI()
+    
     else
         local text = ("%s or %s [where¦reset¦guide-bug¦taint¦etrace-start¦etrace-end¦clear-log¦log¦api-probe¦devcoords¦devmode]"):format(_G.SLASH_WOWPRO1, _G.SLASH_WOWPRO2)
         _G.ChatFrame1:AddMessage(text)

--- a/WoWPro/WoWPro_Command.lua
+++ b/WoWPro/WoWPro_Command.lua
@@ -151,11 +151,14 @@ local function handler(msg, editbox)
         end
         _G.ReloadUI()
 
-        for _, name in ipairs(WoWProCharDB.disabledAddons) do
-            _G.C_AddOns.EnableAddOn(name)
+    elseif ltoken == "enable-addons" then
+        if WoWProCharDB.disabledAddons then
+            for _, name in ipairs(WoWProCharDB.disabledAddons) do
+                _G.C_AddOns.EnableAddOn(name)
+            end
+            WoWProCharDB.disabledAddons = {}
+            ReloadUI()
         end
-        WoWProCharDB.disabledAddons = {}
-        _G.ReloadUI()
     else
         local text = ("%s or %s [where¦reset¦guide-bug¦taint¦etrace-start¦etrace-end¦clear-log¦log¦api-probe¦devcoords¦devmode]"):format(_G.SLASH_WOWPRO1, _G.SLASH_WOWPRO2)
         _G.ChatFrame1:AddMessage(text)

--- a/WoWPro/WoWPro_Command.lua
+++ b/WoWPro/WoWPro_Command.lua
@@ -157,7 +157,7 @@ local function handler(msg, editbox)
                 _G.C_AddOns.EnableAddOn(name)
             end
             WoWProCharDB.disabledAddons = {}
-            ReloadUI()
+            _G.ReloadUI()
         end
     else
         local text = ("%s or %s [where¦reset¦guide-bug¦taint¦etrace-start¦etrace-end¦clear-log¦log¦api-probe¦devcoords¦devmode]"):format(_G.SLASH_WOWPRO1, _G.SLASH_WOWPRO2)

--- a/WoWPro/WoWPro_Command.lua
+++ b/WoWPro/WoWPro_Command.lua
@@ -130,9 +130,9 @@ local function handler(msg, editbox)
             "!BugGrabber",
             "TomTom",
         }
-    
+
         WoWProCharDB.disabledAddons = {}
-    
+
         local function isAddonKept(name)
             for _, addon in ipairs(keepEnabled) do
                 if name == addon then
@@ -141,7 +141,7 @@ local function handler(msg, editbox)
             end
             return false
         end
-    
+
         for i = 1, C_AddOns.GetNumAddOns() do
             local name, _, _, enabled = C_AddOns.GetAddOnInfo(i)
     
@@ -150,16 +150,16 @@ local function handler(msg, editbox)
                 table.insert(WoWProCharDB.disabledAddons, name)
             end
         end
-    
+
         ReloadUI()
-    
+
         for _, name in ipairs(WoWProCharDB.disabledAddons) do
             C_AddOns.EnableAddOn(name)
         end
-    
+
         WoWProCharDB.disabledAddons = {}
         ReloadUI()
-    
+
     else
         local text = ("%s or %s [where¦reset¦guide-bug¦taint¦etrace-start¦etrace-end¦clear-log¦log¦api-probe¦devcoords¦devmode]"):format(_G.SLASH_WOWPRO1, _G.SLASH_WOWPRO2)
         _G.ChatFrame1:AddMessage(text)

--- a/WoWPro/WoWPro_Command.lua
+++ b/WoWPro/WoWPro_Command.lua
@@ -142,24 +142,20 @@ local function handler(msg, editbox)
             return false
         end
 
-        for i = 1, C_AddOns.GetNumAddOns() do
-            local name, _, _, enabled = C_AddOns.GetAddOnInfo(i)
-    
+        for i = 1, _G.C_AddOns.GetNumAddOns() do
+            local name, _, _, enabled = _G.C_AddOns.GetAddOnInfo(i)
             if enabled and not isAddonKept(name) then
-                C_AddOns.DisableAddOn(name)
+                _G.C_AddOns.DisableAddOn(name)
                 table.insert(WoWProCharDB.disabledAddons, name)
             end
         end
-
-        ReloadUI()
+        _G.ReloadUI()
 
         for _, name in ipairs(WoWProCharDB.disabledAddons) do
-            C_AddOns.EnableAddOn(name)
+            _G.C_AddOns.EnableAddOn(name)
         end
-
         WoWProCharDB.disabledAddons = {}
-        ReloadUI()
-
+        _G.ReloadUI()
     else
         local text = ("%s or %s [where¦reset¦guide-bug¦taint¦etrace-start¦etrace-end¦clear-log¦log¦api-probe¦devcoords¦devmode]"):format(_G.SLASH_WOWPRO1, _G.SLASH_WOWPRO2)
         _G.ChatFrame1:AddMessage(text)

--- a/WoWPro/WoWPro_Command.lua
+++ b/WoWPro/WoWPro_Command.lua
@@ -1,5 +1,5 @@
 -- luacheck: globals date pairs ipairs type issecurevariable print
--- luacheck: globals tostring tinsert
+-- luacheck: globals tostring tinsert table
 
 _G.SLASH_WOWPRO1 = "/wp"
 _G.SLASH_WOWPRO2 = "/wow-pro"


### PR DESCRIPTION
add new command /wp disable-addons which will disable all addons apart from WoWPro and WoWPro_Levelling, BugSack,BugGrabber, TomTom to establish if addons are tainting.

Add a second command /wp enable-addons for user to re-enable all addons that were disabled from running the above command.

One small issue that i haven't been able to figure out and that is how to disable Dependencies like this 

![image](https://github.com/user-attachments/assets/3480d6dd-bba2-40be-97f2-4da3a139ca96)
