### PR TITLE
Add TOC directives for 11.1.0 addon category

### DIFF
--- a/WoWPro/WoWPro.toc
+++ b/WoWPro/WoWPro.toc
@@ -7,6 +7,17 @@
 ## SavedVariablesPerCharacter: WoWProCharDB
 ## OptionalDeps: Carbonite, TomTom
 ## Version: 2024.12.31.A
+## Category-enUS: Quests
+## Category-deDE: Quests
+## Category-esES: Misiones
+## Category-esMX: Misiones
+## Category-frFR: Quêtes
+## Category-itIT: Missioni
+## Category-koKR: 퀘스트
+## Category-ptBR: Missões
+## Category-ruRU: Задания
+## Category-zhCN: 任务
+## Category-zhTW: 任務
 ## X-Category: Compilations
 ## X-License: Creative Commons Attribution-NonCommercial-NoDerivs 3.0 Unported License.
 Libraries\LibStub\LibStub.lua


### PR DESCRIPTION
I've tested this with the existing live clients (11.0.7, Cata Classic and Classic Era) and they all ignore the new directives - so this change is backwards compatible.

Localization from the warcraft Wiki: https://warcraft.wiki.gg/wiki/Addon_Categories