### PR TITLE
Fix: Friendship reputation not working in non-English clients

### DIFF
--- a/WoWPro/WoWPro_Broker.lua
+++ b/WoWPro/WoWPro_Broker.lua
@@ -2645,24 +2645,24 @@ function WoWPro.NextStep(guideIndex, rowIndex)
                         WoWPro:Error("Bad Faction number in %q", WoWPro.rep[guideIndex])
                         break
                     end
-                    
+
                     -- Use GetFriendshipReputationRanks for numeric level instead of localized string matching
-                    local rankInfo = _G.C_GossipInfo.GetFriendshipReputationRanks(factionIndex)
+                    local rankInfo = _G.C_GossipInfo and _G.C_GossipInfo.GetFriendshipReputationRanks and _G.C_GossipInfo.GetFriendshipReputationRanks(factionIndex)
                     if rankInfo and rankInfo.currentLevel then
                         standingId = rankInfo.currentLevel - 1
                     else
                         -- Fallback to old string matching (should never happen in MoP+)
                         local friendTextLevel = reputationInfo.reaction:lower()
                         standingId = Rep2IdAndClass[friendTextLevel] and Rep2IdAndClass[friendTextLevel][1] or 0
-                        WoWPro:dbp("GetFriendshipReputationRanks not available for faction %d, using text fallback", factionIndex)
+                        WoWPro:dbp("NPC %s is a %s", reputationInfo.name, friendTextLevel)
                     end
-                    
+
                     if reputationInfo.nextThreshold then
                         earnedValue = reputationInfo.standing - reputationInfo.nextThreshold
                     else
                         earnedValue = 0 -- The reputation is at max
                     end
-                    WoWPro:dbp("NPC %s is a %s: standing %d, earned %d", reputationInfo.name, friendTextLevel, standingId, earnedValue)
+                    WoWPro:dbp("NPC %s: standing %d, earned %d", reputationInfo.name, standingId, earnedValue)
                 else
                     local factionInfo = WoWPro.C_Reputation_GetFactionDataByID(factionIndex)
                     if not factionInfo then

--- a/WoWPro/WoWPro_Broker.lua
+++ b/WoWPro/WoWPro_Broker.lua
@@ -2645,8 +2645,19 @@ function WoWPro.NextStep(guideIndex, rowIndex)
                         WoWPro:Error("Bad Faction number in %q", WoWPro.rep[guideIndex])
                         break
                     end
-                    local friendTextLevel = reputationInfo.reaction:lower()
-                    standingId = Rep2IdAndClass[friendTextLevel][1]
+                    
+                    -- Use GetFriendshipReputationRanks for numeric level instead of localized string matching
+                    local rankInfo = C_GossipInfo.GetFriendshipReputationRanks(factionIndex)
+                    if rankInfo and rankInfo.currentLevel then
+                        -- API returns 1-6, we need 0-5 for our table
+                        standingId = rankInfo.currentLevel - 1
+                    else
+                        -- Fallback to old string matching (should never happen in MoP+)
+                        local friendTextLevel = reputationInfo.reaction:lower()
+                        standingId = Rep2IdAndClass[friendTextLevel] and Rep2IdAndClass[friendTextLevel][1] or 0
+                        WoWPro:Warning("GetFriendshipReputationRanks not available for faction %d, using text fallback", factionIndex)
+                    end
+                    
                     if reputationInfo.nextThreshold then
                         earnedValue = reputationInfo.standing - reputationInfo.nextThreshold
                     else

--- a/WoWPro/WoWPro_Broker.lua
+++ b/WoWPro/WoWPro_Broker.lua
@@ -2647,15 +2647,14 @@ function WoWPro.NextStep(guideIndex, rowIndex)
                     end
                     
                     -- Use GetFriendshipReputationRanks for numeric level instead of localized string matching
-                    local rankInfo = C_GossipInfo.GetFriendshipReputationRanks(factionIndex)
+                    local rankInfo = _G.C_GossipInfo.GetFriendshipReputationRanks(factionIndex)
                     if rankInfo and rankInfo.currentLevel then
-                        -- API returns 1-6, we need 0-5 for our table
                         standingId = rankInfo.currentLevel - 1
                     else
                         -- Fallback to old string matching (should never happen in MoP+)
                         local friendTextLevel = reputationInfo.reaction:lower()
                         standingId = Rep2IdAndClass[friendTextLevel] and Rep2IdAndClass[friendTextLevel][1] or 0
-                        WoWPro:Warning("GetFriendshipReputationRanks not available for faction %d, using text fallback", factionIndex)
+                        WoWPro:dbp("GetFriendshipReputationRanks not available for faction %d, using text fallback", factionIndex)
                     end
                     
                     if reputationInfo.nextThreshold then


### PR DESCRIPTION
## Problem
Friendship reputation requirements (e.g. Tillers) were not working in non-English WoW clients because the addon was matching localized strings against English-only lookup tables.

## Solution  
Use `C_GossipInfo.GetFriendshipReputationRanks()` API to get numeric friendship levels instead of string matching.

## Changes
- Modified friendship reputation check in WoWPro_Broker.lua (~line 925)
- Use numeric API that returns consistent values (1-6) across all client languages
- Added fallback to old string matching for backwards compatibility (with debug message only)

## Testing
- Tested on German (deDE) MoP Classic client
- Verified all Tillers friendship levels detected correctly
- Confirmed Golden Lotus (standard reputation) still works as expected
- Range conditions (e.g. stranger-buddy) work correctly

## Impact
Fixes friendship reputation for all non-English clients without breaking existing functionality.