### PR TITLE
simplify profession data handling and harden tradeskill scanning

### DIFF
--- a/WoWPro/WoWPro.lua
+++ b/WoWPro/WoWPro.lua
@@ -110,7 +110,12 @@ WoWPro:Export("Error")
 
 local function ends_with(str, ending)
     return ending == "" or str:sub(-#ending) == ending
- end
+end
+
+local function QueueTradeWindowScan(...)
+    WoWPro:dbp("QueueTradeWindowScan() running ScanTrade()")
+    WoWPro.ScanTrade(...)
+end
 
 -- WoWPro Log function all only --
 function WoWPro.LogCall(nomen, ...)
@@ -561,7 +566,7 @@ function WoWPro:OnEnable()
         WoWPro:RegisterBucketEvent({"CRITERIA_UPDATE"}, 0.50, WoWPro.UpdateGuideReal)
     end
     WoWPro:RegisterBucketEvent({"LOOT_CLOSED"}, 0.250, WoWPro.AutoCompleteChest)
-    WoWPro:RegisterBucketEvent({"TRADE_SKILL_SHOW", "TRADE_SKILL_LIST_UPDATE"}, 0.250, WoWPro.ScanTrade)
+    WoWPro:RegisterBucketEvent({"TRADE_SKILL_SHOW", "TRADE_SKILL_LIST_UPDATE"}, 0.250, QueueTradeWindowScan)
     WoWPro:RegisterBucketMessage("WoWPro_LoadGuide",0.25,WoWPro.LoadGuideReal)
     WoWPro:RegisterBucketMessage("WoWPro_LoadGuideSteps",0.25,WoWPro.LoadGuideStepsReal)
     WoWPro:RegisterBucketMessage("WoWPro_GuideSetup",0.25,WoWPro.SetupGuideReal)

--- a/WoWPro/WoWPro_Events.lua
+++ b/WoWPro/WoWPro_Events.lua
@@ -791,11 +791,14 @@ local tradeSkillRefreshPending = false
 
 local function QueueTradeSkillRefresh()
     if tradeSkillRefreshPending then
+        WoWPro:dbp("QueueTradeSkillRefresh() skipped: already pending")
         return
     end
     tradeSkillRefreshPending = true
+    WoWPro:dbp("QueueTradeSkillRefresh() scheduled")
     _G.C_Timer.After(0.2, function()
         tradeSkillRefreshPending = false
+        WoWPro:dbp("QueueTradeSkillRefresh() running RefreshCurrentTradeSkills()")
         WoWPro.RefreshCurrentTradeSkills()
     end)
 end

--- a/WoWPro/WoWPro_Events.lua
+++ b/WoWPro/WoWPro_Events.lua
@@ -274,7 +274,7 @@ WoWPro.RegisterEventHandler("PLAYER_ENTERING_WORLD", function(event, ...)
     WoWPro.LockdownTimer = 1.5
     WoWPro.AutoHideFrame("|cff33ff33Battleground Exit Auto Show|r: "..event, "INSTANCE")
     WoWPro:InitializeHearthBind()
-    WoWPro:UpdateTradeSkills()
+    WoWPro:RefreshCurrentTradeSkills()
     end, true)
 
 -- Locking event processong till after things get settled --
@@ -787,9 +787,27 @@ WoWPro.RegisterEventHandler("QUEST_ACCEPTED", function(event, ...)
     end
 end)
 
+local tradeSkillRefreshPending = false
+
+local function QueueTradeSkillRefresh()
+    if tradeSkillRefreshPending then
+        return
+    end
+    tradeSkillRefreshPending = true
+    _G.C_Timer.After(0.2, function()
+        tradeSkillRefreshPending = false
+        WoWPro.RefreshCurrentTradeSkills()
+    end)
+end
+
 -- scan skill lines when they change
 WoWPro.RegisterEventHandler("SKILL_LINES_CHANGED", function(event, ...)
-    WoWPro.UpdateTradeSkills(...)
+    QueueTradeSkillRefresh()
+end)
+
+-- refresh profession levels when a spell is learned in a skill line
+WoWPro.RegisterEventHandler("LEARNED_SPELL_IN_SKILL_LINE", function(event, ...)
+    QueueTradeSkillRefresh()
 end)
 
 -- register newly learned recipes

--- a/WoWPro/WoWPro_Trade.lua
+++ b/WoWPro/WoWPro_Trade.lua
@@ -6,8 +6,8 @@
 
 -- list of all available professions and their skillLine ID
 
-if WoWPro.CLASSIC then   --  Gets Profs to work in Classic doing this, not sure something else can be done (Classic does not recognize the [2477] = { exp = 0, parent ...etc lines)
-	WoWPro.ProfessionSkillLines = {
+local function makeProfessionSkillLines(extraSkillLines)
+	local skillLines = {
 		[164] = { name = 'Blacksmithing' },
 		[165] = { name = 'Leatherworking' },
 		[171] = { name = 'Alchemy' },
@@ -17,297 +17,268 @@ if WoWPro.CLASSIC then   --  Gets Profs to work in Classic doing this, not sure 
 		[202] = { name = 'Engineering' },
 		[333] = { name = 'Enchanting' },
 		[393] = { name = 'Skinning' },
-		[129] = { name = 'First Aid'},
-	  --  Not included in GetTradeSkillLineInfoByID()
+		[129] = { name = 'First Aid' },
 		[185] = { name = 'Cooking' },
 		[356] = { name = 'Fishing' },
 		[633] = { name = 'Lockpicking' },
 	}
 
-	elseif WoWPro.BC then
-	WoWPro.ProfessionSkillLines = {
-		[164] = { name = 'Blacksmithing' },
-		[165] = { name = 'Leatherworking' },
-		[171] = { name = 'Alchemy' },
-		[182] = { name = 'Herbalism' },
-		[186] = { name = 'Mining' },
-		[197] = { name = 'Tailoring' },
-		[202] = { name = 'Engineering' },
-		[333] = { name = 'Enchanting' },
-		[393] = { name = 'Skinning' },
-		[129] = { name = 'First Aid'},
-		[755] = { name = 'Jewelcrafting' },
-	  --  Not included in GetTradeSkillLineInfoByID()
-		[185] = { name = 'Cooking' },
-		[356] = { name = 'Fishing' },
-		[633] = { name = 'Lockpicking' },
-	}
+	for skillLineID, data in pairs(extraSkillLines or {}) do
+		skillLines[skillLineID] = data
+	end
 
-	elseif WoWPro.WRATH then
-	WoWPro.ProfessionSkillLines = {
-		[164] = { name = 'Blacksmithing' },
-		[165] = { name = 'Leatherworking' },
-		[171] = { name = 'Alchemy' },
-		[182] = { name = 'Herbalism' },
-		[186] = { name = 'Mining' },
-		[197] = { name = 'Tailoring' },
-		[202] = { name = 'Engineering' },
-		[333] = { name = 'Enchanting' },
-		[393] = { name = 'Skinning' },
-		[129] = { name = 'First Aid'},
+	return skillLines
+end
+
+local function addExpansionSkillLines(skillLines, parentID, expansions)
+	for _, expansion in ipairs(expansions) do
+		skillLines[expansion.id] = {
+			exp = expansion.exp,
+			parent = parentID,
+			name = expansion.name,
+		}
+	end
+end
+
+local function buildRetailProfessionSkillLines()
+	local skillLines = makeProfessionSkillLines({
 		[755] = { name = 'Jewelcrafting' },
 		[773] = { name = 'Inscription' },
-	  --  Not included in GetTradeSkillLineInfoByID()
-		[185] = { name = 'Cooking' },
-		[356] = { name = 'Fishing' },
-		[633] = { name = 'Lockpicking' },
-		[762] = { name = 'Riding' },
-	}
-    elseif WoWPro.CATA then
-	WoWPro.ProfessionSkillLines = {
-		[164] = { name = 'Blacksmithing' },
-		[165] = { name = 'Leatherworking' },
-		[171] = { name = 'Alchemy' },
-		[182] = { name = 'Herbalism' },
-		[186] = { name = 'Mining' },
-		[197] = { name = 'Tailoring' },
-		[202] = { name = 'Engineering' },
-		[333] = { name = 'Enchanting' },
-		[393] = { name = 'Skinning' },
-		[129] = { name = 'First Aid'},
-		[755] = { name = 'Jewelcrafting' },
-		[773] = { name = 'Inscription' },
-	  --  Not included in GetTradeSkillLineInfoByID()
-		[185] = { name = 'Cooking' },
-		[356] = { name = 'Fishing' },
-		[633] = { name = 'Lockpicking' },
-		[762] = { name = 'Riding' },
-	}
-    elseif WoWPro.MOP then
-	WoWPro.ProfessionSkillLines = {
-		[164] = { name = 'Blacksmithing' },
-		[165] = { name = 'Leatherworking' },
-		[171] = { name = 'Alchemy' },
-		[182] = { name = 'Herbalism' },
-		[186] = { name = 'Mining' },
-		[197] = { name = 'Tailoring' },
-		[202] = { name = 'Engineering' },
-		[333] = { name = 'Enchanting' },
-		[393] = { name = 'Skinning' },
-		[129] = { name = 'First Aid'},
-		[755] = { name = 'Jewelcrafting' },
-		[773] = { name = 'Inscription' },
-	  --  Not included in GetTradeSkillLineInfoByID()
-		[185] = { name = 'Cooking' },
-		[356] = { name = 'Fishing' },
-		[633] = { name = 'Lockpicking' },
-		[762] = { name = 'Riding' },
-	}
-	else
-	WoWPro.ProfessionSkillLines = {
-		[164] = { name = 'Blacksmithing' },
-			[2907] = { exp = 11, parent = 164, name = 'Midnight Blacksmithing' },
-			[2872] = { exp = 10, parent = 164, name = 'Khaz Algar Blacksmithing' },
-			[2822] = { exp = 9, parent = 164, name = 'Dragon Isles Blacksmithing' },
-			[2751] = { exp = 8, parent = 164, name = 'Shadowlands Blacksmithing' },
-			[2437] = { exp = 7, parent = 164, name = 'Battle for Azeroth Blacksmithing' },
-			[2454] = { exp = 6, parent = 164, name = 'Legion Blacksmithing' },
-			[2472] = { exp = 5, parent = 164, name = 'Draenor Blacksmithing' },
-			[2473] = { exp = 4, parent = 164, name = 'Pandaria Blacksmithing' },
-			[2474] = { exp = 3, parent = 164, name = 'Cataclysm Blacksmithing' },
-			[2475] = { exp = 2, parent = 164, name = 'Northrend Blacksmithing' },
-			[2476] = { exp = 1, parent = 164, name = 'Outland Blacksmithing' },
-			[2477] = { exp = 0, parent = 164, name = 'Blacksmithing' },
-
-		[165] = { name = 'Leatherworking' },
-			[2915] = { exp = 11, parent = 165, name = 'Midnight Leatherworking' },
-			[2880] = { exp = 10, parent = 165, name = 'Khaz Algar Leatherworking' },
-			[2830] = { exp = 9, parent = 165, name = 'Dragon Isles Leatherworking' },
-			[2758] = { exp = 8, parent = 165, name = 'Shadowlands Leatherworking' },
-			[2525] = { exp = 7, parent = 165, name = 'Battle for Azeroth Leatherworking' },
-			[2526] = { exp = 6, parent = 165, name = 'Legion Leatherworking' },
-			[2527] = { exp = 5, parent = 165, name = 'Draenor Leatherworking' },
-			[2528] = { exp = 4, parent = 165, name = 'Pandaria Leatherworking' },
-			[2529] = { exp = 3, parent = 165, name = 'Cataclysm Leatherworking' },
-			[2530] = { exp = 2, parent = 165, name = 'Northrend Leatherworking' },
-			[2531] = { exp = 1, parent = 165, name = 'Outland Leatherworking' },
-			[2532] = { exp = 0, parent = 165, name = 'Leatherworking' },
-
-		[171] = { name = 'Alchemy' },
-			[2906] = { exp = 11, parent = 171, name = 'Midnight Alchemy' },
-			[2871] = { exp = 10, parent = 171, name = 'Khaz Algar Alchemy' },
-			[2823] = { exp = 9, parent = 171, name = 'Dragon Isles Alchemy' },
-			[2750] = { exp = 8, parent = 171, name = 'Shadowlands Alchemy' },
-			[2478] = { exp = 7, parent = 171, name = 'Battle for Azeroth Alchemy' },
-			[2479] = { exp = 6, parent = 171, name = 'Legion Alchemy' },
-			[2480] = { exp = 5, parent = 171, name = 'Draenor Alchemy' },
-			[2481] = { exp = 4, parent = 171, name = 'Pandaria Alchemy' },
-			[2482] = { exp = 3, parent = 171, name = 'Cataclysm Alchemy' },
-			[2483] = { exp = 2, parent = 171, name = 'Northrend Alchemy' },
-			[2484] = { exp = 1, parent = 171, name = 'Outland Alchemy' },
-			[2485] = { exp = 0, parent = 171, name = 'Alchemy' },
-
-		[182] = { name = 'Herbalism' },
-			[2912] = { exp = 11, parent = 182, name = 'Midnight Herbalism' },
-			[2877] = { exp = 10, parent = 182, name = 'Khaz Algar Herbalism' },
-			[2832] = { exp = 9, parent = 182, name = 'Dragon Isles Herbalism' },
-			[2760] = { exp = 8, parent = 182, name = 'Shadowlands Herbalism' },
-			[2549] = { exp = 7, parent = 182, name = 'Battle for Azeroth Herbalism' },
-			[2550] = { exp = 6, parent = 182, name = 'Legion Herbalism' },
-			[2551] = { exp = 5, parent = 182, name = 'Draenor Herbalism' },
-			[2552] = { exp = 4, parent = 182, name = 'Pandaria Herbalism' },
-			[2553] = { exp = 3, parent = 182, name = 'Cataclysm Herbalism' },
-			[2554] = { exp = 2, parent = 182, name = 'Northrend Herbalism' },
-			[2555] = { exp = 1, parent = 182, name = 'Outland Herbalism' },
-			[2556] = { exp = 0, parent = 182, name = 'Herbalism' },
-
-		-- Cooking is not included in GetTradeSkillLineInfoByID()
-		[185] = { name = 'Cooking' },
-			[2908] = { exp = 11, parent = 185, name = 'Midnight Cooking' },
-			[2873] = { exp = 10, parent = 185, name = 'Khaz Algar Cooking' },
-			[2824] = { exp = 9, parent = 185, name = 'Dragon Isles Cooking' },
-			[2752] = { exp = 8, parent = 185, name = 'Shadowlands Cooking' },
-			[2541] = { exp = 7, parent = 185, name = 'Battle for Azeroth Cooking' },
-			[2542] = { exp = 6, parent = 185, name = 'Legion Cooking' },
-			[2543] = { exp = 5, parent = 185, name = 'Draenor Cooking' },
-			[2544] = { exp = 4, parent = 185, name = 'Pandaria Cooking' },
-			-- Cooking Pandaria Specializations
-				[975] = { exp = 4, parent = 185, name = 'Way of the Grill' },
-				[976] = { exp = 4, parent = 185, name = 'Way of the Wok' },
-				[977] = { exp = 4, parent = 185, name = 'Way of the Pot' },
-				[978] = { exp = 4, parent = 185, name = 'Way of the Steamer' },
-				[979] = { exp = 4, parent = 185, name = 'Way of the Oven' },
-				[980] = { exp = 4, parent = 185, name = 'Way of the Brew' },
-			[2545] = { exp = 3, parent = 185, name = 'Cataclysm Cooking' },
-			[2546] = { exp = 2, parent = 185, name = 'Northrend Cooking' },
-			[2547] = { exp = 1, parent = 185, name = 'Outland Cooking' },
-			[2548] = { exp = 0, parent = 185, name = 'Cooking' },
-
-		[186] = { name = 'Mining' },
-			[2916] = { exp = 11, parent = 186, name = 'Midnight Mining' },
-			[2881] = { exp = 10, parent = 186, name = 'Khaz Algar Mining' },
-			[2833] = { exp = 9, parent = 186, name = 'Dragon Isles Mining' },
-			[2761] = { exp = 8, parent = 186, name = 'Shadowlands Mining' },
-			[2565] = { exp = 7, parent = 186, name = 'Battle for Azeroth Mining' },
-			[2566] = { exp = 6, parent = 186, name = 'Legion Mining' },
-			[2567] = { exp = 5, parent = 186, name = 'Draenor Mining' },
-			[2568] = { exp = 4, parent = 186, name = 'Pandaria Mining' },
-			[2569] = { exp = 3, parent = 186, name = 'Cataclysm Mining' },
-			[2570] = { exp = 2, parent = 186, name = 'Northrend Mining' },
-			[2571] = { exp = 1, parent = 186, name = 'Outland Mining' },
-			[2572] = { exp = 0, parent = 186, name = 'Mining' },
-
-		[197] = { name = 'Tailoring' },
-			[2918] = { exp = 11, parent = 197, name = 'Midnight Tailoring' },
-			[2883] = { exp = 10, parent = 197, name = 'Khaz Algar Tailoring' },
-			[2831] = { exp = 9, parent = 197, name = 'Dragon Isles Tailoring' },
-			[2759] = { exp = 8, parent = 197, name = 'Shadowlands Tailoring' },
-			[2533] = { exp = 7, parent = 197, name = 'Battle for Azeroth Tailoring' },
-			[2534] = { exp = 6, parent = 197, name = 'Legion Tailoring' },
-			[2535] = { exp = 5, parent = 197, name = 'Draenor Tailoring' },
-			[2536] = { exp = 4, parent = 197, name = 'Pandaria Tailoring' },
-			[2537] = { exp = 3, parent = 197, name = 'Cataclysm Tailoring' },
-			[2538] = { exp = 2, parent = 197, name = 'Northrend Tailoring' },
-			[2539] = { exp = 1, parent = 197, name = 'Outland Tailoring' },
-			[2540] = { exp = 0, parent = 197, name = 'Tailoring' },
-
-		[202] = { name = 'Engineering' },
-			[2910] = { exp = 11, parent = 202, name = 'Midnight Engineering' },
-			[2875] = { exp = 10, parent = 202, name = 'Khaz Algar Engineering' },
-			[2827] = { exp = 9, parent = 202, name = 'Dragon Isles Engineering' },
-			[2755] = { exp = 8, parent = 202, name = 'Shadowlands Engineering' },
-			[2499] = { exp = 7, parent = 202, name = 'Battle for Azeroth Engineering' },
-			[2500] = { exp = 6, parent = 202, name = 'Legion Engineering' },
-			[2501] = { exp = 5, parent = 202, name = 'Draenor Engineering' },
-			[2502] = { exp = 4, parent = 202, name = 'Pandaria Engineering' },
-			[2503] = { exp = 3, parent = 202, name = 'Cataclysm Engineering' },
-			[2504] = { exp = 2, parent = 202, name = 'Northrend Engineering' },
-			[2505] = { exp = 1, parent = 202, name = 'Outland Engineering' },
-			[2506] = { exp = 0, parent = 202, name = 'Engineering' },
-
-		[333] = { name = 'Enchanting' },
-			[2909] = { exp = 11, parent = 333, name = 'Midnight Enchanting' },
-			[2874] = { exp = 10, parent = 333, name = 'Khaz Algar Enchanting' },
-			[2825] = { exp = 9, parent = 333, name = 'Dragon Isles Enchanting' },
-			[2753] = { exp = 8, parent = 333, name = 'Shadowlands Enchanting' },
-			[2486] = { exp = 7, parent = 333, name = 'Battle for Azeroth Enchanting' },
-			[2487] = { exp = 6, parent = 333, name = 'Legion Enchanting' },
-			[2488] = { exp = 5, parent = 333, name = 'Draenor Enchanting' },
-			[2489] = { exp = 4, parent = 333, name = 'Pandaria Enchanting' },
-			[2491] = { exp = 3, parent = 333, name = 'Cataclysm Enchanting' },
-			[2492] = { exp = 2, parent = 333, name = 'Northrend Enchanting' },
-			[2493] = { exp = 1, parent = 333, name = 'Outland Enchanting' },
-			[2494] = { exp = 0, parent = 333, name = 'Enchanting' },
-
-		-- Fishing is not included in GetTradeSkillLineInfoByID()
-		[356] = { name = 'Fishing' },
-			[2911] = { exp = 11, parent = 356, name = 'Midnight Fishing' },
-			[2876] = { exp = 10, parent = 356, name = 'Khaz Algar Fishing' },
-			[2826] = { exp = 9, parent = 356, name = 'Dragon Isles Fishing' },
-			[2754] = { exp = 8, parent = 356, name = 'Shadowlands Fishing' },
-			[2585] = { exp = 8, parent = 356, name = 'Battle for Azeroth Fishing' },
-			[2586] = { exp = 7, parent = 356, name = 'Legion Fishing' },
-			[2587] = { exp = 5, parent = 356, name = 'Draenor Fishing' },
-			[2588] = { exp = 4, parent = 356, name = 'Pandaria Fishing' },
-			[2589] = { exp = 3, parent = 356, name = 'Cataclysm Fishing' },
-			[2590] = { exp = 2, parent = 356, name = 'Northrend Fishing' },
-			[2591] = { exp = 1, parent = 356, name = 'Outland Fishing' },
-			[2592] = { exp = 0, parent = 356, name = 'Fishing' },
-
-		[393] = { name = 'Skinning' },
-			[2917] = { exp = 11, parent = 393, name = 'Midnight Skinning' },
-			[2882] = { exp = 10, parent = 393, name = 'Khaz Algar Skinning' },
-			[2834] = { exp = 9, parent = 393, name = 'Dragon Isles Skinning' },
-			[2762] = { exp = 8, parent = 393, name = 'Shadowlands Skinning' },
-			[2557] = { exp = 7, parent = 393, name = 'Battle for Azeroth Skinning' },
-			[2558] = { exp = 6, parent = 393, name = 'Legion Skinning' },
-			[2559] = { exp = 5, parent = 393, name = 'Draenor Skinning' },
-			[2560] = { exp = 4, parent = 393, name = 'Pandaria Skinning' },
-			[2561] = { exp = 3, parent = 393, name = 'Cataclysm Skinning' },
-			[2562] = { exp = 2, parent = 393, name = 'Northrend Skinning' },
-			[2563] = { exp = 1, parent = 393, name = 'Outland Sknning' },
-			[2564] = { exp = 0, parent = 393, name = 'Skinning' },
-
-		[755] = { name = 'Jewelcrafting' },
-			[2914] = { exp = 11, parent = 755, name = 'Midnight Jewelcrafting' },
-			[2879] = { exp = 10, parent = 755, name = 'Khaz Algar Jewelcrafting' },
-			[2829] = { exp = 9, parent = 755, name = 'Dragon Isles Jewelcrafting' },
-			[2757] = { exp = 8, parent = 755, name = 'Shadowlands Jewelcrafting' },
-			[2517] = { exp = 7, parent = 755, name = 'Battle for Azeroth Jewelcrafting' },
-			[2518] = { exp = 6, parent = 755, name = 'Legion Jewelcrafting' },
-			[2519] = { exp = 5, parent = 755, name = 'Draenor Jewelcrafting' },
-			[2520] = { exp = 4, parent = 755, name = 'Pandaria Jewelcrafting' },
-			[2521] = { exp = 3, parent = 755, name = 'Cataclysm Jewelcrafting' },
-			[2522] = { exp = 2, parent = 755, name = 'Northrend Jewelcrafting' },
-			[2523] = { exp = 1, parent = 755, name = 'Outland Jewelcrafting' },
-			[2524] = { exp = 0, parent = 755, name = 'Jewelcrafting' },
-
-		[773] = { name = 'Inscription' },
-			[2913] = { exp = 11, parent = 773, name = 'Midnight Inscription' },
-			[2878] = { exp = 10, parent = 773, name = 'Khaz Algar Inscription' },
-			[2828] = { exp = 9, parent = 773, name = 'Dragon Isles Inscription' },
-			[2756] = { exp = 8, parent = 773, name = 'Shadowlands Inscription' },
-			[2507] = { exp = 7, parent = 773, name = 'Battle for Azeroth Inscription' },
-			[2508] = { exp = 6, parent = 773, name = 'Legion Inscription' },
-			[2509] = { exp = 5, parent = 773, name = 'Draenor Inscription' },
-			[2510] = { exp = 4, parent = 773, name = 'Pandaria Inscription' },
-			[2511] = { exp = 3, parent = 773, name = 'Cataclysm Inscription' },
-			[2512] = { exp = 2, parent = 773, name = 'Northrend Inscription' },
-			[2513] = { exp = 1, parent = 773, name = 'Outland Inscription' },
-			[2514] = { exp = 0, parent = 773, name = 'Inscription' },
-
-		[129] = { name = 'First Aid'},
-
-		--  Not included in GetTradeSkillLineInfoByID()
-		[633] = { name = 'Lockpicking' },
 		[794] = { name = 'Archaeology' },
 		[960] = { name = 'Runeforging' },
-		[2720] = { exp = 7, name = 'Junkyard Tinkering'},
-		[2787] = { exp = 8, name = 'Abominable Stitching'},
-		[2791] = { exp = 8, name = 'Ascension Crafting'},
-		[2819] = { exp = 8, name = 'Protoform Synthesis'}
+		[2720] = { exp = 7, name = 'Junkyard Tinkering' },
+		[2787] = { exp = 8, name = 'Abominable Stitching' },
+		[2791] = { exp = 8, name = 'Ascension Crafting' },
+		[2819] = { exp = 8, name = 'Protoform Synthesis' },
+	})
+
+	local expansions = {
+		[164] = {
+			{ id = 2907, exp = 11, name = 'Midnight Blacksmithing' },
+			{ id = 2872, exp = 10, name = 'Khaz Algar Blacksmithing' },
+			{ id = 2822, exp = 9, name = 'Dragon Isles Blacksmithing' },
+			{ id = 2751, exp = 8, name = 'Shadowlands Blacksmithing' },
+			{ id = 2437, exp = 7, name = 'Battle for Azeroth Blacksmithing' },
+			{ id = 2454, exp = 6, name = 'Legion Blacksmithing' },
+			{ id = 2472, exp = 5, name = 'Draenor Blacksmithing' },
+			{ id = 2473, exp = 4, name = 'Pandaria Blacksmithing' },
+			{ id = 2474, exp = 3, name = 'Cataclysm Blacksmithing' },
+			{ id = 2475, exp = 2, name = 'Northrend Blacksmithing' },
+			{ id = 2476, exp = 1, name = 'Outland Blacksmithing' },
+			{ id = 2477, exp = 0, name = 'Blacksmithing' },
+		},
+		[165] = {
+			{ id = 2915, exp = 11, name = 'Midnight Leatherworking' },
+			{ id = 2880, exp = 10, name = 'Khaz Algar Leatherworking' },
+			{ id = 2830, exp = 9, name = 'Dragon Isles Leatherworking' },
+			{ id = 2758, exp = 8, name = 'Shadowlands Leatherworking' },
+			{ id = 2525, exp = 7, name = 'Battle for Azeroth Leatherworking' },
+			{ id = 2526, exp = 6, name = 'Legion Leatherworking' },
+			{ id = 2527, exp = 5, name = 'Draenor Leatherworking' },
+			{ id = 2528, exp = 4, name = 'Pandaria Leatherworking' },
+			{ id = 2529, exp = 3, name = 'Cataclysm Leatherworking' },
+			{ id = 2530, exp = 2, name = 'Northrend Leatherworking' },
+			{ id = 2531, exp = 1, name = 'Outland Leatherworking' },
+			{ id = 2532, exp = 0, name = 'Leatherworking' },
+		},
+		[171] = {
+			{ id = 2906, exp = 11, name = 'Midnight Alchemy' },
+			{ id = 2871, exp = 10, name = 'Khaz Algar Alchemy' },
+			{ id = 2823, exp = 9, name = 'Dragon Isles Alchemy' },
+			{ id = 2750, exp = 8, name = 'Shadowlands Alchemy' },
+			{ id = 2478, exp = 7, name = 'Battle for Azeroth Alchemy' },
+			{ id = 2479, exp = 6, name = 'Legion Alchemy' },
+			{ id = 2480, exp = 5, name = 'Draenor Alchemy' },
+			{ id = 2481, exp = 4, name = 'Pandaria Alchemy' },
+			{ id = 2482, exp = 3, name = 'Cataclysm Alchemy' },
+			{ id = 2483, exp = 2, name = 'Northrend Alchemy' },
+			{ id = 2484, exp = 1, name = 'Outland Alchemy' },
+			{ id = 2485, exp = 0, name = 'Alchemy' },
+		},
+		[182] = {
+			{ id = 2912, exp = 11, name = 'Midnight Herbalism' },
+			{ id = 2877, exp = 10, name = 'Khaz Algar Herbalism' },
+			{ id = 2832, exp = 9, name = 'Dragon Isles Herbalism' },
+			{ id = 2760, exp = 8, name = 'Shadowlands Herbalism' },
+			{ id = 2549, exp = 7, name = 'Battle for Azeroth Herbalism' },
+			{ id = 2550, exp = 6, name = 'Legion Herbalism' },
+			{ id = 2551, exp = 5, name = 'Draenor Herbalism' },
+			{ id = 2552, exp = 4, name = 'Pandaria Herbalism' },
+			{ id = 2553, exp = 3, name = 'Cataclysm Herbalism' },
+			{ id = 2554, exp = 2, name = 'Northrend Herbalism' },
+			{ id = 2555, exp = 1, name = 'Outland Herbalism' },
+			{ id = 2556, exp = 0, name = 'Herbalism' },
+		},
+		[185] = {
+			{ id = 2908, exp = 11, name = 'Midnight Cooking' },
+			{ id = 2873, exp = 10, name = 'Khaz Algar Cooking' },
+			{ id = 2824, exp = 9, name = 'Dragon Isles Cooking' },
+			{ id = 2752, exp = 8, name = 'Shadowlands Cooking' },
+			{ id = 2541, exp = 7, name = 'Battle for Azeroth Cooking' },
+			{ id = 2542, exp = 6, name = 'Legion Cooking' },
+			{ id = 2543, exp = 5, name = 'Draenor Cooking' },
+			{ id = 2544, exp = 4, name = 'Pandaria Cooking' },
+			{ id = 975, exp = 4, name = 'Way of the Grill' },
+			{ id = 976, exp = 4, name = 'Way of the Wok' },
+			{ id = 977, exp = 4, name = 'Way of the Pot' },
+			{ id = 978, exp = 4, name = 'Way of the Steamer' },
+			{ id = 979, exp = 4, name = 'Way of the Oven' },
+			{ id = 980, exp = 4, name = 'Way of the Brew' },
+			{ id = 2545, exp = 3, name = 'Cataclysm Cooking' },
+			{ id = 2546, exp = 2, name = 'Northrend Cooking' },
+			{ id = 2547, exp = 1, name = 'Outland Cooking' },
+			{ id = 2548, exp = 0, name = 'Cooking' },
+		},
+		[186] = {
+			{ id = 2916, exp = 11, name = 'Midnight Mining' },
+			{ id = 2881, exp = 10, name = 'Khaz Algar Mining' },
+			{ id = 2833, exp = 9, name = 'Dragon Isles Mining' },
+			{ id = 2761, exp = 8, name = 'Shadowlands Mining' },
+			{ id = 2565, exp = 7, name = 'Battle for Azeroth Mining' },
+			{ id = 2566, exp = 6, name = 'Legion Mining' },
+			{ id = 2567, exp = 5, name = 'Draenor Mining' },
+			{ id = 2568, exp = 4, name = 'Pandaria Mining' },
+			{ id = 2569, exp = 3, name = 'Cataclysm Mining' },
+			{ id = 2570, exp = 2, name = 'Northrend Mining' },
+			{ id = 2571, exp = 1, name = 'Outland Mining' },
+			{ id = 2572, exp = 0, name = 'Mining' },
+		},
+		[197] = {
+			{ id = 2918, exp = 11, name = 'Midnight Tailoring' },
+			{ id = 2883, exp = 10, name = 'Khaz Algar Tailoring' },
+			{ id = 2831, exp = 9, name = 'Dragon Isles Tailoring' },
+			{ id = 2759, exp = 8, name = 'Shadowlands Tailoring' },
+			{ id = 2533, exp = 7, name = 'Battle for Azeroth Tailoring' },
+			{ id = 2534, exp = 6, name = 'Legion Tailoring' },
+			{ id = 2535, exp = 5, name = 'Draenor Tailoring' },
+			{ id = 2536, exp = 4, name = 'Pandaria Tailoring' },
+			{ id = 2537, exp = 3, name = 'Cataclysm Tailoring' },
+			{ id = 2538, exp = 2, name = 'Northrend Tailoring' },
+			{ id = 2539, exp = 1, name = 'Outland Tailoring' },
+			{ id = 2540, exp = 0, name = 'Tailoring' },
+		},
+		[202] = {
+			{ id = 2910, exp = 11, name = 'Midnight Engineering' },
+			{ id = 2875, exp = 10, name = 'Khaz Algar Engineering' },
+			{ id = 2827, exp = 9, name = 'Dragon Isles Engineering' },
+			{ id = 2755, exp = 8, name = 'Shadowlands Engineering' },
+			{ id = 2499, exp = 7, name = 'Battle for Azeroth Engineering' },
+			{ id = 2500, exp = 6, name = 'Legion Engineering' },
+			{ id = 2501, exp = 5, name = 'Draenor Engineering' },
+			{ id = 2502, exp = 4, name = 'Pandaria Engineering' },
+			{ id = 2503, exp = 3, name = 'Cataclysm Engineering' },
+			{ id = 2504, exp = 2, name = 'Northrend Engineering' },
+			{ id = 2505, exp = 1, name = 'Outland Engineering' },
+			{ id = 2506, exp = 0, name = 'Engineering' },
+		},
+		[333] = {
+			{ id = 2909, exp = 11, name = 'Midnight Enchanting' },
+			{ id = 2874, exp = 10, name = 'Khaz Algar Enchanting' },
+			{ id = 2825, exp = 9, name = 'Dragon Isles Enchanting' },
+			{ id = 2753, exp = 8, name = 'Shadowlands Enchanting' },
+			{ id = 2486, exp = 7, name = 'Battle for Azeroth Enchanting' },
+			{ id = 2487, exp = 6, name = 'Legion Enchanting' },
+			{ id = 2488, exp = 5, name = 'Draenor Enchanting' },
+			{ id = 2489, exp = 4, name = 'Pandaria Enchanting' },
+			{ id = 2491, exp = 3, name = 'Cataclysm Enchanting' },
+			{ id = 2492, exp = 2, name = 'Northrend Enchanting' },
+			{ id = 2493, exp = 1, name = 'Outland Enchanting' },
+			{ id = 2494, exp = 0, name = 'Enchanting' },
+		},
+		[356] = {
+			{ id = 2911, exp = 11, name = 'Midnight Fishing' },
+			{ id = 2876, exp = 10, name = 'Khaz Algar Fishing' },
+			{ id = 2826, exp = 9, name = 'Dragon Isles Fishing' },
+			{ id = 2754, exp = 8, name = 'Shadowlands Fishing' },
+			{ id = 2585, exp = 8, name = 'Battle for Azeroth Fishing' },
+			{ id = 2586, exp = 7, name = 'Legion Fishing' },
+			{ id = 2587, exp = 5, name = 'Draenor Fishing' },
+			{ id = 2588, exp = 4, name = 'Pandaria Fishing' },
+			{ id = 2589, exp = 3, name = 'Cataclysm Fishing' },
+			{ id = 2590, exp = 2, name = 'Northrend Fishing' },
+			{ id = 2591, exp = 1, name = 'Outland Fishing' },
+			{ id = 2592, exp = 0, name = 'Fishing' },
+		},
+		[393] = {
+			{ id = 2917, exp = 11, name = 'Midnight Skinning' },
+			{ id = 2882, exp = 10, name = 'Khaz Algar Skinning' },
+			{ id = 2834, exp = 9, name = 'Dragon Isles Skinning' },
+			{ id = 2762, exp = 8, name = 'Shadowlands Skinning' },
+			{ id = 2557, exp = 7, name = 'Battle for Azeroth Skinning' },
+			{ id = 2558, exp = 6, name = 'Legion Skinning' },
+			{ id = 2559, exp = 5, name = 'Draenor Skinning' },
+			{ id = 2560, exp = 4, name = 'Pandaria Skinning' },
+			{ id = 2561, exp = 3, name = 'Cataclysm Skinning' },
+			{ id = 2562, exp = 2, name = 'Northrend Skinning' },
+			{ id = 2563, exp = 1, name = 'Outland Skinning' },
+			{ id = 2564, exp = 0, name = 'Skinning' },
+		},
+		[755] = {
+			{ id = 2914, exp = 11, name = 'Midnight Jewelcrafting' },
+			{ id = 2879, exp = 10, name = 'Khaz Algar Jewelcrafting' },
+			{ id = 2829, exp = 9, name = 'Dragon Isles Jewelcrafting' },
+			{ id = 2757, exp = 8, name = 'Shadowlands Jewelcrafting' },
+			{ id = 2517, exp = 7, name = 'Battle for Azeroth Jewelcrafting' },
+			{ id = 2518, exp = 6, name = 'Legion Jewelcrafting' },
+			{ id = 2519, exp = 5, name = 'Draenor Jewelcrafting' },
+			{ id = 2520, exp = 4, name = 'Pandaria Jewelcrafting' },
+			{ id = 2521, exp = 3, name = 'Cataclysm Jewelcrafting' },
+			{ id = 2522, exp = 2, name = 'Northrend Jewelcrafting' },
+			{ id = 2523, exp = 1, name = 'Outland Jewelcrafting' },
+			{ id = 2524, exp = 0, name = 'Jewelcrafting' },
+		},
+		[773] = {
+			{ id = 2913, exp = 11, name = 'Midnight Inscription' },
+			{ id = 2878, exp = 10, name = 'Khaz Algar Inscription' },
+			{ id = 2828, exp = 9, name = 'Dragon Isles Inscription' },
+			{ id = 2756, exp = 8, name = 'Shadowlands Inscription' },
+			{ id = 2507, exp = 7, name = 'Battle for Azeroth Inscription' },
+			{ id = 2508, exp = 6, name = 'Legion Inscription' },
+			{ id = 2509, exp = 5, name = 'Draenor Inscription' },
+			{ id = 2510, exp = 4, name = 'Pandaria Inscription' },
+			{ id = 2511, exp = 3, name = 'Cataclysm Inscription' },
+			{ id = 2512, exp = 2, name = 'Northrend Inscription' },
+			{ id = 2513, exp = 1, name = 'Outland Inscription' },
+			{ id = 2514, exp = 0, name = 'Inscription' },
+		},
 	}
+
+	for parentID, parentExpansions in pairs(expansions) do
+		addExpansionSkillLines(skillLines, parentID, parentExpansions)
 	end
+
+	return skillLines
+end
+
+if WoWPro.CLASSIC then   --  Gets Profs to work in Classic doing this, not sure something else can be done (Classic does not recognize the [2477] = { exp = 0, parent ...etc lines)
+	WoWPro.ProfessionSkillLines = makeProfessionSkillLines()
+
+elseif WoWPro.BC then
+	WoWPro.ProfessionSkillLines = makeProfessionSkillLines({
+		[755] = { name = 'Jewelcrafting' },
+	})
+
+elseif WoWPro.WRATH then
+	WoWPro.ProfessionSkillLines = makeProfessionSkillLines({
+		[755] = { name = 'Jewelcrafting' },
+		[773] = { name = 'Inscription' },
+		[762] = { name = 'Riding' },
+	})
+elseif WoWPro.CATA then
+	WoWPro.ProfessionSkillLines = makeProfessionSkillLines({
+		[755] = { name = 'Jewelcrafting' },
+		[773] = { name = 'Inscription' },
+		[762] = { name = 'Riding' },
+	})
+elseif WoWPro.MOP then
+	WoWPro.ProfessionSkillLines = makeProfessionSkillLines({
+		[755] = { name = 'Jewelcrafting' },
+		[773] = { name = 'Inscription' },
+		[762] = { name = 'Riding' },
+	})
+else
+	WoWPro.ProfessionSkillLines = buildRetailProfessionSkillLines()
+end
 
 WoWPro.ProfessionExpansion2Skill = {}
 for skill, data in pairs(WoWPro.ProfessionSkillLines) do
@@ -404,7 +375,7 @@ elseif WoWPro.RETAIL then
             -- WoWPro:dbp("UpdateTradeSkills() scanning %d", skillLineID)
             local professionInfo = _G.C_TradeSkillUI.GetProfessionInfoBySkillLineID(skillLineID)
             -- WoWPro:dbp("UpdateTradeSkills() scanned %d/%s", skillLineID, professionInfo.professionName)
-            if professionInfo.skillLevel > 0 and WoWPro.ProfessionSkillLines[skillLineID] then
+            if professionInfo and professionInfo.skillLevel > 0 and WoWPro.ProfessionSkillLines[skillLineID] then
                 tradeskills[skillLineID] = {
                     name = WoWPro.ProfessionSkillLines[skillLineID].name,
                     skillLvl = professionInfo.skillLevel,
@@ -445,20 +416,25 @@ end
 -- update WoWProCharDB.Tradeskill map so we don't forget detailed ScanTrade() info
 function WoWPro.UpdateTradeSkillsTable(tradeskills)
     if not WoWProCharDB.Tradeskills then
-        WoWProCharDB.Tradeskills = tradeskills
-        return
+        WoWProCharDB.Tradeskills = {}
     end
+
+    local toRemove = {}
 
     -- remove unlearned/unavailable professions, except for cooking or fishing
     for trade in pairs(WoWProCharDB.Tradeskills) do
         local skillLine = WoWPro.ProfessionSkillLines[trade]
         if not skillLine then
             WoWPro:dbp("UpdateTradeSkillsTable(): Deleted unavailable %d", trade)
-            WoWProCharDB.Tradeskills[trade] = nil
+            toRemove[trade] = true
         elseif tradeskills[trade] == nil and trade ~= 185 and skillLine.parent ~= 185 and trade ~= 356 and skillLine.parent ~= 356 then
             WoWPro:dbp("UpdateTradeSkillsTable(): Deleted unlearned %d/%s", trade, skillLine.name)
-            WoWProCharDB.Tradeskills[trade] = nil
+            toRemove[trade] = true
         end
+    end
+
+    for trade in pairs(toRemove) do
+        WoWProCharDB.Tradeskills[trade] = nil
     end
 
     -- add/update learned professions
@@ -478,7 +454,7 @@ function WoWPro.TradeskillsReport()
         text = text .. "_TID Lvl Max ++ Name\n"
         for tradeID, tradeskill in pairs(WoWProCharDB.Tradeskills) do
             local line
-            line = ("%04d %03d %03d %02d %q\n"):format(tradeID, tradeskill.skillLvl, tradeskill.skillMax, tradeskill.Mod, tradeskill.name)
+            line = ("%04d %03d %03d %02d %q\n"):format(tradeID, tradeskill.skillLvl, tradeskill.skillMax, tradeskill.skillMod, tradeskill.name)
             text = text .. line
         end
         LogBox.Box:SetText(text)
@@ -504,7 +480,7 @@ else
         WoWPro:dbp("ScanTrade() checking environment.")
         -- read tradeskill information, if the window is open
         local baseInfo = _G.C_TradeSkillUI.GetBaseProfessionInfo();
-        if baseInfo.professsionID == 0 then
+        if not baseInfo or baseInfo.professionID == 0 then
             WoWPro:dbp("ScanTrade() No window.")
             return
         end
@@ -543,16 +519,16 @@ else
         local catInfo = {}
         for _, catID in ipairs({_G.C_TradeSkillUI.GetCategories()}) do
             -- only scan category IDs we are interested in
-            local skillLineID = WoWPro.ProfessionSkillLines[catID]
-            if skillLineID then
+            local profession = WoWPro.ProfessionSkillLines[catID]
+            if profession then
                 _G.C_TradeSkillUI.GetCategoryInfo(catID, catInfo)
                 if catInfo.hasProgressBar and catInfo.skillLineCurrentLevel and catInfo.skillLineMaxLevel then
-                    tradeInfo = WoWProCharDB.Tradeskills[skillLineID] or {}
-                    tradeInfo.name = WoWPro.ProfessionSkillLines[skillLineID].name
+                    tradeInfo = WoWProCharDB.Tradeskills[catID] or {}
+                    tradeInfo.name = profession.name
                     tradeInfo.skillLvl = catInfo.skillLineCurrentLevel
                     tradeInfo.skillMax = catInfo.skillLineMaxLevel
                     tradeInfo.skillMod = childInfo.skillModifier
-                    WoWProCharDB.Tradeskills[skillLineID] = tradeInfo
+                    WoWProCharDB.Tradeskills[catID] = tradeInfo
                 end
             end
         end
@@ -566,16 +542,20 @@ else
             local recipeInfo = _G.C_TradeSkillUI.GetRecipeInfo(recipeID)
             if recipeInfo.learned then
                 local link = _G.C_TradeSkillUI.GetRecipeLink(recipeID)
-                local _, _, spellId = link:find("^|%x+|Henchant:(.+)|h%[.+%]")
-                spellId = tonumber(spellId)
-                if not spellId then
-                    local safe_link = link:gsub("|", "¦")
-                    WoWPro:Error("Error scanning recipeID %d for [%s]: %s", recipeID, recipeInfo.name, safe_link)
+                if not link then
+                    WoWPro:dbp("ScanTrade() recipeID %d had no link", recipeID)
                 else
-                    if not Trades[spellId] then
-                        Trades[spellId] = true
-                        WoWPro:dbp("Newly learned %s:%d", recipeInfo.name, spellId)
-                        learned = learned + 1
+                    local _, _, spellId = link:find("^|%x+|Henchant:(.+)|h%[.+%]")
+                    spellId = tonumber(spellId)
+                    if not spellId then
+                        local safe_link = link:gsub("|", "¦")
+                        WoWPro:Error("Error scanning recipeID %d for [%s]: %s", recipeID, recipeInfo.name, safe_link)
+                    else
+                        if not Trades[spellId] then
+                            Trades[spellId] = true
+                            WoWPro:dbp("Newly learned %s:%d", recipeInfo.name, spellId)
+                            learned = learned + 1
+                        end
                     end
                 end
             end

--- a/WoWPro/WoWPro_Trade.lua
+++ b/WoWPro/WoWPro_Trade.lua
@@ -342,7 +342,7 @@ if not WoWPro.RETAIL then
     end
 
     -- get tradeskill information from skill lines
-    function WoWPro.UpdateTradeSkills()
+    function WoWPro.RefreshCurrentTradeSkills()
         local scanned = 0
         local tradeskills = {}
 
@@ -362,19 +362,19 @@ if not WoWPro.RETAIL then
         end
 
         WoWPro.UpdateTradeSkillsTable(tradeskills)
-        WoWPro:dbp("UpdateTradeSkills() for Classic scanned %d tradeskills", scanned)
+        WoWPro:dbp("RefreshCurrentTradeSkills() for Classic scanned %d tradeskills", scanned)
     end
 elseif WoWPro.RETAIL then
-    function WoWPro.UpdateTradeSkills()
+    function WoWPro.RefreshCurrentTradeSkills()
         local scanned = 0
         local tradeskills = {}
 
         -- first scan all profession tradeskill lines that are learned
         local tradeSkills = _G.C_TradeSkillUI.GetAllProfessionTradeSkillLines()
         for _, skillLineID in pairs(tradeSkills) do
-            -- WoWPro:dbp("UpdateTradeSkills() scanning %d", skillLineID)
+            -- WoWPro:dbp("RefreshCurrentTradeSkills() scanning %d", skillLineID)
             local professionInfo = _G.C_TradeSkillUI.GetProfessionInfoBySkillLineID(skillLineID)
-            -- WoWPro:dbp("UpdateTradeSkills() scanned %d/%s", skillLineID, professionInfo.professionName)
+            -- WoWPro:dbp("RefreshCurrentTradeSkills() scanned %d/%s", skillLineID, professionInfo.professionName)
             if professionInfo and professionInfo.skillLevel > 0 and WoWPro.ProfessionSkillLines[skillLineID] then
                 tradeskills[skillLineID] = {
                     name = WoWPro.ProfessionSkillLines[skillLineID].name,
@@ -382,16 +382,16 @@ elseif WoWPro.RETAIL then
                     skillMax = professionInfo.maxSkillLevel,
                     skillMod = professionInfo.skillModifier
                 }
-                WoWPro:dbp("UpdateTradeSkills() added %d/%s skillLvl=%d skillMax=%d", skillLineID, professionInfo.professionName, professionInfo.skillLevel, professionInfo.maxSkillLevel)
+                WoWPro:dbp("RefreshCurrentTradeSkills() added %d/%s skillLvl=%d skillMax=%d", skillLineID, professionInfo.professionName, professionInfo.skillLevel, professionInfo.maxSkillLevel)
                 scanned = scanned + 1
             end
         end
 
         -- scan with GetProfessions()
         for _, profID in pairs({_G.GetProfessions()}) do
-            -- WoWPro:dbp("UpdateTradeSkills() scan profession %d", profID)
+            -- WoWPro:dbp("RefreshCurrentTradeSkills() scan profession %d", profID)
             local name, _, skillLineRank, skillLineMaxRank, _, _, skillLineID, skillLineModifier = _G.GetProfessionInfo(profID)
-            -- WoWPro:dbp("UpdateTradeSkills() scanning %s/%s/%d", name, tostring(subName), skillLineID)
+            -- WoWPro:dbp("RefreshCurrentTradeSkills() scanning %s/%s/%d", name, tostring(subName), skillLineID)
             -- skillLineID is always the parent ID, so once you learn an expansion, ...
             if WoWPro.ProfessionSkillLines[skillLineID] then
                 tradeskills[skillLineID] = {
@@ -400,16 +400,21 @@ elseif WoWPro.RETAIL then
                     skillMax = skillLineMaxRank,
                     skillMod = skillLineModifier
                 }
-                WoWPro:dbp("UpdateTradeSkills() added %d/%s", skillLineID, name)
+                WoWPro:dbp("RefreshCurrentTradeSkills() added %d/%s", skillLineID, name)
                 scanned = scanned + 1
             end
         end
 
         WoWPro.UpdateTradeSkillsTable(tradeskills)
-        WoWPro:dbp("UpdateTradeSkills() scanned %d tradeskills", scanned)
+        WoWPro:dbp("RefreshCurrentTradeSkills() scanned %d tradeskills", scanned)
     end
 else
-    WoWPro:Error("UpdateTradeSkills(): Release Confusion!")
+    WoWPro:Error("RefreshCurrentTradeSkills(): Release Confusion!")
+end
+
+-- Compatibility alias for existing callers.
+function WoWPro.UpdateTradeSkills(...)
+    return WoWPro.RefreshCurrentTradeSkills(...)
 end
 
 


### PR DESCRIPTION
This change consolidates profession/tradeskill handling across the earlier refactor commits and the latest follow-up cleanup.

It replaces duplicated profession skill-line tables with data-driven builders, introduces an explicit no-window profession refresh path, and keeps backward compatibility by preserving the old update entry point as an alias.

It also strengthens scan reliability and event behavior:

Rewires startup and skill-line events to use explicit current-profession refresh.
Adds debounced handling for bursty skill-line updates.
Refreshes profession data on LEARNED_SPELL_IN_SKILL_LINE.
Preserves detailed, window-dependent recipe/category scanning via bucketed profession-window events.
Additional hardening and correctness updates:

Adds nil-safe guards around Blizzard tradeskill API reads.
Fixes tradeskill report formatting to use skillMod consistently.
Makes tradeskill table updates safer by deferring removals until after iteration.
Improves recipe-link handling when links are missing or malformed.
Follow-up cleanup in this commit:

Adds debug trace logs for both refresh paths to make in-game verification easier.
Wraps bucketed trade-window scanning in a named helper callback for clearer instrumentation.
Moves the helper to file scope for cleaner OnEnable registration flow and readability.
Behavioral intent:

Keep fast no-window profession level updates.
Keep detailed window-based recipe/category persistence.
Use both methods without duplicate or noisy event handling paths.
Optional testing notes to include:

Verify SKILL_LINES_CHANGED and LEARNED_SPELL_IN_SKILL_LINE trigger debounced current-profession refresh.
Verify opening/updating profession UI triggers bucketed detailed ScanTrade path.
Verify rapid skill-line bursts collapse into a single refresh cycle.
Verify tradeskill report displays modifier values from skillMod.
