### PR TITLE
Faction Selection Bugfix

### DIFF
--- a/WoWPro/WoWPro_Events.lua
+++ b/WoWPro/WoWPro_Events.lua
@@ -562,6 +562,7 @@ WoWPro.RegisterEventHandler("PLAYER_LEAVING_WORLD", function(event, ...)
 if not WoWPro.CLASSIC then
     WoWPro.RegisterEventHandler("NEUTRAL_FACTION_SELECT_RESULT", function (event, ...)
         WoWPro:dbp("Detected Faction selection. Re-evaluating guide.")
+        WoWPro.Faction = _G.UnitFactionGroup("player")
         WoWPro:UpdateGuide(event)
     end)
 end


### PR DESCRIPTION
WoW-Pro permanently stores the faction when starting up and does not currently update it when a neutral character selects their faction.

This change will reset the faction in the NEUTRAL_FACTION_SELECT_RESULT even handler and should (hopefully) get the guide to behave itself when players leave the Pandren starting area.