### PR TITLE
Display a progress bar for "Fill The Bar Quests"

### DIFF
--- a/WoWPro/WoWPro.lua
+++ b/WoWPro/WoWPro.lua
@@ -340,6 +340,7 @@ local defaults = { profile = {
     stickytitletextsize = 13,
     stickytitletextcolor = {1, 1, 1},
     guideprogress = false,
+    progressbar = true,
 } }
 
 

--- a/WoWPro/WoWPro_Broker.lua
+++ b/WoWPro/WoWPro_Broker.lua
@@ -742,7 +742,16 @@ function WoWPro.UpdateQuestTrackerRow(row)
                     if WoWPro.QuestLog[qid].leaderBoard[l] then
                         track = track.."- "..WoWPro.QuestLog[qid].leaderBoard[l]
 						if select(2, _G.GetQuestLogLeaderBoard(l, j)) == "progressbar" then
-							track = "- "..floor(_G.GetQuestProgressBarPercent(qid)).."% out of 100% Complete."
+                            local progress = floor(_G.GetQuestProgressBarPercent(qid))
+							track = "- "..progress.."% out of 100% Complete."
+                            row.progressBar:SetValue(progress)
+                            if WoWProDB.profile.progressbar then
+                                row.progressBar:Show()
+                            else
+                                row.progressBar:Hide()
+                            end
+                        else
+                            row.progressBar:Hide()
 						end
 						if select(3, _G.GetQuestLogLeaderBoard(l, j)) then
                             track =  track.." (C)"
@@ -758,8 +767,16 @@ function WoWPro.UpdateQuestTrackerRow(row)
                 for l, lquesttext in ipairs({(";"):split(questtext)}) do
                     if WoWPro.ValidObjective(lquesttext) then
 						if select(2, _G.GetQuestLogLeaderBoard(lquesttext:sub(1, 1) , j)) == "progressbar" then
-							track = "- "..floor(_G.GetQuestProgressBarPercent(qid)).."% out of 100% Complete.\n"
+                            local progress = floor(_G.GetQuestProgressBarPercent(qid))
+							track = "- "..progress.."% out of 100% Complete.\n"
+                            row.progressBar:SetValue(progress)
+                            if WoWProDB.profile.progressbar then
+                                row.progressBar:Show()
+                            else
+                                row.progressBar:Hide()
+                            end
 						else
+                            row.progressBar:Hide()
 							local _, status = WoWPro.QuestObjectiveStatus(qid, lquesttext)
 							if l > 1 then
 								track = track.."\n"

--- a/WoWPro/WoWPro_Config.lua
+++ b/WoWPro/WoWPro_Config.lua
@@ -168,7 +168,6 @@ local function createDisplayConfig()
                 set = function(info,val) WoWProDB.profile.guidescroll = val
                     WoWPro:TitlebarSet()
                     WoWPro:UpdateGuide("Config: Scroll Mode") end,
-                    width = "double"
             },
             guideprogress = {
                 order = 21.5,
@@ -180,6 +179,17 @@ local function createDisplayConfig()
                     WoWProDB.profile.guideprogress = val
                     WoWPro:TitlebarSet()
                     WoWPro:UpdateGuide("Config: Guide Progress")
+                end,
+            },
+            progressbar = {
+                order = 21.7,
+                type = "toggle",
+                name = L["Display Quest Progress Bar"],
+                desc = L["If enabled, will show a progrerss bar for % based quests"],
+                get = function(info) return WoWProDB.profile.progressbar end,
+                set = function(info, val)
+                    WoWProDB.profile.progressbar = val
+                    WoWPro:UpdateGuide("Config: Display Quest Progress")
                 end,
             },
             checksoundfile = {

--- a/WoWPro/WoWPro_Frames.lua
+++ b/WoWPro/WoWPro_Frames.lua
@@ -268,12 +268,17 @@ function WoWPro.RowSizeSet()
             row.track:Show()
             row.track:SetPoint("TOPLEFT", row.action, "BOTTOMLEFT", 0, -noteh-5)
             trackh = row.track:GetHeight()
+            row.progressBar:SetWidth(row:GetWidth()-30)
         else
             row.track:Hide()
+            row.progressBar:Hide();
             trackh = 1
         end
 
         newh = noteh + trackh + max(row.step:GetHeight(),row.action:GetHeight()) + space*2 +3
+        if  row.progressBar:IsVisible() then
+            newh = newh + 20
+        end
         row:SetHeight(newh)
 
         -- Hiding the row if it's past the set number of steps --
@@ -690,6 +695,8 @@ function WoWPro:CreateRows()
         row.step = WoWPro:CreateStep(row, row.action)
         row.note = WoWPro:CreateNote(row, row.action)
         row.track = WoWPro:CreateTrack(row, row.action)
+        row.progressBar = WoWPro:CreateProgressBar(row, row.track)
+        row.progressBar:Hide()
         row.itembutton, row.itemicon, row.itemcooldown = WoWPro:CreateItemButton(row, i)
 		row.itembuttonSecured = WoWPro:CreateItemButtonSecured(i)
         row.targetbutton, row.targeticon = WoWPro:CreateTargetButton(row, i)

--- a/WoWPro/WoWPro_Widgets.lua
+++ b/WoWPro/WoWPro_Widgets.lua
@@ -126,6 +126,27 @@ function WoWPro:CreateTrack(parent, anchor1)
     return track
 end
 
+function WoWPro:CreateProgressBar(parent, anchor1)
+    local progressBar = _G.CreateFrame("StatusBar", nil, parent, BackdropTemplateMixin and "BackdropTemplate")
+    progressBar:SetPoint("TOPLEFT", anchor1, "BOTTOMLEFT", 0, -3)
+    progressBar:SetSize(100, 17)
+
+    progressBar:SetStatusBarTexture("Interface/TargetingFrame/UI-StatusBar")
+    progressBar:SetBackdrop( {
+        bgFile = [[Interface\CHARACTERFRAME\UI-Party-Background]],
+        edgeFile = [[Interface\Tooltips\UI-Tooltip-Border]],
+        tile = true, tileSize = 16, edgeSize = 5,
+        insets = { left = 0,  right = 0,  top = 0,  bottom = 0 }
+    })
+    progressBar:SetBackdropBorderColor(1, 1, 1, 1)
+    progressBar:SetBackdropColor(.8, .8, .8, 1)
+
+    progressBar:SetStatusBarColor(0, 1, 0)
+    progressBar:SetMinMaxValues(0, 100)
+    progressBar:SetValue(0)
+    return progressBar
+end
+
 function WoWPro:CreateItemButton(parent, id)
     local itembutton = _G.CreateFrame("Button", "WoWPro_itembutton"..id, parent, "InsecureActionButtonTemplate")
     itembutton:SetAttribute("type", "item")


### PR DESCRIPTION
Display's a progress bar of "fill the bar style" quests:

<img width="373" height="304" alt="image" src="https://github.com/user-attachments/assets/55237ab2-e606-4df6-8b6a-fdad061effc2" />

<img width="368" height="360" alt="image" src="https://github.com/user-attachments/assets/38b4ebf3-fd3c-4d5a-9bcb-5a5cf836ed71" />

I have added a config option to remove the bars for folks who don't like it!