### PR TITLE
Refactor row update

### DIFF
--- a/WoWPro/RowUpdate.lua
+++ b/WoWPro/RowUpdate.lua
@@ -1,4 +1,5 @@
 -- luacheck: std lua51
+-- luacheck: globals InCombatLockdown GetBindingKey SetOverrideBindingClick C_ChatInfo C_ChromieTime C_PetBattles HasExtraActionBar ExtraActionButton1 ExtraActionButton1Icon tinsert strupper strsub strlower
 
 -- WoWPro addon namespace
 -- luacheck: globals WoWPro WoWProDB
@@ -38,6 +39,29 @@
 -- currentRow step note itembutton itembuttonSecured itemicon itemcooldown
 -- lootsbuttons jumpbutton jumpbuttonSecured eabutton eabuttonSecured
 -- eaicon targetbutton targetbuttonSecured
+
+local ShouldShowRow
+local ComputeRowLimit
+local HideRemainingRows
+local RunModulePreRowUpdate
+local NormalizeStepText
+local NormalizeNote
+local FormatCoords
+local EmbedCoordsInNote
+local AddNoCoordsWarning
+local IsStickyVisible
+local BuildDropdownMenu
+local SetupTrashItemButton
+local SetupUseItemButton
+local SetupItemKeybind
+local SetupPetSwitchButton
+local SetupPetSwitchKeybind
+local SetupLootButtons
+local SetupJumpButton
+local SetupEAButton
+local SetupTargetButton
+local ApplyRowSizing
+local ApplyMainFrameLayout
 
 function WoWPro:RowUpdate(offset)
     WoWPro.RowDropdownMenu = {}
@@ -102,7 +126,7 @@ function WoWPro:RowUpdate(offset)
         end
 
         -- Sticky visibility
-        local showSticky = IsStickyVisible(k, k, completion, stickyBoundary)
+        IsStickyVisible(k, k, completion, stickyBoundary)
 
         -- Set row text
         currentRow.step:SetText(step)
@@ -133,7 +157,7 @@ function WoWPro:RowUpdate(offset)
         end
 
         -- Loot buttons
-        note = SetupLootButtons(currentRow, item, action, note, k)
+        SetupLootButtons(currentRow, item, action, note, k)
 
         -- Jump button
         if jump then
@@ -183,7 +207,7 @@ end
 -----------------------
 -- Text, Note, Coord, and Step Normalization Helpers
 -- Normalize step text (expand markup, trim whitespace)
-local function NormalizeStepText(step)
+NormalizeStepText = function(step)
     -- Expand WoWPro markup if present
     if step then
         step = WoWPro.ExpandMarkup(step)
@@ -194,7 +218,7 @@ local function NormalizeStepText(step)
 end
 
 -- Normalize note text (newline cleanup, collapse blank lines)
-local function NormalizeNote(note)
+NormalizeNote = function(note)
     if not note then
         return ""
     end
@@ -218,7 +242,7 @@ local function NormalizeNote(note)
 end
 
 -- Validate and format coordinate text
-local function FormatCoords(GID, action, step, coord)
+FormatCoords = function(GID, action, step, coord)
     if not coord then
         return nil
     end
@@ -241,7 +265,7 @@ local function FormatCoords(GID, action, step, coord)
 end
 
 -- Embed coordinates + zone into note text
-local function EmbedCoordsInNote(note, coord, zone)
+EmbedCoordsInNote = function(note, coord, zone)
     if not coord then
         return note
     end
@@ -261,8 +285,8 @@ local function EmbedCoordsInNote(note, coord, zone)
 end
 
 -- Add "No coordinates" warning when appropriate
-local function AddNoCoordsWarning(note, action, GID)
-    if not coord and action and not WoWPro.Guides[GID].NoCoordsOK then
+AddNoCoordsWarning = function(note, action, GID)
+    if action and not WoWPro.Guides[GID].NoCoordsOK then
         return note .. "\n(No coordinates)"
     end
     return note
@@ -305,7 +329,7 @@ local function StickyObjectiveIncomplete(QID, questtext)
 end
 
 -- Main sticky visibility logic extracted from RowUpdate
-local function IsStickyVisible(stepIdx, k, completion, stickyBoundary)
+IsStickyVisible = function(stepIdx, k, completion, stickyBoundary)
     -- Completed sticky steps never show
     if completion[stepIdx] then
         return false
@@ -380,7 +404,7 @@ end
 -- Item Button Helpers
 
 -- Helper: Bind keys to a visible item button (only once per RowUpdate pass)
-local function SetupItemKeybind(i, currentRow)
+SetupItemKeybind = function(i, currentRow)
     -- Only bind if button is visible and not in combat
     if currentRow.itembutton:IsVisible() and not InCombatLockdown() then
         WoWPro.BindKeysToButton(i)
@@ -407,7 +431,7 @@ local function SetupItemSecuredOverlay(currentRow, attributeType, attributeValue
 end
 
 -- Helper: Setup trash-item button (action "*")
-local function SetupTrashItemButton(currentRow, use, k)
+SetupTrashItemButton = function(currentRow, use, k)
     if InCombatLockdown() then
         return
     end
@@ -499,7 +523,7 @@ local function SelectUseItem(use)
 end
 
 -- Helper: Setup item-use button (action uses item)
-local function SetupUseItemButton(currentRow, use, k)
+SetupUseItemButton = function(currentRow, use, k)
     if InCombatLockdown() then
         return
     end
@@ -529,7 +553,7 @@ end
 
 -- Pet Switch Button Helpers
 -- Helper: Bind keys to pet-switch button (only once per RowUpdate pass)
-local function SetupPetSwitchKeybind(i, currentRow)
+SetupPetSwitchKeybind = function(i, currentRow)
     if currentRow.itembutton:IsVisible() and not InCombatLockdown() then
         local key1, key2 = GetBindingKey("CLICK WoWPro_FauxPetSwitchButton:LeftButton")
 
@@ -573,7 +597,7 @@ local function SetupPetSwitchSecuredOverlay(currentRow, switch, k)
 end
 
 -- Helper: Setup pet-switch button (WoWPro.switch[k] > 0)
-local function SetupPetSwitchButton(currentRow, switch, k)
+SetupPetSwitchButton = function(currentRow, switch, k)
     if InCombatLockdown() then
         return
     end
@@ -659,7 +683,7 @@ local function NormalizeLootNote(note)
 end
 
 -- Main helper: Setup loot buttons + update note
-local function SetupLootButtons(currentRow, item, action, note, k)
+SetupLootButtons = function(currentRow, item, action, note, k)
     -- No loot items → hide all buttons
     if not item then
         HideAllLootButtons(currentRow)
@@ -741,7 +765,7 @@ local function SetupJumpSecuredOverlay(currentRow)
 end
 
 -- Helper: Setup jump button (guide jump)
-local function SetupJumpButton(currentRow, jumpTag, i)
+SetupJumpButton = function(currentRow, jumpTag, i)
     if not jumpTag then
         return
     end
@@ -858,7 +882,7 @@ local function SetupEAIconTracking(currentRow)
 end
 
 -- Main helper: Setup EA button
-local function SetupEAButton(currentRow, eab, i)
+SetupEAButton = function(currentRow, eab, i)
     if not eab then
         return
     end
@@ -960,7 +984,7 @@ local function SetupTargetKeybind(i, currentRow)
 end
 
 -- Main helper: Setup target button
-local function SetupTargetButton(currentRow, target, module)
+SetupTargetButton = function(currentRow, target, module)
     if not target then
         -- Hide both buttons when no target tag
         if not InCombatLockdown() then
@@ -1001,7 +1025,7 @@ end
 
 -- Row Visibility, RowLimit, and Layout Helpers
 -- Helper: Determine if a row should be shown (non-sticky logic)
-local function ShouldShowRow(stepIdx, completion)
+ShouldShowRow = function(stepIdx, completion)
     -- Completed steps are filtered out (RowUpdate never completes steps)
     if completion[stepIdx] then
         return false
@@ -1019,7 +1043,7 @@ local function ShouldShowRow(stepIdx, completion)
 end
 
 -- Helper: Hide all remaining rows starting at index i
-local function HideRemainingRows(startIndex)
+HideRemainingRows = function(startIndex)
     for j = startIndex, 15 do
         local row = WoWPro.rows[j]
         row:Hide()
@@ -1041,7 +1065,7 @@ local function HideRemainingRows(startIndex)
 end
 
 -- Helper: Apply row sizing (height, spacing, indentation)
-local function ApplyRowSizing()
+ApplyRowSizing = function()
     -- RowSizeSet adjusts row height based on note text, icons, etc.
     -- Safe to call only out of combat.
     if not InCombatLockdown() then
@@ -1050,7 +1074,7 @@ local function ApplyRowSizing()
 end
 
 -- Helper: Apply main frame layout (anchors, scroll, sticky header)
-local function ApplyMainFrameLayout()
+ApplyMainFrameLayout = function()
     -- MainFrameLayout adjusts the entire guide frame layout.
     if not InCombatLockdown() then
         WoWPro.MainFrameLayout()
@@ -1058,14 +1082,14 @@ local function ApplyMainFrameLayout()
 end
 
 -- Helper: Update RowLimit based on visible steps
-local function ComputeRowLimit(stepList)
+ComputeRowLimit = function(stepList)
     -- RowLimit is simply the number of visible steps
     return #stepList
 end
 
 -- Module Hook Helpers
 -- Helper: Run module-specific PreRowUpdate() if present
-local function RunModulePreRowUpdate(module, currentRow)
+RunModulePreRowUpdate = function(module, currentRow)
     -- Some modules define a PreRowUpdate hook to adjust row before processing
     local mod = WoWPro[module:GetName()]
     if mod and mod.PreRowUpdate then
@@ -1073,83 +1097,7 @@ local function RunModulePreRowUpdate(module, currentRow)
     end
 end
 
--- Helper: Run module-specific RowUpdateTarget() if present
-local function RunModuleTargetOverride(module, currentRow)
-    -- Some modules override target macrotext logic
-    local mod = WoWPro[module:GetName()]
-    if mod and mod.RowUpdateTarget then
-        mod:RowUpdateTarget(currentRow)
-    end
-end
-
--- Unified Keybinding Helpers
--- Helper: Bind a key to a normal (non-secured) button
-local function BindKeyToButton(frame, key, buttonName)
-    -- Only bind out of combat
-    if InCombatLockdown() then
-        return false
-    end
-
-    if key then
-        SetOverrideBindingClick(WoWPro.MainFrame, false, key, buttonName, "LeftButton")
-        return true
-    end
-
-    return false
-end
-
--- Helper: Bind a key to a secured button
-local function BindKeyToSecuredButton(frame, key, securedButtonName)
-    -- Only bind out of combat
-    if InCombatLockdown() then
-        return false
-    end
-
-    if key then
-        SetOverrideBindingClick(WoWPro.MainFrame, false, key, securedButtonName, "LeftButton")
-        return true
-    end
-
-    return false
-end
-
--- Helper: Retrieve primary + secondary binding keys for a faux button
-local function GetFauxBindingKeys(fauxName)
-    local key1, key2 = GetBindingKey("CLICK " .. fauxName .. ":LeftButton")
-    return key1, key2
-end
-
--- Helper: Bind both primary + secondary keys to a secured button
-local function BindKeysToSecuredButton(fauxName, securedButtonName)
-    local key1, key2 = GetFauxBindingKeys(fauxName)
-    local bound = false
-
-    if key1 then
-        bound = BindKeyToSecuredButton(WoWPro.MainFrame, key1, securedButtonName) or bound
-    end
-    if key2 then
-        bound = BindKeyToSecuredButton(WoWPro.MainFrame, key2, securedButtonName) or bound
-    end
-
-    return bound
-end
-
--- Helper: Bind both primary + secondary keys to a normal button
-local function BindKeysToButton(fauxName, buttonName)
-    local key1, key2 = GetFauxBindingKeys(fauxName)
-    local bound = false
-
-    if key1 then
-        bound = BindKeyToButton(WoWPro.MainFrame, key1, buttonName) or bound
-    end
-    if key2 then
-        bound = BindKeyToButton(WoWPro.MainFrame, key2, buttonName) or bound
-    end
-
-    return bound
-end
-
-WoWPro.BuildDropdownMenu = function(i, currentRow, step, QID, coord, sticky, GID)
+BuildDropdownMenu = function(i, currentRow, step, QID, coord, sticky, GID)
     -- Populate RowDropdownMenu data --
     WoWPro.RowDropdownMenu = WoWPro.RowDropdownMenu or {}
     local dropdown = {}

--- a/WoWPro/RowUpdate.lua
+++ b/WoWPro/RowUpdate.lua
@@ -40,6 +40,7 @@
 -- eaicon targetbutton targetbuttonSecured
 
 function WoWPro:RowUpdate(offset)
+    WoWPro.RowDropdownMenu = {}
     local module = self
     local GID = WoWProDB.char.currentguide
     local completion = WoWPro.Completion
@@ -108,7 +109,7 @@ function WoWPro:RowUpdate(offset)
         currentRow.note:SetText(note)
 
         -- Dropdown menu
-        BuildDropdownMenu(i, currentRow, step, action, WoWPro.QID[k], formattedCoord, WoWPro.sticky[k], module)
+        BuildDropdownMenu(i, currentRow, step, WoWPro.QID[k], formattedCoord, WoWPro.sticky[k], GID)
 
         -- Item buttons
         if use and use ~= "" then
@@ -1146,4 +1147,182 @@ local function BindKeysToButton(fauxName, buttonName)
     end
 
     return bound
+end
+
+WoWPro.BuildDropdownMenu = function(i, currentRow, step, QID, coord, sticky, GID)
+    -- Populate RowDropdownMenu data --
+    WoWPro.RowDropdownMenu = WoWPro.RowDropdownMenu or {}
+    local dropdown = {}
+    if step then
+        tinsert(dropdown,
+            {text = step.." Options", isTitle = true}
+        )
+        if WoWPro.RETAIL then
+            -- TODO: Is this needed at all?
+            _G.QuestMapUpdateAllQuests()
+            _G.QuestPOIUpdateIcons()
+        end
+        if coord then
+            tinsert(dropdown,
+                {text = "Map Coordinates", func = function()
+                    WoWPro.UserClicked = true
+                    WoWPro:RemoveMapPoint()
+                    WoWPro:MapPoint(currentRow.num)
+                    WoWPro.UserClicked = nil
+                end}
+            )
+        end
+        if QID and WoWPro.QuestLog[QID] and WoWPro.QuestLog[QID].index and _G.IsInGroup() then
+            tinsert(dropdown,
+                {text = "Share Quest", func = function()
+                    _G.QuestLogPushQuest(WoWPro.QuestLog[QID].index)
+                end}
+            )
+        end
+        if sticky then
+            tinsert(dropdown,
+                {text = "Un-Sticky", func = function()
+                    WoWPro.sticky[currentRow.index] = false
+                    WoWPro:UpdateGuide("ClickedUnSticky")
+                end}
+            )
+        else
+            tinsert(dropdown,
+                {text = "Make Sticky", func = function()
+                    WoWPro.sticky[currentRow.index] = true
+                    WoWPro.unsticky[currentRow.index] = false
+                    WoWPro:UpdateGuide("ClickedMakeSticky")
+                end}
+            )
+        end
+        if QID then
+            local questId = string.match(QID, "([^%^]*)")
+
+            tinsert(dropdown,
+                {text = "Wowhead Link", func = function()
+                    local link = "https://www.wowhead.com/quest=" .. questId
+
+                    local newEditBox = _G.CreateFrame("Frame", "WowheadLinkBox" .. questId, _G.UIParent)
+                    newEditBox:SetSize(300, 100)
+                    newEditBox:SetPoint("CENTER")
+                    newEditBox:SetFrameStrata("DIALOG")
+
+                    local texture = newEditBox:CreateTexture(nil, "BACKGROUND")
+                    texture:SetAllPoints(true)
+                    texture:SetColorTexture(0.1, 0.1, 0.1, 0.8)
+
+                    local titleBar = newEditBox:CreateTexture(nil, "OVERLAY")
+                    titleBar:SetHeight(24)
+                    titleBar:SetPoint("TOPLEFT", 10, -10)
+                    titleBar:SetPoint("TOPRIGHT", -10, -10)
+                    titleBar:SetColorTexture(0, 0, 0, 0)
+
+                    local title = newEditBox:CreateFontString(nil, "OVERLAY", "GameFontNormalLarge")
+                    title:SetPoint("TOP", titleBar, "TOP", 0, -6)
+                    title:SetText("Wowhead Link")
+
+                    local editBox = _G.CreateFrame("EditBox", nil, newEditBox, "InputBoxTemplate")
+                    editBox:SetAutoFocus(true)
+                    editBox:SetWidth(260)
+                    editBox:SetHeight(32)
+                    editBox:SetPoint("TOP", titleBar, "BOTTOM", 0, -10)
+                    editBox:SetText(link)
+                    editBox:HighlightText()
+
+                    local closeButton = _G.CreateFrame("Button", nil, newEditBox, "UIPanelCloseButton")
+                    closeButton:SetPoint("TOPRIGHT")
+                    closeButton:SetScript("OnClick", function() newEditBox:Hide() end)
+
+                    editBox:SetScript("OnEscapePressed", function() newEditBox:Hide() end)
+                end}
+            )
+        end
+
+        WoWPro.RowDropdownMenu[i] = dropdown
+        tinsert(dropdown,
+            { text = "Report an Issue", func = function()
+                WoWPro.LogBox = WoWPro.LogBox or WoWPro:CreateErrorLog("Report an Issue","Hit escape to dismiss")
+                local LogBox = WoWPro.LogBox
+                local X, Y, mapId = WoWPro:GetPlayerZonePosition()
+                local text = "Please Type Your Issue Below This Line.\n------------------------------------------------\n\n\n\n\n\n\nThe Below Info is Needed By The Support Team To Assist In Your Issue - Do Not Edit Anything Past This Point\n"
+
+                -- Add step info without GID
+                local Sindex = WoWPro.rows[currentRow.num].index
+                if WoWPro.rows[currentRow.num]:IsVisible() then
+                    text = text .. "\n|cffffff00Step Info:|r\n" .. WoWPro.EmitSafeStep(Sindex) .. "\n"
+                end
+
+                text = text .. "\n|cffffff00Guide Info:|r\n"
+                text = text .. GID .. "\n"
+                text = text .. "Faction: " .. WoWPro.Faction .. "\n"
+
+                -- Retrieve additional player information
+                local _, class = _G.UnitClass("player")
+                local _, race = _G.UnitRace("player")
+                class = strupper(strsub(class, 1, 1)) .. strlower(strsub(class, 2))
+                local level = _G.UnitLevel("player")
+                local version = _G.C_AddOns.GetAddOnMetadata("WoWPro", "Version")
+                local locale = _G.GetLocale()
+                local gameVersion, _, _, _ = _G.GetBuildInfo()
+
+                -- Retrieve the player's realm name
+                local realmName = _G.GetRealmName()
+
+                -- Retrieve the player's character name
+                local playerName = _G.UnitName("player")
+
+                text = text .. "\n|cffffff00Player Info:|r\n"
+                text = text .. "Character Name: " .. playerName .. "\n"
+                text = text .. "Class: " .. class .. "\n"
+                text = text .. "Race: " .. race .. "\n"
+                text = text .. "Level: " .. level .. "\n"
+                text = text .. "Realm: " .. realmName .. "\n"
+                text = text .. "Addon Version: " .. version .. "\n"
+                text = text .. "Game Version: " .. gameVersion .. "\n"
+                text = text .. "Locale: " .. locale .. "\n"
+                if (not X) or (not Y) then
+                    text = text .. "Location: Unknown\n"
+                else
+                    text = text .. "Coordinates: " .. string.format("%.2f, %.2f", X*100, Y*100) .. "\n"
+                    text = text .. "Map ID: " .. tostring(mapId) .. "\n"
+                end
+                text = text .. "Zone: " .. WoWPro.GetZoneText() .. "\n"
+                text = text .. "Sub Zone: " .. _G.GetSubZoneText() .. "\n"
+
+                -- Add instructions for copying the text
+                if _G.IsMacClient() then
+                    text = text .. "\n\nTo copy this information, press ⌘+A to select all text, then press ⌘+C to copy it. You can then paste this into a Discord ticket by pressing ⌘+V.\n"
+                else
+                    text = text .. "\n\nTo copy this information, press Ctrl+A to select all text, then press Ctrl+C to copy it. You can then paste this into a Discord ticket by pressing Ctrl+V.\n"
+                end
+
+                -- Set the text of the LogBox and show it
+                LogBox.Box:SetText(text)
+
+                -- Create a hidden frame to measure the text width
+                local hiddenFrame = _G.CreateFrame("Frame")
+                hiddenFrame:Hide()
+
+                local fontString = hiddenFrame:CreateFontString(nil, "ARTWORK", "GameFontNormal")
+                fontString:SetText(text)
+
+                -- Get the width of the text
+                local textWidth = fontString:GetStringWidth()
+
+                -- Set the width of the LogBox and the text box
+                LogBox:SetWidth(textWidth + 20)
+                LogBox.Box:SetWidth(textWidth + 20)
+
+                LogBox.Box:Show()
+
+                -- Hide the EditBox if it exists
+                if WoWPro.EditBox then
+                    WoWPro.EditBox:Hide()
+                end
+
+                LogBox:Show()
+            end}
+        )
+    end
+    WoWPro.RowDropdownMenu[i] = dropdown
 end

--- a/WoWPro/RowUpdate.lua
+++ b/WoWPro/RowUpdate.lua
@@ -1,0 +1,1149 @@
+-- luacheck: std lua51
+
+-- WoWPro addon namespace
+-- luacheck: globals WoWPro WoWProDB
+
+-- WoW API globals used in RowUpdate
+-- luacheck: globals
+-- InCombatLockdown
+-- GetBindingKey
+-- SetOverrideBindingClick
+-- C_ChatInfo
+-- C_ChromieTime
+-- C_PetBattles
+-- HasExtraActionBar
+-- ExtraActionButton1
+-- ExtraActionButton1Icon
+
+-- Frame API
+-- luacheck: globals
+-- CreateFrame
+-- UIParent
+
+-- Utility functions used implicitly
+-- luacheck: globals
+-- tonumber tostring select ipairs pairs next type
+-- string table math
+
+-- WoWPro utility functions referenced
+-- luacheck: globals
+-- ShouldShowRow ComputeRowLimit HideRemainingRows RunModulePreRowUpdate
+-- FormatCoords NormalizeStepText NormalizeNote EmbedCoordsInNote AddNoCoordsWarning
+-- IsStickyVisible BuildDropdownMenu SetupTrashItemButton SetupUseItemButton
+-- SetupItemKeybind SetupPetSwitchButton SetupPetSwitchKeybind SetupLootButtons
+-- SetupJumpButton SetupEAButton SetupTargetButton ApplyRowSizing ApplyMainFrameLayout
+
+-- Row fields accessed
+-- luacheck: globals
+-- currentRow step note itembutton itembuttonSecured itemicon itemcooldown
+-- lootsbuttons jumpbutton jumpbuttonSecured eabutton eabuttonSecured
+-- eaicon targetbutton targetbuttonSecured
+
+function WoWPro:RowUpdate(offset)
+    local module = self
+    local GID = WoWProDB.char.currentguide
+    local completion = WoWPro.Completion
+    local reload = false
+    local sendsteps = ""
+    local stickyBoundary = WoWPro:GetActiveStickyCount()
+
+    -- Build list of visible steps
+    local stepList = {}
+    for idx = 1, WoWPro.stepcount do
+        if ShouldShowRow(idx, completion) then
+            table.insert(stepList, idx)
+        end
+    end
+
+    -- RowLimit = number of visible steps
+    WoWPro.RowLimit = ComputeRowLimit(stepList)
+
+    -- Hide rows beyond visible limit
+    if #stepList == 0 then
+        HideRemainingRows(1)
+        return reload
+    end
+
+    -- Process visible rows
+    for i = 1, math.min(#stepList, 15) do
+        local k = stepList[i]
+        local currentRow = WoWPro.rows[i]
+        currentRow.index = k
+        currentRow.num = i
+
+        -- Run module hook
+        RunModulePreRowUpdate(module, currentRow)
+
+        -- Extract step fields
+        local action = WoWPro.action[k]
+        local step   = NormalizeStepText(WoWPro.step[k])
+        local note   = NormalizeNote(WoWPro.note[k])
+        local use    = WoWPro.use[k]
+        local item   = WoWPro.item[k]
+        local target = WoWPro.target[k]
+        local jump   = WoWPro.jump[k]
+        local eab    = WoWPro.eab[k]
+        local switch = WoWPro.switch[k]
+        local coord  = WoWPro.map[k]
+        local zone   = WoWPro.zone[k]
+
+        -- Format coordinates
+        local formattedCoord, playerZone = FormatCoords(GID, action, step, coord)
+        if playerZone then
+            zone = playerZone
+        end
+
+        -- Embed coords into note
+        if formattedCoord then
+            note = EmbedCoordsInNote(note, formattedCoord, zone)
+        else
+            note = AddNoCoordsWarning(note, action, GID)
+        end
+
+        -- Sticky visibility
+        local showSticky = IsStickyVisible(k, k, completion, stickyBoundary)
+
+        -- Set row text
+        currentRow.step:SetText(step)
+        currentRow.note:SetText(note)
+
+        -- Dropdown menu
+        BuildDropdownMenu(i, currentRow, step, action, WoWPro.QID[k], formattedCoord, WoWPro.sticky[k], module)
+
+        -- Item buttons
+        if use and use ~= "" then
+            if use:sub(1, 1) == "*" then
+                SetupTrashItemButton(currentRow, use:sub(2), k)
+            else
+                SetupUseItemButton(currentRow, use, k)
+            end
+            SetupItemKeybind(i, currentRow)
+        else
+            if not InCombatLockdown() then
+                currentRow.itembutton:Hide()
+                currentRow.itembuttonSecured:Hide()
+            end
+        end
+
+        -- Pet switch button
+        if switch and switch ~= "" then
+            SetupPetSwitchButton(currentRow, switch, k)
+            SetupPetSwitchKeybind(i, currentRow)
+        end
+
+        -- Loot buttons
+        note = SetupLootButtons(currentRow, item, action, note, k)
+
+        -- Jump button
+        if jump then
+            SetupJumpButton(currentRow, jump, i)
+        else
+            if not InCombatLockdown() then
+                currentRow.jumpbutton:Hide()
+                currentRow.jumpbuttonSecured:Hide()
+            end
+        end
+
+        -- EA button
+        if eab then
+            SetupEAButton(currentRow, eab, i)
+        else
+            if not InCombatLockdown() then
+                currentRow.eabutton:Hide()
+                currentRow.eabuttonSecured:Hide()
+            end
+        end
+
+        -- Target button
+        SetupTargetButton(currentRow, target, module)
+
+        -- Save row
+        WoWPro.rows[i] = currentRow
+    end
+
+    -- Hide unused rows
+    HideRemainingRows(#stepList + 1)
+    -- Update current index
+    WoWPro.CurrentIndex = WoWPro.rows[1 + stickyBoundary].index
+
+    -- Layout updates
+    ApplyRowSizing()
+    ApplyMainFrameLayout()
+
+    -- Group sync
+    if WoWPro.GroupSync then
+        C_ChatInfo.SendAddonMessage("WoWPro", sendsteps, "PARTY")
+    end
+
+    return reload
+end
+
+-- Rowupdate Helpers --
+-----------------------
+-- Text, Note, Coord, and Step Normalization Helpers
+-- Normalize step text (expand markup, trim whitespace)
+local function NormalizeStepText(step)
+    -- Expand WoWPro markup if present
+    if step then
+        step = WoWPro.ExpandMarkup(step)
+        -- Trim leading/trailing whitespace
+        return step:trim()
+    end
+    return ""
+end
+
+-- Normalize note text (newline cleanup, collapse blank lines)
+local function NormalizeNote(note)
+    if not note then
+        return ""
+    end
+
+    -- Expand markup first
+    note = WoWPro.ExpandMarkup(note)
+
+    -- Replace CRLF with LF
+    note = note:gsub("\r\n", "\n")
+
+    -- Strip leading blank lines
+    note = note:gsub("^\n+", "")
+
+    -- Strip trailing blank lines
+    note = note:gsub("\n+$", "")
+
+    -- Collapse multiple blank lines
+    note = note:gsub("\n\n+", "\n")
+
+    return note
+end
+
+-- Validate and format coordinate text
+local function FormatCoords(GID, action, step, coord)
+    if not coord then
+        return nil
+    end
+
+    -- PLAYER coordinate mode
+    if coord == "PLAYER" then
+        local x, y, m = WoWPro:GetPlayerZonePosition()
+        if x and y then
+            local formatted = ("%.2f"):format(x * 100) .. "," .. ("%.2f"):format(y * 100)
+            local zone = ("%d;player"):format(m)
+            return formatted, zone
+        else
+            return nil, nil
+        end
+    end
+
+    -- Validate normal coords
+    WoWPro:ValidateMapCoords(GID, action, step, coord)
+    return coord, nil
+end
+
+-- Embed coordinates + zone into note text
+local function EmbedCoordsInNote(note, coord, zone)
+    if not coord then
+        return note
+    end
+
+    local coords = coord
+    -- Truncate long coordinate strings
+    if coords:len() > 64 then
+        coords = coords:sub(1, 64) .. "..."
+    end
+
+    note = note .. " (" .. coords .. ")"
+    if zone then
+        note = note .. "@" .. zone
+    end
+
+    return note
+end
+
+-- Add "No coordinates" warning when appropriate
+local function AddNoCoordsWarning(note, action, GID)
+    if not coord and action and not WoWPro.Guides[GID].NoCoordsOK then
+        return note .. "\n(No coordinates)"
+    end
+    return note
+end
+
+-- Sticky Visibility Helpers
+-- Check if a sticky step is paired with an unsticky step that hides it
+local function IsPairedStickyHidden(activeUS, stepIdx)
+    -- activeUS = currently active unsticky step
+    -- If activeUS has a paired sticky S, hide that S
+    if activeUS and WoWPro.unsticky[activeUS] and not WoWPro.sticky[activeUS] then
+        local pairedS = WoWPro.FindPairedStickyStep(activeUS)
+        return pairedS == stepIdx
+    end
+    return false
+end
+
+-- Check if any quest objective is incomplete for sticky visibility
+local function StickyObjectiveIncomplete(QID, questtext)
+    if not QID or not questtext then
+        return false
+    end
+
+    local qid = WoWPro:QIDInTable(QID, WoWPro.QuestLog)
+    if not qid then
+        return false
+    end
+
+    -- Split questtext into objective list
+    for _, obj in ipairs({(";"):split(questtext)}) do
+        if WoWPro.ValidObjective(obj) then
+            local complete = WoWPro.QuestObjectiveStatus(qid, obj)
+            if not complete then
+                return true
+            end
+        end
+    end
+
+    return false
+end
+
+-- Main sticky visibility logic extracted from RowUpdate
+local function IsStickyVisible(stepIdx, k, completion, stickyBoundary)
+    -- Completed sticky steps never show
+    if completion[stepIdx] then
+        return false
+    end
+
+    local action = WoWPro.action[stepIdx]
+    local QID = WoWPro.QID[stepIdx]
+    local questtext = WoWPro.questtext and WoWPro.questtext[stepIdx]
+    local available = WoWPro.available and WoWPro.available[stepIdx]
+    local activeReq = WoWPro.active and WoWPro.active[stepIdx]
+
+    local activeUS = WoWPro.ActiveStep
+    local isSUS = WoWPro.sticky[stepIdx] and WoWPro.unsticky[stepIdx]
+
+    -- Hide paired sticky S when its US step is active
+    if IsPairedStickyHidden(activeUS, stepIdx) then
+        return false
+    end
+
+    -- Sticky steps beyond progression boundary are hidden
+    -- Except S!US (sticky+unsticky) which stays visible until completion
+    if not isSUS and stepIdx > stickyBoundary then
+        return false
+    end
+
+    -- AVAILABLE filter (sticky visibility only)
+    if not isSUS and available and not WoWPro.QuestAvailable(available, false, "AVAILABLE") then
+        return false
+    end
+
+    -- ACTIVE filter (sticky visibility only)
+    if not isSUS and activeReq and not WoWPro:QIDsInTableLogical(activeReq, WoWPro.QuestLog) then
+        return false
+    end
+
+    -- Action C with QID and questtext: show only while objectives incomplete
+    if action == "C" and QID and questtext then
+        if stepIdx == k then
+            return true -- active sticky always shows
+        end
+        if not completion[stepIdx] and WoWPro:QIDsInTable(QID, WoWPro.QuestLog) then
+            return StickyObjectiveIncomplete(QID, questtext)
+        end
+        return false
+    end
+
+    -- Action C with QID but no questtext
+    if action == "C" and QID then
+        if stepIdx == k then
+            return true
+        end
+        if not completion[stepIdx] and WoWPro:QIDsInTable(QID, WoWPro.QuestLog) then
+            return true
+        end
+        return false
+    end
+
+    -- Action C with no QID: show if stepIdx <= k
+    if action == "C" and not QID then
+        return stepIdx <= k
+    end
+
+    -- S!US steps always show until completion
+    if isSUS then
+        return true
+    end
+
+    -- Default: show if stepIdx <= k
+    return stepIdx <= k
+end
+
+-- Item Button Helpers
+
+-- Helper: Bind keys to a visible item button (only once per RowUpdate pass)
+local function SetupItemKeybind(i, currentRow)
+    -- Only bind if button is visible and not in combat
+    if currentRow.itembutton:IsVisible() and not InCombatLockdown() then
+        WoWPro.BindKeysToButton(i)
+        return true
+    end
+    return false
+end
+
+-- Helper: Setup secured overlay for item button (mirrors main button)
+local function SetupItemSecuredOverlay(currentRow, attributeType, attributeValue)
+    if InCombatLockdown() then
+        return
+    end
+
+    if currentRow.itembutton:IsVisible() and currentRow.itembutton:IsShown() then
+        local secured = currentRow.itembuttonSecured
+        secured:Show()
+        secured:SetAttribute("type1", attributeType)
+        secured:SetAttribute("item1", attributeValue)
+        secured:ClearAllPoints()
+        secured:SetPoint("BOTTOMLEFT", currentRow.itembutton, "BOTTOMLEFT", 0, 0)
+        secured:SetFrameLevel(currentRow.itembutton:GetFrameLevel() + 1)
+    end
+end
+
+-- Helper: Setup trash-item button (action "*")
+local function SetupTrashItemButton(currentRow, use, k)
+    if InCombatLockdown() then
+        return
+    end
+
+    currentRow.itembutton:Show()
+    currentRow.itemicon:SetTexture(WoWPro.C_Item_GetItemIconByID(use))
+
+    -- Clicking the button destroys the item
+    currentRow.itembutton:SetAttribute("type1", "click1")
+    currentRow.itembutton:SetAttribute("click", "clickbutton")
+    currentRow.itembutton:SetScript("OnClick", function()
+        WoWPro.TrashItem(use, k)
+    end)
+
+    -- Secured overlay
+    SetupItemSecuredOverlay(currentRow, "click1", "clickbutton")
+end
+
+-- Helper: Track cooldown + icon changes for item-use button
+local function SetupItemCooldown(currentRow, itemID)
+    local timeElapsed = 0
+
+    currentRow.itembutton:SetScript("OnUpdate", function(_, elapsed)
+        timeElapsed = timeElapsed + elapsed
+        if timeElapsed < 0.05 then
+            return
+        end
+        timeElapsed = 0
+
+        local icon = WoWPro.C_Item_GetItemIconByID(itemID)
+        local count = WoWPro.C_Item_GetItemCount(itemID)
+        local start, duration, enabled = WoWPro.GetItemCooldown(itemID)
+
+        -- Update icon visibility
+        if count > 0 and not currentRow.itemicon.item_IsVisible then
+            currentRow.itemicon.item_IsVisible = true
+            currentRow.itemicon:SetTexture(icon)
+            currentRow.itemicon.currentTexture = icon
+        elseif count > 0 and icon ~= currentRow.itemicon.currentTexture then
+            currentRow.itemicon:SetTexture(icon)
+            currentRow.itemicon.currentTexture = icon
+        elseif count == 0 and currentRow.itemicon.item_IsVisible then
+            currentRow.itemicon.item_IsVisible = false
+            currentRow.itemicon:SetTexture()
+            currentRow.itemicon.currentTexture = nil
+        end
+
+        -- Cooldown overlay
+        if enabled and duration > 0 and not currentRow.itemcooldown.OnCooldown then
+            currentRow.itemcooldown:Show()
+            currentRow.itemcooldown:SetCooldown(start, duration)
+            currentRow.itemcooldown.OnCooldown = true
+            currentRow.itemcooldown.ActiveItem = itemID
+        elseif currentRow.itemcooldown.OnCooldown and duration == 0 then
+            currentRow.itemcooldown:Hide()
+            currentRow.itemcooldown.OnCooldown = false
+        elseif currentRow.itemcooldown.ActiveItem ~= itemID and start then
+            currentRow.itemcooldown.OnCooldown = false
+            currentRow.itemcooldown:SetCooldown(start, duration)
+            currentRow.itemcooldown.ActiveItem = itemID
+        end
+    end)
+end
+
+-- Helper: Select correct item from multi-item use tag
+local function SelectUseItem(use)
+    local items = WoWPro.SelectItemToUse(use)
+    if not items then
+        return nil
+    end
+
+    -- "&" mode: first item in original order
+    if use:find("&", 1, true) then
+        for _, itemID in ipairs({("&"):split(use)}) do
+            if items[itemID] then
+                return itemID
+            end
+        end
+        return nil
+    end
+
+    -- "^" mode: SelectItemToUse already picked the first available
+    if use:find("^", 1, true) then
+        return next(items)
+    end
+
+    -- Single item mode
+    return next(items)
+end
+
+-- Helper: Setup item-use button (action uses item)
+local function SetupUseItemButton(currentRow, use, k)
+    if InCombatLockdown() then
+        return
+    end
+
+    local itemID = SelectUseItem(use)
+    if not itemID then
+        currentRow.itembutton:Hide()
+        return
+    end
+
+    currentRow.itembutton:Show()
+    currentRow.itemicon.item_IsVisible = nil
+    currentRow.itemicon.currentTexture = nil
+    currentRow.itemcooldown.OnCooldown = nil
+    currentRow.itemcooldown.ActiveItem = nil
+
+    -- Setup secure item-use
+    currentRow.itembutton:SetAttribute("type1", "item")
+    currentRow.itembutton:SetAttribute("item1", "item:" .. itemID)
+
+    -- Cooldown + icon tracking
+    SetupItemCooldown(currentRow, itemID)
+
+    -- Secured overlay
+    SetupItemSecuredOverlay(currentRow, "item", "item:" .. itemID)
+end
+
+-- Pet Switch Button Helpers
+-- Helper: Bind keys to pet-switch button (only once per RowUpdate pass)
+local function SetupPetSwitchKeybind(i, currentRow)
+    if currentRow.itembutton:IsVisible() and not InCombatLockdown() then
+        local key1, key2 = GetBindingKey("CLICK WoWPro_FauxPetSwitchButton:LeftButton")
+
+        -- Bind primary key
+        if key1 then
+            SetOverrideBindingClick(WoWPro.MainFrame, false, key1, "WoWPro_itembuttonSecured"..i, "LeftButton")
+        end
+
+        -- Bind secondary key
+        if key2 then
+            SetOverrideBindingClick(WoWPro.MainFrame, false, key2, "WoWPro_itembuttonSecured"..i, "LeftButton")
+        end
+
+        return (key1 or key2) ~= nil
+    end
+
+    return false
+end
+
+-- Helper: Setup secured overlay for pet-switch button
+local function SetupPetSwitchSecuredOverlay(currentRow, switch, k)
+    if InCombatLockdown() then
+        return
+    end
+
+    if currentRow.itembutton:IsVisible() and currentRow.itembutton:IsShown() then
+        local secured = currentRow.itembuttonSecured
+        secured:Show()
+
+        -- Secured attribute for pet switching
+        secured:SetAttribute("type", "SwitchPet")
+        secured.SwitchPet = function()
+            C_PetBattles.ChangePet(switch)
+            WoWPro.CompleteStep(k, "Clicked pet switch")
+        end
+
+        secured:ClearAllPoints()
+        secured:SetPoint("BOTTOMLEFT", currentRow.itembutton, "BOTTOMLEFT", 0, 0)
+        secured:SetFrameLevel(currentRow.itembutton:GetFrameLevel() + 1)
+    end
+end
+
+-- Helper: Setup pet-switch button (WoWPro.switch[k] > 0)
+local function SetupPetSwitchButton(currentRow, switch, k)
+    if InCombatLockdown() then
+        return
+    end
+
+    -- Show main button
+    currentRow.itembutton:Show()
+
+    -- Set icon
+    currentRow.itemicon:SetTexture(WoWPro.PetIcon(switch))
+
+    -- Set secure attributes for main button
+    currentRow.itembutton:SetAttribute("type", "SwitchPet")
+    currentRow.itembutton.SwitchPet = function()
+        C_PetBattles.ChangePet(switch)
+        WoWPro.CompleteStep(k, "Clicked pet switch")
+    end
+
+    -- Secured overlay
+    SetupPetSwitchSecuredOverlay(currentRow, switch, k)
+end
+
+-- Loot Button Helpers
+-- Helper: Hide all loot buttons on the row
+local function HideAllLootButtons(currentRow)
+    for i = 1, #currentRow.lootsbuttons do
+        currentRow.lootsbuttons[i].button:Hide()
+    end
+end
+
+-- Helper: Parse semicolon-separated item list
+local function ParseLootItems(item)
+    if not item or item == "" then
+        return {}
+    end
+    local items = {(";"):split(item)}
+    for i, v in ipairs(items) do
+        items[i] = v:trim()
+    end
+    return items
+end
+
+-- Helper: Update note text based on loot items + action type
+local function UpdateLootNote(note, action, itemNames, k)
+    -- If note is empty, just list the items
+    if note == "" then
+        return table.concat(itemNames, ", ")
+    end
+
+    -- Action-specific prefixes
+    if action == "B" then
+        return "Buy " .. table.concat(itemNames, ", ") .. " " .. note
+    elseif action == "M" then
+        return "Craft " .. table.concat(itemNames, ", ") .. " " .. note
+    else
+        -- Default: kill + loot unless chat/noncombat flags override
+        if not (WoWPro.chat[k] or WoWPro.noncombat[k]) then
+            return "Kill and loot " .. note
+        end
+    end
+
+    return note
+end
+
+-- Helper: Normalize note after loot processing
+local function NormalizeLootNote(note)
+    if type(note) ~= "string" then
+        return ""
+    end
+
+    -- CRLF → LF
+    note = note:gsub("\r\n", "\n")
+
+    -- Strip leading blank lines
+    note = note:gsub("^\n+", "")
+
+    -- Strip trailing blank lines
+    note = note:gsub("\n+$", "")
+
+    -- Collapse multiple blank lines
+    note = note:gsub("\n\n+", "\n")
+
+    return note
+end
+
+-- Main helper: Setup loot buttons + update note
+local function SetupLootButtons(currentRow, item, action, note, k)
+    -- No loot items → hide all buttons
+    if not item then
+        HideAllLootButtons(currentRow)
+        return note
+    end
+
+    local items = ParseLootItems(item)
+    local itemNames = {}
+    local buttonIndex = 1
+
+    -- Assign items to loot buttons
+    for _, itemID in ipairs(items) do
+        if itemID ~= "" and buttonIndex <= #currentRow.lootsbuttons then
+            local lootData = currentRow.lootsbuttons[buttonIndex]
+            local nomen = lootData.button:SetItemByID(itemID)
+            lootData.button:Show()
+            table.insert(itemNames, nomen)
+            buttonIndex = buttonIndex + 1
+        end
+    end
+
+    -- Hide unused loot buttons
+    for i = buttonIndex, #currentRow.lootsbuttons do
+        currentRow.lootsbuttons[i].button:Hide()
+    end
+
+    -- Update note text based on loot items
+    note = UpdateLootNote(note, action, itemNames, k)
+
+    -- Normalize note formatting
+    note = NormalizeLootNote(note)
+
+    -- Apply updated note to row
+    currentRow.note:SetText(note)
+
+    return note
+end
+
+-- Jump Button Helpers
+-- Helper: Bind keys to jump button (only once per RowUpdate pass)
+local function SetupJumpKeybind(i, currentRow)
+    if currentRow.jumpbutton:IsVisible() and not InCombatLockdown() then
+        local key1, key2 = GetBindingKey("CLICK WoWPro_FauxJumpButton:LeftButton")
+
+        -- Bind primary key
+        if key1 then
+            SetOverrideBindingClick(WoWPro.MainFrame, false, key1, "WoWPro_jumpbutton"..i, "LeftButton")
+        end
+
+        -- Bind secondary key
+        if key2 then
+            SetOverrideBindingClick(WoWPro.MainFrame, false, key2, "WoWPro_jumpbutton"..i, "LeftButton")
+        end
+
+        return (key1 or key2) ~= nil
+    end
+
+    return false
+end
+
+-- Helper: Setup secured overlay for jump button
+local function SetupJumpSecuredOverlay(currentRow)
+    if InCombatLockdown() then
+        return
+    end
+
+    if currentRow.jumpbutton:IsVisible() and currentRow.jumpbutton:IsShown() then
+        local secured = currentRow.jumpbuttonSecured
+        secured:Show()
+
+        -- Mirror main button click
+        secured:SetAttribute("type", "click")
+        secured:SetAttribute("clickbutton", currentRow.jumpbutton)
+
+        secured:ClearAllPoints()
+        secured:SetPoint("BOTTOMLEFT", currentRow.jumpbutton, "BOTTOMLEFT", 0, 0)
+        secured:SetFrameLevel(currentRow.jumpbutton:GetFrameLevel() + 1)
+    end
+end
+
+-- Helper: Setup jump button (guide jump)
+local function SetupJumpButton(currentRow, jumpTag, i)
+    if not jumpTag then
+        return
+    end
+
+    local newguide, ctID = (";"):split(jumpTag)
+
+    if not InCombatLockdown() then
+        currentRow.jumpbutton:Show()
+    end
+
+    -- Main click handler
+    currentRow.jumpbutton:SetScript("OnClick", function()
+        WoWPro:dbp("WoWPro.CompleteStep: jumping from %s to %s.",
+            WoWProDB.char.currentguide, newguide)
+
+        -- Chromie Time selection (Retail only)
+        if ctID and WoWPro.RETAIL then
+            C_ChromieTime.SelectChromieTimeOption(ctID)
+        end
+
+        -- Load new guide
+        WoWPro:LoadGuide(newguide)
+    end)
+
+    -- Secured overlay
+    SetupJumpSecuredOverlay(currentRow)
+
+    -- Keybinding
+    SetupJumpKeybind(i, currentRow)
+end
+
+-- Extra Action Button (EA Button) Helpers
+-- Helper: Bind keys to EA button (only once per RowUpdate pass)
+local function SetupEAKeybind(i, currentRow)
+    if currentRow.eabutton:IsVisible() and not InCombatLockdown() then
+        local key1, key2 = GetBindingKey("CLICK WoWPro_FauxEAButton:LeftButton")
+
+        -- Bind primary key
+        if key1 then
+            SetOverrideBindingClick(WoWPro.MainFrame, false, key1, "WoWPro_eabuttonSecure"..i, "LeftButton")
+        end
+
+        -- Bind secondary key
+        if key2 then
+            SetOverrideBindingClick(WoWPro.MainFrame, false, key2, "WoWPro_eabuttonSecure"..i, "LeftButton")
+        end
+
+        return (key1 or key2) ~= nil
+    end
+
+    return false
+end
+
+-- Helper: Setup secured overlay for EA button
+local function SetupEASecuredOverlay(currentRow, macroText)
+    if InCombatLockdown() then
+        return
+    end
+
+    if currentRow.eabutton:IsVisible() and currentRow.eabutton:IsShown() then
+        local secured = currentRow.eabuttonSecured
+        secured:Show()
+
+        -- Mirror macrotext
+        secured:SetAttribute("macrotext", macroText)
+
+        secured:ClearAllPoints()
+        secured:SetPoint("BOTTOMLEFT", currentRow.eabutton, "BOTTOMLEFT", 0, 0)
+        secured:SetFrameLevel(currentRow.eabutton:GetFrameLevel() + 1)
+    end
+end
+
+-- Helper: Track EA icon + visibility changes
+local function SetupEAIconTracking(currentRow)
+    local timeElapsed = 0
+
+    currentRow.eabutton:SetScript("OnUpdate", function(_, elapsed)
+        -- Throttle updates to 50ms
+        timeElapsed = timeElapsed + elapsed
+        if timeElapsed < 0.05 then
+            return
+        end
+        timeElapsed = 0
+
+        -- Determine EA icon source
+        local eabIcon = nil
+        if ExtraActionButton1 and ExtraActionButton1.icon then
+            eabIcon = ExtraActionButton1.icon
+        elseif ExtraActionButton1Icon then
+            eabIcon = ExtraActionButton1Icon
+        end
+
+        local texture = eabIcon and eabIcon:GetTexture() or nil
+        local visible = HasExtraActionBar()
+
+        -- Visibility changed
+        if visible ~= currentRow.eaicon.EAB1_IsVisible then
+            currentRow.eaicon.EAB1_IsVisible = visible
+
+            if visible then
+                currentRow.eaicon:SetTexture(texture)
+                currentRow.eaicon.currentTexture = texture
+            else
+                currentRow.eaicon:SetTexture()
+                currentRow.eaicon.currentTexture = nil
+            end
+
+        -- Texture changed while visible
+        elseif texture ~= currentRow.eaicon.currentTexture and visible then
+            currentRow.eaicon.currentTexture = texture
+            currentRow.eaicon:SetTexture(texture)
+        end
+    end)
+end
+
+-- Main helper: Setup EA button
+local function SetupEAButton(currentRow, eab, i)
+    if not eab then
+        return
+    end
+
+    local macroText = "/click ExtraActionButton1"
+
+    if not InCombatLockdown() then
+        currentRow.eabutton:Show()
+        currentRow.eabutton:SetAttribute("macrotext", macroText)
+
+        -- Reset EA icon state
+        currentRow.eaicon.EAB1_IsVisible = nil
+        currentRow.eaicon.currentTexture = nil
+
+        -- Icon tracking
+        SetupEAIconTracking(currentRow)
+
+        -- Secured overlay
+        SetupEASecuredOverlay(currentRow, macroText)
+    end
+
+    -- Keybinding
+    SetupEAKeybind(i, currentRow)
+end
+
+-- Target Button Helpers
+-- Helper: Build macrotext for target button
+local function BuildTargetMacro(target)
+    if not target then
+        return ""
+    end
+
+    local tar, emote = (","):split(target)
+
+    -- Raw macro (starts with "/")
+    if tar:sub(1, 1) == "/" then
+        return tar:gsub("\\n", "\n")
+    end
+
+    -- Target + emote
+    if emote then
+        return "/target " .. tar .. "\n/" .. emote
+    end
+
+    -- Default: clear dead target, target mob, set skull marker
+    local macro = "/cleartarget[dead]\n/target " .. tar .. "\n"
+
+    if not WoWPro.MIDNIGHT then
+        macro = macro ..
+            "/run if GetRaidTargetIndex('target') ~= 8 and not UnitIsDead('target') then " ..
+            "SetRaidTarget('target', 8) end"
+    end
+
+    return macro
+end
+
+-- Helper: Setup secured overlay for target button
+local function SetupTargetSecuredOverlay(currentRow, macroText)
+    if InCombatLockdown() then
+        -- Store pending macro for post-combat setup
+        currentRow.targetbuttonSecured._pendingMacro = macroText
+        currentRow.targetbuttonSecured._pendingPosition =
+            {"BOTTOMLEFT", currentRow.targetbutton, "BOTTOMLEFT", 0, 0}
+        return
+    end
+
+    if currentRow.targetbutton:IsVisible() and currentRow.targetbutton:IsShown() then
+        local secured = currentRow.targetbuttonSecured
+        secured:Show()
+        secured:SetAttribute("macrotext", macroText)
+
+        -- Overlay secured button directly over visible icon
+        secured:ClearAllPoints()
+        secured:SetPoint("BOTTOMLEFT", currentRow.targetbutton, "BOTTOMLEFT", 0, 0)
+        secured:SetFrameStrata("HIGH")
+        secured:SetFrameLevel(currentRow.targetbutton:GetFrameLevel() + 1)
+    end
+end
+
+-- Helper: Bind keys to target button (only once per RowUpdate pass)
+local function SetupTargetKeybind(i, currentRow)
+    if currentRow.targetbutton:IsVisible() then
+        local key1, key2 = GetBindingKey("CLICK WoWPro_FauxTargetButton:LeftButton")
+
+        if key1 and not InCombatLockdown() then
+            SetOverrideBindingClick(WoWPro.MainFrame, false, key1,
+                "WoWPro_targetbuttonSecure"..i, "LeftButton")
+        end
+
+        if key2 and not InCombatLockdown() then
+            SetOverrideBindingClick(WoWPro.MainFrame, false, key2,
+                "WoWPro_targetbuttonSecure"..i, "LeftButton")
+        end
+
+        return (key1 or key2) ~= nil
+    end
+
+    return false
+end
+
+-- Main helper: Setup target button
+local function SetupTargetButton(currentRow, target, module)
+    if not target then
+        -- Hide both buttons when no target tag
+        if not InCombatLockdown() then
+            currentRow.targetbutton:Hide()
+            currentRow.targetbuttonSecured:Hide()
+        end
+        return
+    end
+
+    if not InCombatLockdown() then
+        currentRow.targetbutton:Show()
+    end
+
+    -- Build macrotext
+    local macroText = BuildTargetMacro(target)
+
+    -- Allow module override
+    if WoWPro[module:GetName()].RowUpdateTarget then
+        WoWPro[module:GetName()]:RowUpdateTarget(currentRow)
+        macroText = currentRow.targetbutton:GetAttribute("macrotext") or macroText
+    else
+        currentRow.targetbutton:SetAttribute("macrotext", macroText)
+    end
+
+    WoWPro:dbp("Target text set to: %s", macroText)
+
+    -- Position target button (only out of combat)
+    if not InCombatLockdown() then
+        currentRow.targetbutton.Position(WoWPro.use[currentRow.index] or WoWPro.eab[currentRow.index])
+    end
+
+    -- Secured overlay
+    SetupTargetSecuredOverlay(currentRow, macroText)
+
+    -- Keybinding
+    SetupTargetKeybind(currentRow.num, currentRow)
+end
+
+-- Row Visibility, RowLimit, and Layout Helpers
+-- Helper: Determine if a row should be shown (non-sticky logic)
+local function ShouldShowRow(stepIdx, completion)
+    -- Completed steps are filtered out (RowUpdate never completes steps)
+    if completion[stepIdx] then
+        return false
+    end
+
+    -- US steps: only show if paired sticky is complete or no sticky exists
+    if WoWPro.unsticky[stepIdx] and not WoWPro.sticky[stepIdx] then
+        local pairedSticky = WoWPro.FindPairedStickyStep(stepIdx)
+        if pairedSticky and not completion[pairedSticky] then
+            return false
+        end
+    end
+
+    return true
+end
+
+-- Helper: Hide all remaining rows starting at index i
+local function HideRemainingRows(startIndex)
+    for j = startIndex, 15 do
+        local row = WoWPro.rows[j]
+        row:Hide()
+
+        if not InCombatLockdown() then
+            if row.itembutton then row.itembutton:Hide() end
+            if row.itembuttonSecured then row.itembuttonSecured:Hide() end
+
+            if row.targetbutton then row.targetbutton:Hide() end
+            if row.targetbuttonSecured then row.targetbuttonSecured:Hide() end
+
+            if row.jumpbutton then row.jumpbutton:Hide() end
+            if row.jumpbuttonSecured then row.jumpbuttonSecured:Hide() end
+
+            if row.eabutton then row.eabutton:Hide() end
+            if row.eabuttonSecured then row.eabuttonSecured:Hide() end
+        end
+    end
+end
+
+-- Helper: Apply row sizing (height, spacing, indentation)
+local function ApplyRowSizing()
+    -- RowSizeSet adjusts row height based on note text, icons, etc.
+    -- Safe to call only out of combat.
+    if not InCombatLockdown() then
+        WoWPro.RowSizeSet()
+    end
+end
+
+-- Helper: Apply main frame layout (anchors, scroll, sticky header)
+local function ApplyMainFrameLayout()
+    -- MainFrameLayout adjusts the entire guide frame layout.
+    if not InCombatLockdown() then
+        WoWPro.MainFrameLayout()
+    end
+end
+
+-- Helper: Update RowLimit based on visible steps
+local function ComputeRowLimit(stepList)
+    -- RowLimit is simply the number of visible steps
+    return #stepList
+end
+
+-- Module Hook Helpers
+-- Helper: Run module-specific PreRowUpdate() if present
+local function RunModulePreRowUpdate(module, currentRow)
+    -- Some modules define a PreRowUpdate hook to adjust row before processing
+    local mod = WoWPro[module:GetName()]
+    if mod and mod.PreRowUpdate then
+        mod:PreRowUpdate(currentRow)
+    end
+end
+
+-- Helper: Run module-specific RowUpdateTarget() if present
+local function RunModuleTargetOverride(module, currentRow)
+    -- Some modules override target macrotext logic
+    local mod = WoWPro[module:GetName()]
+    if mod and mod.RowUpdateTarget then
+        mod:RowUpdateTarget(currentRow)
+    end
+end
+
+-- Unified Keybinding Helpers
+-- Helper: Bind a key to a normal (non-secured) button
+local function BindKeyToButton(frame, key, buttonName)
+    -- Only bind out of combat
+    if InCombatLockdown() then
+        return false
+    end
+
+    if key then
+        SetOverrideBindingClick(WoWPro.MainFrame, false, key, buttonName, "LeftButton")
+        return true
+    end
+
+    return false
+end
+
+-- Helper: Bind a key to a secured button
+local function BindKeyToSecuredButton(frame, key, securedButtonName)
+    -- Only bind out of combat
+    if InCombatLockdown() then
+        return false
+    end
+
+    if key then
+        SetOverrideBindingClick(WoWPro.MainFrame, false, key, securedButtonName, "LeftButton")
+        return true
+    end
+
+    return false
+end
+
+-- Helper: Retrieve primary + secondary binding keys for a faux button
+local function GetFauxBindingKeys(fauxName)
+    local key1, key2 = GetBindingKey("CLICK " .. fauxName .. ":LeftButton")
+    return key1, key2
+end
+
+-- Helper: Bind both primary + secondary keys to a secured button
+local function BindKeysToSecuredButton(fauxName, securedButtonName)
+    local key1, key2 = GetFauxBindingKeys(fauxName)
+    local bound = false
+
+    if key1 then
+        bound = BindKeyToSecuredButton(WoWPro.MainFrame, key1, securedButtonName) or bound
+    end
+    if key2 then
+        bound = BindKeyToSecuredButton(WoWPro.MainFrame, key2, securedButtonName) or bound
+    end
+
+    return bound
+end
+
+-- Helper: Bind both primary + secondary keys to a normal button
+local function BindKeysToButton(fauxName, buttonName)
+    local key1, key2 = GetFauxBindingKeys(fauxName)
+    local bound = false
+
+    if key1 then
+        bound = BindKeyToButton(WoWPro.MainFrame, key1, buttonName) or bound
+    end
+    if key2 then
+        bound = BindKeyToButton(WoWPro.MainFrame, key2, buttonName) or bound
+    end
+
+    return bound
+end

--- a/WoWPro/RowUpdate.lua
+++ b/WoWPro/RowUpdate.lua
@@ -67,7 +67,7 @@ function WoWPro:RowUpdate(offset)
     WoWPro.RowDropdownMenu = {}
     local module = self
     local GID = WoWProDB.char.currentguide
-    local completion = WoWPro.Completion
+    local completion = (WoWProCharDB.Guide[GID] and WoWProCharDB.Guide[GID].completion) or {}
     local reload = false
     local sendsteps = ""
     local stickyBoundary = WoWPro:GetActiveStickyCount()

--- a/WoWPro/WoWPro.toc
+++ b/WoWPro/WoWPro.toc
@@ -44,6 +44,7 @@ WoWPro_ZoneData.lua
 WoWPro_ZoneDataLegacy.lua
 WoWPro_Mapping.lua
 WoWPro_Broker.lua
+WoWPro_RowUpdate.lua
 WoWPro_AutoComplete.lua
 WoWPro_Events.lua
 WoWPro_Markup.lua

--- a/WoWPro/WoWPro_Broker.lua
+++ b/WoWPro/WoWPro_Broker.lua
@@ -1514,182 +1514,9 @@ function WoWPro:RowUpdate(offset)
             WoWPro:CheckFunction(currentRow, button, down)
         end)
 
--- Right-Click Drop-Down --
-local dropdown = {}
-if step then
-    tinsert(dropdown,
-        {text = step.." Options", isTitle = true}
-    )
-    if WoWPro.RETAIL then
-        -- TODO: Is this needed at all?
-        _G.QuestMapUpdateAllQuests()
-        _G.QuestPOIUpdateIcons()
-    end
-    if coord then
-        tinsert(dropdown,
-            {text = "Map Coordinates", func = function()
-                WoWPro.UserClicked = true
-                WoWPro:RemoveMapPoint()
-                WoWPro:MapPoint(currentRow.num)
-                WoWPro.UserClicked = nil
-            end}
-        )
-    end
-    if QID and WoWPro.QuestLog[QID] and WoWPro.QuestLog[QID].index and _G.IsInGroup() then
-        tinsert(dropdown,
-            {text = "Share Quest", func = function()
-                _G.QuestLogPushQuest(WoWPro.QuestLog[QID].index)
-            end}
-        )
-    end
-    if sticky then
-        tinsert(dropdown,
-            {text = "Un-Sticky", func = function()
-                WoWPro.sticky[currentRow.index] = false
-                WoWPro:UpdateGuide("ClickedUnSticky")
-            end}
-        )
-    else
-        tinsert(dropdown,
-            {text = "Make Sticky", func = function()
-                WoWPro.sticky[currentRow.index] = true
-                WoWPro.unsticky[currentRow.index] = false
-                WoWPro:UpdateGuide("ClickedMakeSticky")
-            end}
-        )
-    end
-    if QID then
-        local questId = string.match(QID, "([^%^]*)")
-
-        tinsert(dropdown,
-        {text = "Wowhead Link", func = function()
-            local link = "https://www.wowhead.com/quest=" .. questId
-
-            local newEditBox = _G.CreateFrame("Frame", "WowheadLinkBox" .. questId, _G.UIParent)
-            newEditBox:SetSize(300, 100)
-            newEditBox:SetPoint("CENTER")
-            newEditBox:SetFrameStrata("DIALOG")
-
-            local texture = newEditBox:CreateTexture(nil, "BACKGROUND")
-            texture:SetAllPoints(true)
-            texture:SetColorTexture(0.1, 0.1, 0.1, 0.8)
-
-            local titleBar = newEditBox:CreateTexture(nil, "OVERLAY")
-            titleBar:SetHeight(24)
-            titleBar:SetPoint("TOPLEFT", 10, -10)
-            titleBar:SetPoint("TOPRIGHT", -10, -10)
-            titleBar:SetColorTexture(0, 0, 0, 0)
-
-            local title = newEditBox:CreateFontString(nil, "OVERLAY", "GameFontNormalLarge")
-            title:SetPoint("TOP", titleBar, "TOP", 0, -6)
-            title:SetText("Wowhead Link")
-
-            local editBox = _G.CreateFrame("EditBox", nil, newEditBox, "InputBoxTemplate")
-            editBox:SetAutoFocus(true)
-            editBox:SetWidth(260)
-            editBox:SetHeight(32)
-            editBox:SetPoint("TOP", titleBar, "BOTTOM", 0, -10)
-            editBox:SetText(link)
-            editBox:HighlightText()
-
-            local closeButton = _G.CreateFrame("Button", nil, newEditBox, "UIPanelCloseButton")
-            closeButton:SetPoint("TOPRIGHT")
-            closeButton:SetScript("OnClick", function() newEditBox:Hide() end)
-
-            editBox:SetScript("OnEscapePressed", function() newEditBox:Hide() end)
-            end}
-        )
-    end
-
-    WoWPro.RowDropdownMenu[i] = dropdown
-    tinsert(dropdown,
-    { text = "Report an Issue", func = function()
-        WoWPro.LogBox = WoWPro.LogBox or WoWPro:CreateErrorLog("Report an Issue","Hit escape to dismiss")
-        local LogBox = WoWPro.LogBox
-        local X, Y, mapId = WoWPro:GetPlayerZonePosition()
-        local text = "Please Type Your Issue Below This Line.\n------------------------------------------------\n\n\n\n\n\n\nThe Below Info is Needed By The Support Team To Assist In Your Issue - Do Not Edit Anything Past This Point\n"
-
-
-    -- Add step info without GID
-    local Sindex = WoWPro.rows[currentRow.num].index
-    if WoWPro.rows[currentRow.num]:IsVisible() then
-    text = text .. "\n|cffffff00Step Info:|r\n" .. WoWPro.EmitSafeStep(Sindex) .. "\n"
-    end
-
-    text = text .. "\n|cffffff00Guide Info:|r\n"
-    text = text .. GID .. "\n"
-    text = text .. "Faction: " .. WoWPro.Faction .. "\n"
-
-
-        -- Retrieve additional player information
-        local _, class = _G.UnitClass("player")
-        local _, race = _G.UnitRace("player")
-        class = strupper(strsub(class, 1, 1)) .. strlower(strsub(class, 2))
-        local level = _G.UnitLevel("player")
-        local version = _G.C_AddOns.GetAddOnMetadata("WoWPro", "Version")
-        local locale = _G.GetLocale()
-        local gameVersion, _, _, _ = _G.GetBuildInfo()  -- Get the game version
-
-        -- Retrieve the player's realm name
-        local realmName = _G.GetRealmName()
-
-        -- Retrieve the player's character name
-        local playerName = _G.UnitName("player")
-
-        text = text .. "\n|cffffff00Player Info:|r\n"
-        text = text .. "Character Name: " .. playerName .. "\n"
-        text = text .. "Class: " .. class .. "\n"
-        text = text .. "Race: " .. race .. "\n"
-        text = text .. "Level: " .. level .. "\n"
-        text = text .. "Realm: " .. realmName .. "\n"  -- Add the player's realm name
-        text = text .. "Addon Version: " .. version .. "\n"
-        text = text .. "Game Version: " .. gameVersion .. "\n"  -- Add the game version
-        text = text .. "Locale: " .. locale .. "\n"
-        if (not X) or (not Y) then
-            text = text .. "Location: Unknown\n"
-        else
-            text = text .. "Coordinates: " .. string.format("%.2f, %.2f", X*100, Y*100) .. "\n"
-            text = text .. "Map ID: " .. tostring(mapId) .. "\n"  -- Map ID on a separate line
+        if WoWPro.BuildDropdownMenu then
+            WoWPro.BuildDropdownMenu(i, currentRow, step, QID, coord, sticky, GID)
         end
-        text = text .. "Zone: " .. WoWPro.GetZoneText() .. "\n"
-        text = text .. "Sub Zone: " .. _G.GetSubZoneText() .. "\n"
-
-        -- Add instructions for copying the text
-        if _G.IsMacClient() then
-            text = text .. "\n\nTo copy this information, press ⌘+A to select all text, then press ⌘+C to copy it. You can then paste this into a Discord ticket by pressing ⌘+V.\n"
-        else
-            text = text .. "\n\nTo copy this information, press Ctrl+A to select all text, then press Ctrl+C to copy it. You can then paste this into a Discord ticket by pressing Ctrl+V.\n"
-        end
-
-        -- Set the text of the LogBox and show it
-        LogBox.Box:SetText(text)
-
-        -- Create a hidden frame to measure the text width
-        local hiddenFrame = _G.CreateFrame("Frame")
-        hiddenFrame:Hide()
-
-        local fontString = hiddenFrame:CreateFontString(nil, "ARTWORK", "GameFontNormal")
-        fontString:SetText(text)
-
-        -- Get the width of the text
-        local textWidth = fontString:GetStringWidth()
-
-        -- Set the width of the LogBox and the text box
-        LogBox:SetWidth(textWidth + 20)  -- Add some padding
-        LogBox.Box:SetWidth(textWidth + 20)  -- Add some padding
-
-        LogBox.Box:Show()
-
-        -- Hide the EditBox if it exists
-        if WoWPro.EditBox then
-            WoWPro.EditBox:Hide()
-        end
-
-        LogBox:Show()
-    end}
-    )
-    end
-    WoWPro.RowDropdownMenu[i] = dropdown
 
         -- Item Button --
         if showButtons then
@@ -1704,7 +1531,7 @@ if step then
                 currentRow.itembutton:SetAttribute("click", "clickbutton")
                 currentRow.itembutton:SetScript("OnClick", function ()
                     WoWPro.TrashItem(use, k)
-                    end)
+                end)
                 if not _G.InCombatLockdown() then
                     if currentRow.itembutton:IsVisible() and currentRow.itembutton:IsShown() then
                         currentRow.itembuttonSecured:Show()
@@ -1723,7 +1550,7 @@ if step then
                     WoWPro.BindKeysToButton(i)
                     itemkb = true
                 end
-           elseif use and WoWPro.SelectItemToUse(use) then
+            elseif use and WoWPro.SelectItemToUse(use) then
                 local items = WoWPro.SelectItemToUse(use)
                 local _use = nil
 
@@ -1836,7 +1663,7 @@ if step then
                         currentRow.itembuttonSecured:Show()
                         currentRow.itembuttonSecured:SetAttribute("type", "SwitchPet")
                         currentRow.itembuttonSecured.SwitchPet = function ()
-                        _G.C_PetBattles.ChangePet(switch)
+                            _G.C_PetBattles.ChangePet(switch)
                             WoWPro.CompleteStep(kk, "Clicked pet switch")
                         end
                         currentRow.itembuttonSecured:ClearAllPoints()
@@ -1897,9 +1724,9 @@ if step then
             -- Normalize note to avoid trailing blank lines impacting layout
             if type(note) == "string" then
                 note = note:gsub("\r\n", "\n")        -- CRLF -> LF
-                             :gsub("^\n+", "")         -- strip leading newlines
-                             :gsub("\n+$", "")         -- strip trailing newlines
-                             :gsub("\n\n+", "\n")    -- collapse multiple blank lines
+                            :gsub("^\n+", "")         -- strip leading newlines
+                            :gsub("\n+$", "")         -- strip trailing newlines
+                            :gsub("\n\n+", "\n")    -- collapse multiple blank lines
             end
             currentRow.note:SetText(note)
         else
@@ -1911,18 +1738,18 @@ if step then
 
         --Guide Jump Button
         if showButtons and WoWPro.jump[k] then
-			local newguide, ctID = (";"):split(WoWPro.jump[k])
-			if not _G.InCombatLockdown() then
-				currentRow.jumpbutton:Show()
-			end
-			currentRow.jumpbutton:SetScript("OnClick", function()
-				WoWPro:dbp("WoWPro.CompleteStep: jumping from %s to %s.",WoWProDB.char.currentguide, newguide)
-				if ctID and WoWPro.RETAIL then
-					_G.C_ChromieTime.SelectChromieTimeOption(ctID)
-				end
-				WoWPro:LoadGuide(newguide)
-			end)
-			  if not jumpkb and currentRow.targetbutton:IsVisible() and not _G.InCombatLockdown() then
+            local newguide, ctID = (";"):split(WoWPro.jump[k])
+            if not _G.InCombatLockdown() then
+                currentRow.jumpbutton:Show()
+            end
+            currentRow.jumpbutton:SetScript("OnClick", function()
+                WoWPro:dbp("WoWPro.CompleteStep: jumping from %s to %s.",WoWProDB.char.currentguide, newguide)
+                if ctID and WoWPro.RETAIL then
+                    _G.C_ChromieTime.SelectChromieTimeOption(ctID)
+                end
+                WoWPro:LoadGuide(newguide)
+            end)
+            if not jumpkb and currentRow.targetbutton:IsVisible() and not _G.InCombatLockdown() then
                 local key1, key2 = _G.GetBindingKey("CLICK WoWPro_FauxJumpButton:LeftButton")
                 if key1 then
                     _G.SetOverrideBindingClick(WoWPro.MainFrame, false, key1, "WoWPro_jumpbutton"..i, "LeftButton")
@@ -1975,14 +1802,14 @@ if step then
                     end
                 end)
 
-				if currentRow.eabutton:IsShown() then
-					currentRow.eabuttonSecured:Show()
-					currentRow.eabuttonSecured:SetAttribute("macrotext", mtext)
-					currentRow.eabuttonSecured:ClearAllPoints()
-					currentRow.eabuttonSecured:SetPoint("BOTTOMLEFT", currentRow.eabutton, "BOTTOMLEFT", 0, 0)
-					currentRow.eabuttonSecured:SetFrameLevel(currentRow.eabutton:GetFrameLevel() + 1)
-				end
-			end
+                if currentRow.eabutton:IsShown() then
+                    currentRow.eabuttonSecured:Show()
+                    currentRow.eabuttonSecured:SetAttribute("macrotext", mtext)
+                    currentRow.eabuttonSecured:ClearAllPoints()
+                    currentRow.eabuttonSecured:SetPoint("BOTTOMLEFT", currentRow.eabutton, "BOTTOMLEFT", 0, 0)
+                    currentRow.eabuttonSecured:SetFrameLevel(currentRow.eabutton:GetFrameLevel() + 1)
+                end
+            end
 
             if not eakb and currentRow.eabutton:IsVisible() and not _G.InCombatLockdown() then
                 local key1, key2 = _G.GetBindingKey("CLICK WoWPro_FauxEAButton:LeftButton")
@@ -1998,11 +1825,10 @@ if step then
             if not _G.InCombatLockdown() then
                 currentRow.eabutton:Hide()
             end
-			if not _G.InCombatLockdown() then
-				currentRow.eabuttonSecured:Hide()
-			end
+            if not _G.InCombatLockdown() then
+                currentRow.eabuttonSecured:Hide()
+            end
         end
-
 
         -- Target Button --
         if showButtons and target and not _G.InCombatLockdown() then
@@ -2032,8 +1858,8 @@ if step then
                 currentRow.targetbutton.Position(use or eab)
             end
 
-			-- Set up secured button for hotkey execution (outside combat check to handle late setup)
-			if currentRow.targetbutton:IsVisible() and currentRow.targetbutton:IsShown() then
+            -- Set up secured button for hotkey execution (outside combat check to handle late setup)
+            if currentRow.targetbutton:IsVisible() and currentRow.targetbutton:IsShown() then
                 if not _G.InCombatLockdown() then
                     currentRow.targetbuttonSecured:Show()
                     currentRow.targetbuttonSecured:SetAttribute("macrotext", mtext)
@@ -2048,7 +1874,7 @@ if step then
                     currentRow.targetbuttonSecured._pendingMacro = mtext
                     currentRow.targetbuttonSecured._pendingPosition = {"BOTTOMLEFT", currentRow.targetbutton, "BOTTOMLEFT", 0, 0}
                 end
-			end
+            end
             if not targetkb and currentRow.targetbutton:IsVisible() then
                 local key1, key2 = _G.GetBindingKey("CLICK WoWPro_FauxTargetButton:LeftButton")
                 if key1 and not _G.InCombatLockdown() then
@@ -2065,11 +1891,10 @@ if step then
             if not _G.InCombatLockdown() then
                 currentRow.targetbutton:Hide()
             end
-		if not _G.InCombatLockdown() then
-			currentRow.targetbuttonSecured:Hide()
-		end
+            if not _G.InCombatLockdown() then
+                currentRow.targetbuttonSecured:Hide()
+            end
         end
-
         WoWPro.rows[i] = currentRow
     end
 
@@ -2118,228 +1943,170 @@ function WoWPro.UpdateGuideReal(From)
         WoWPro:dbp("UpdateGuideReal(%s): Running", why)
         SoundDiag("UpdateGuideReal source=%s", why)
         if not WoWPro.GuideFrame:IsVisible() then
-        -- Cinematic hides things (or user collapsed frame with double-click).
-        -- Only re-queue if the user did not intentionally collapse the frame.
-        if not WoWPro.UserCollapsed then
-            WoWPro:SendMessage("WoWPro_UpdateGuide","UpdateGuideReal()")
+            -- Cinematic hides things (or user collapsed frame with double-click).
+            -- Only re-queue if the user did not intentionally collapse the frame.
+            if not WoWPro.UserCollapsed then
+                WoWPro:SendMessage("WoWPro_UpdateGuide","UpdateGuideReal()")
+            end
+            WoWPro:dbp("UpdateGuideReal(): Punting")
+            return
         end
-        WoWPro:dbp("UpdateGuideReal(): Punting")
-        return
-    end
-    if not WoWPro.GuideLoaded then
-        WoWPro:print("Suppresssed guide update. Guide %s is not loaded yet!",tostring(GID))
-        return
-    end
-    if WoWPro.LoadAllGuidesActive then
-        WoWPro:dbp("UpdateGuideReal(): Test Load active, supressing.")
-        return
-    end
-    WoWPro:print("Running: UpdateGuideReal(), WoWPro Version %s.", WoWPro.Version);
+        if not WoWPro.GuideLoaded then
+            WoWPro:print("Suppresssed guide update. Guide %s is not loaded yet!",tostring(GID))
+            return
+        end
+        if WoWPro.LoadAllGuidesActive then
+            WoWPro:dbp("UpdateGuideReal(): Test Load active, supressing.")
+            return
+        end
+        WoWPro:print("Running: UpdateGuideReal(), WoWPro Version %s.", WoWPro.Version);
 
-    local offset = WoWPro.GuideOffset
-    WoWPro.GuideOffset = nil
+        local offset = WoWPro.GuideOffset
+        WoWPro.GuideOffset = nil
 
-    -- If the user is in combat, or if a GID is not present, or if the guide cannot be found, end --
-    if WoWPro.InitLockdown then
-        WoWPro:print("Suppresssed guide update.  In InitLockdown.")
-        return
-    end
-    if WoWPro.MaybeCombatLockdown() then
-        WoWPro:print("Punted guide update.  In Combat.")
-        WoWPro:SendMessage("WoWPro_UpdateGuide","InCombat")
-        return
-    end
-    if  not GID or not WoWPro.Guides[GID] then
-        WoWPro:print("Suppresssed guide update. Guide %s is invalid.",tostring(GID))
-        return
-    end
+        -- If the user is in combat, or if a GID is not present, or if the guide cannot be found, end --
+        if WoWPro.InitLockdown then
+            WoWPro:print("Suppresssed guide update.  In InitLockdown.")
+            return
+        end
+        if WoWPro.MaybeCombatLockdown() then
+            WoWPro:print("Punted guide update.  In Combat.")
+            WoWPro:SendMessage("WoWPro_UpdateGuide","InCombat")
+            return
+        end
+        if  not GID or not WoWPro.Guides[GID] then
+            WoWPro:print("Suppresssed guide update. Guide %s is invalid.",tostring(GID))
+            return
+        end
 
-    -- If the module that handles this guide is not present and enabled, then end --
-    local module = WoWPro:GetModule(WoWPro.Guides[GID].guidetype)
-    if not module or not module:IsEnabled() then return end
+        -- If the module that handles this guide is not present and enabled, then end --
+        local module = WoWPro:GetModule(WoWPro.Guides[GID].guidetype)
+        if not module or not module:IsEnabled() then return end
 
-    -- If we already know the current hearth bind, try to auto-complete any matching h step before selecting the active step --
-    if WoWProDB.char and WoWProDB.char.hearth then
-        WoWPro:AutoCompleteSetHearth(nil, WoWProDB.char.hearth, true)
-    end
+        -- If we already know the current hearth bind, try to auto-complete any matching h step before selecting the active step --
+        if WoWProDB.char and WoWProDB.char.hearth then
+            WoWPro:AutoCompleteSetHearth(nil, WoWProDB.char.hearth, true)
+        end
 
-    -- Finding the active step in the guide --
-    WoWPro.ActiveStep = WoWPro.NextStepNotSticky(1)
-    WoWPro:print("UpdateGuideReal(%d): ActiveStep=%s", WoWPro.ActiveStep, WoWPro.EmitSafeStep(WoWPro.ActiveStep))
+        -- Finding the active step in the guide --
+        WoWPro.ActiveStep = WoWPro.NextStepNotSticky(1)
+        WoWPro:print("UpdateGuideReal(%d): ActiveStep=%s", WoWPro.ActiveStep, WoWPro.EmitSafeStep(WoWPro.ActiveStep))
 
-    -- If the active step is a US step, defer paired S completion until after rows are rebuilt.
-    -- This ensures sound visibility checks use current-pass row state, not stale row visibility.
-    local pendingPairedSticky
-    if WoWPro.ActiveStep and WoWPro.unsticky[WoWPro.ActiveStep] and not WoWPro.sticky[WoWPro.ActiveStep] then
-        local guide = WoWProCharDB.Guide[GID]
-        local foundSticky = WoWPro.FindPairedStickyStep(WoWPro.ActiveStep)
-        if foundSticky and not guide.completion[foundSticky] then
-            pendingPairedSticky = foundSticky
-            if WoWPro.DEBUG_STICKY_PAIRING then
-                WoWPro:dbp("[Broker] ActiveStep is US step %d: Queued paired S step %d for completion after row rebuild", WoWPro.ActiveStep, foundSticky)
+        -- If the active step is a US step, defer paired S completion until after rows are rebuilt.
+        -- This ensures sound visibility checks use current-pass row state, not stale row visibility.
+        local pendingPairedSticky
+        if WoWPro.ActiveStep and WoWPro.unsticky[WoWPro.ActiveStep] and not WoWPro.sticky[WoWPro.ActiveStep] then
+            local guide = WoWProCharDB.Guide[GID]
+            local foundSticky = WoWPro.FindPairedStickyStep(WoWPro.ActiveStep)
+            if foundSticky and not guide.completion[foundSticky] then
+                pendingPairedSticky = foundSticky
+                if WoWPro.DEBUG_STICKY_PAIRING then
+                    WoWPro:dbp("[Broker] ActiveStep is US step %d: Queued paired S step %d for completion after row rebuild", WoWPro.ActiveStep, foundSticky)
+                end
             end
         end
-    end
 
-    if WoWPro.Recorder then
-        WoWPro.ActiveStep = WoWPro.Recorder.SelectedStep or WoWPro.ActiveStep
-    end
-    if not offset then WoWPro.Scrollbar:SetValue(WoWPro.ActiveStep) end
-    WoWPro.Scrollbar:SetMinMaxValues(1, max(1, WoWPro.stepcount))
-
-    -- Calling on the guide's module to populate the guide window's rows --
-    local function rowContentUpdate()
-        local reload = WoWPro:RowUpdate(offset)
-        -- Hyjack the click and menu functions for the Recorder if it's enabled --
         if WoWPro.Recorder then
-            WoWPro.Recorder:RowUpdate(offset)
+            WoWPro.ActiveStep = WoWPro.Recorder.SelectedStep or WoWPro.ActiveStep
         end
-        for i, row in pairs(WoWPro.rows) do
-            if WoWPro.RowDropdownMenu[i] then
-                row:SetScript("OnClick", function(self, button, down)
-                    if button == "LeftButton" then
-                        if WoWPro.Recorder then
-                            WoWPro.Recorder:RowLeftClick(i)
-                        else
-                            WoWPro:RowLeftClick(i)
-                        end
-                    elseif button == "RightButton" then
-                        WoWPro.rows[i]:SetChecked(nil)
-                        if WoWPro.Recorder then
-                            WoWPro:RowLeftClick(i)
-                            -- Use context menu for right-click
-                            if _G.MenuUtil and _G.MenuUtil.CreateContextMenu then
-                                _G.MenuUtil.CreateContextMenu(WoWPro.rows[i], function(ownerRegion, rootDescription)
-                                    for _, item in ipairs(WoWPro.Recorder.RowDropdownMenu[i]) do
-                                        if item.text then
-                                            local menuButton = rootDescription:CreateButton(item.text, item.func)
-                                            if item.checked ~= nil then
-                                                menuButton:SetIsSelected(item.checked)
-                                            end
-                                        end
-                                    end
-                                end)
-                            else
-                                local contextMenuFrame = _G.CreateFrame("Frame")
-                                WoWPro.EasyMenu(WoWPro.Recorder.RowDropdownMenu[i], contextMenuFrame, "cursor", 0 , 0, "MENU")
-                            end
-                        else
-                            -- Use context menu for right-click
-                            if _G.MenuUtil and _G.MenuUtil.CreateContextMenu then
-                                _G.MenuUtil.CreateContextMenu(WoWPro.rows[i], function(ownerRegion, rootDescription)
-                                    for _, item in ipairs(WoWPro.RowDropdownMenu[i]) do
-                                        if item.text then
-                                            local menuButton = rootDescription:CreateButton(item.text, item.func)
-                                            if item.checked ~= nil then
-                                                menuButton:SetIsSelected(item.checked)
-                                            end
-                                        end
-                                    end
-                                end)
-                            else
-                                local contextMenuFrame = _G.CreateFrame("Frame")
-                                WoWPro.EasyMenu(WoWPro.RowDropdownMenu[i], contextMenuFrame, "cursor", 0 , 0, "MENU")
-                            end
-                        end
-                    end
-                end)
+        if not offset then WoWPro.Scrollbar:SetValue(WoWPro.ActiveStep) end
+        WoWPro.Scrollbar:SetMinMaxValues(1, max(1, WoWPro.stepcount))
+
+        -- Calling on the guide's module to populate the guide window's rows --
+        local function rowContentUpdate()
+            local reload = WoWPro:RowUpdate(offset)
+            -- Hijack the click and menu functions for the Recorder if it's enabled --
+            if WoWPro.Recorder then
+                WoWPro.Recorder:RowUpdate(offset)
+            end
+            return reload
+        end
+        local reload = true
+        -- Reloading until all stickies that need to unsticky have done so --
+        while reload do
+            reload = rowContentUpdate()
+        end
+
+        if pendingPairedSticky and not WoWProCharDB.Guide[GID].completion[pendingPairedSticky] then
+            SoundDiag("StickyPair complete us=%s sticky=%s visible=%s (post-row rebuild)", tostring(WoWPro.ActiveStep), tostring(pendingPairedSticky), tostring(IsStepVisibleInGuide(pendingPairedSticky)))
+            WoWPro.CompleteStep(pendingPairedSticky, "[Broker] Active US step paired completion", true, "STICKY_UNSTICKY_PAIR")
+            if WoWPro.DEBUG_STICKY_PAIRING then
+                WoWPro:dbp("[Broker] ActiveStep is US step %d: Completed paired S step %d after row rebuild", WoWPro.ActiveStep, pendingPairedSticky)
             end
         end
-        return reload
-    end
-    local reload = true
-    -- Reloading until all stickies that need to unsticky have done so --
-    while reload do
-        reload = rowContentUpdate()
-    end
 
-    if pendingPairedSticky and not WoWProCharDB.Guide[GID].completion[pendingPairedSticky] then
-        SoundDiag("StickyPair complete us=%s sticky=%s visible=%s (post-row rebuild)", tostring(WoWPro.ActiveStep), tostring(pendingPairedSticky), tostring(IsStepVisibleInGuide(pendingPairedSticky)))
-        WoWPro.CompleteStep(pendingPairedSticky, "[Broker] Active US step paired completion", true, "STICKY_UNSTICKY_PAIR")
-        if WoWPro.DEBUG_STICKY_PAIRING then
-            WoWPro:dbp("[Broker] ActiveStep is US step %d: Completed paired S step %d after row rebuild", WoWPro.ActiveStep, pendingPairedSticky)
+        -- Updating the guide list or current guide panels if they are shown --
+        if WoWPro[module:GetName()].GuideList and WoWPro[module:GetName()].GuideList.Frame and WoWPro[module:GetName()].GuideList.Frame:IsVisible() and WoWPro[module:GetName()].UpdateGuideList then
+            WoWPro[module:GetName()]:UpdateGuideList()
         end
-    end
+        if WoWPro.CurrentGuideFrame:IsVisible() then WoWPro.UpdateCurrentGuidePanel() end
 
-    -- Updating the guide list or current guide panels if they are shown --
-    if WoWPro[module:GetName()].GuideList
-    and WoWPro[module:GetName()].GuideList.Frame
-    and WoWPro[module:GetName()].GuideList.Frame:IsVisible()
-    and WoWPro[module:GetName()].UpdateGuideList then
-        WoWPro[module:GetName()]:UpdateGuideList()
-    end
-    if WoWPro.CurrentGuideFrame:IsVisible() then WoWPro.UpdateCurrentGuidePanel() end
-
-    -- Updating the progress count --
-    local p = 0
-    for j = 1, WoWPro.stepcount do
-        if (WoWProCharDB.Guide[GID].completion[j] or WoWProCharDB.Guide[GID].skipped[j])
-        and not WoWPro.sticky[j]
-        and not WoWPro.optional[j]
-        and not WoWPro.repeatable[j] then
-            p = p + 1
+        -- Updating the progress count --
+        local p = 0
+        for j = 1, WoWPro.stepcount do
+            if (WoWProCharDB.Guide[GID].completion[j] or WoWProCharDB.Guide[GID].skipped[j]) and not WoWPro.sticky[j] and not WoWPro.optional[j] and not WoWPro.repeatable[j] then
+                p = p + 1
+            end
         end
-    end
-    WoWProCharDB.Guide[GID].progress = p
-    WoWProCharDB.Guide[GID].total = WoWPro.stepcount - WoWPro.stickycount - WoWPro.optionalcount - (WoWPro.repeatablecount or 0)
+        WoWProCharDB.Guide[GID].progress = p
+        WoWProCharDB.Guide[GID].total = WoWPro.stepcount - WoWPro.stickycount - WoWPro.optionalcount - (WoWPro.repeatablecount or 0)
 
-    -- TODO: make next lines module specific
-    local total = WoWPro.stepcount or 1
-    local currentStep = WoWPro.ActiveStep or 1
-    local currentMainStep = WoWPro.NextStepNotSticky()
-    if WoWPro.Recorder then
-        if WoWProDB.profile.guideprogress then
-            WoWPro.TitleText:SetText((GID or WoWPro.Guides[GID].zone) .. "   (" .. currentStep .. "/" .. total .. ")")
+            -- TODO: make next lines module specific
+        local total = WoWPro.stepcount or 1
+        local currentStep = WoWPro.ActiveStep or 1
+        local currentMainStep = WoWPro.NextStepNotSticky()
+        if WoWPro.Recorder then
+            if WoWProDB.profile.guideprogress then
+                WoWPro.TitleText:SetText((GID or WoWPro.Guides[GID].zone) .. "   (" .. currentStep .. "/" .. total .. ")")
+            else
+                if total > 0 then
+                    local percentage = math.floor((currentMainStep / total) * 100)
+                    WoWPro.TitleText:SetText((GID or WoWPro.Guides[GID].zone) .. "   (" .. percentage .. "%)")
+                else
+                    WoWPro.TitleText:SetText((GID or WoWPro.Guides[GID].zone) .. "   (0%)")
+                end
+            end
         else
-            if total > 0 then
-                local percentage = math.floor((currentMainStep / total) * 100)
-                WoWPro.TitleText:SetText((GID or WoWPro.Guides[GID].zone) .. "   (" .. percentage .. "%)")
+            if WoWProDB.profile.guideprogress then
+                WoWPro.TitleText:SetText((WoWPro.Guides[GID].name or WoWPro.Guides[GID].zone) .. "   (" .. currentStep .. "/" .. total .. ")")
             else
-                WoWPro.TitleText:SetText((GID or WoWPro.Guides[GID].zone) .. "   (0%)")
+                if total > 0 then
+                    local percentage = math.floor((currentMainStep / total) * 100)
+                    WoWPro.TitleText:SetText((WoWPro.Guides[GID].name or WoWPro.Guides[GID].zone) .. "   (" .. percentage .. "%)")
+                else
+                    WoWPro.TitleText:SetText((GID or WoWPro.Guides[GID].zone) .. "   (0%)")
+                end
             end
-        end
-    else
-        if WoWProDB.profile.guideprogress then
-            WoWPro.TitleText:SetText((WoWPro.Guides[GID].name or WoWPro.Guides[GID].zone) .. "   (" .. currentStep .. "/" .. total .. ")")
-        else
-            if total > 0 then
-                local percentage = math.floor((currentMainStep / total) * 100)
-                WoWPro.TitleText:SetText((WoWPro.Guides[GID].name or WoWPro.Guides[GID].zone) .. "   (" .. percentage .. "%)")
-            else
-                WoWPro.TitleText:SetText((GID or WoWPro.Guides[GID].zone) .. "   (0%)")
-            end
-        end
 
-        -- If the guide is complete, loading the next guide --
-        if WoWProCharDB.Guide[GID].done and not WoWPro.Recorder and WoWPro.Leveling and not WoWPro.Leveling.Resetting then
-            if WoWProDB.profile.autoload then
-                WoWProDB.char.currentguide = WoWPro:NextGuide(GID)
-                WoWPro:Print("Switching to next guide: %s",tostring(WoWProDB.char.currentguide))
-                WoWPro:LoadGuide()
-                return
-            else
-                WoWPro.NextGuideDialog:Show()
+            -- If the guide is complete, loading the next guide --
+            if WoWProCharDB.Guide[GID].done and not WoWPro.Recorder and WoWPro.Leveling and not WoWPro.Leveling.Resetting then
+                if WoWProDB.profile.autoload then
+                    WoWProDB.char.currentguide = WoWPro:NextGuide(GID)
+                    WoWPro:Print("Switching to next guide: %s",tostring(WoWProDB.char.currentguide))
+                    WoWPro:LoadGuide()
+                    return
+                else
+                    WoWPro.NextGuideDialog:Show()
+                end
             end
         end
+        WoWPro:MapPoint()
+        WoWPro:SendMessage("WoWPro_PostUpdateGuide")
+        -- Update content and formatting --
+        WoWPro.PaddingSet()
+        WoWPro.RowSet()
+        if not WoWPro.GuideUpdated then
+            WoWPro:dbp("[Broker]: First Guide Update completed.  Resuming normal processing.")
+            WoWPro.GuideUpdated = true
+            WoWPro.FirstUpdatePending = false
+            WoWPro:dbp("[Naughty Broker]: Invoke the ZONE_CHANGED_NEW_AREA event handler directly before Replay!")
+            WoWPro.ZONE_CHANGED_NEW_AREA("ZONE_CHANGED_NEW_AREA_GUIDE_UPDATE")
+            WoWPro.EventReplayStart()
+        end
     end
-    WoWPro:MapPoint()
-    WoWPro:SendMessage("WoWPro_PostUpdateGuide")
-    -- Update content and formatting --
-    WoWPro.PaddingSet()
-    WoWPro.RowSet()
-    if not WoWPro.GuideUpdated then
-        WoWPro:dbp("[Broker]: First Guide Update completed.  Resuming normal processing.")
-        WoWPro.GuideUpdated = true
-        WoWPro.FirstUpdatePending = false
-        WoWPro:dbp("[Naughty Broker]: Invoke the ZONE_CHANGED_NEW_AREA event handler directly before Replay!")
-        WoWPro.ZONE_CHANGED_NEW_AREA("ZONE_CHANGED_NEW_AREA_GUIDE_UPDATE")
-        WoWPro.EventReplayStart()
-    end
-end
     runUpdate()
     WoWPro.UpdateGuideRealInProgress = false
 end
-
 
 local Rep2IdAndClass
 Rep2IdAndClass = {
@@ -2359,8 +2126,6 @@ Rep2IdAndClass = {
     ["good friend"] = {4,true},
     ["best friend"] = {5,true},
 }
-
-
 
 -- Next Step --
 -- Determines the next active step --

--- a/WoWPro/WoWPro_Mists.toc
+++ b/WoWPro/WoWPro_Mists.toc
@@ -33,6 +33,7 @@ WoWPro_ZoneData.lua
 WoWPro_ZoneDataLegacy.lua
 WoWPro_Mapping.lua
 WoWPro_Broker.lua
+WoWPro_RowUpdate.lua
 WoWPro_AutoComplete.lua
 WoWPro_Events.lua
 WoWPro_Markup.lua

--- a/WoWPro/WoWPro_TBC.toc
+++ b/WoWPro/WoWPro_TBC.toc
@@ -33,6 +33,7 @@ WoWPro_ZoneData.lua
 WoWPro_ZoneDataLegacy.lua
 WoWPro_Mapping.lua
 WoWPro_Broker.lua
+WoWPro_RowUpdate.lua
 WoWPro_AutoComplete.lua
 WoWPro_Events.lua
 WoWPro_Markup.lua

--- a/WoWPro/WoWPro_Vanilla.toc
+++ b/WoWPro/WoWPro_Vanilla.toc
@@ -33,6 +33,7 @@ WoWPro_ZoneData.lua
 WoWPro_ZoneDataLegacy.lua
 WoWPro_Mapping.lua
 WoWPro_Broker.lua
+WoWPro_RowUpdate.lua
 WoWPro_AutoComplete.lua
 WoWPro_Events.lua
 WoWPro_Markup.lua


### PR DESCRIPTION
Extract RowUpdate helpers from Broker and isolate row-menu behavior

### Summary:
- Moves RowUpdate-specific logic out of Broker and into a dedicated RowUpdate file.
- Creates self-contained helpers for row rendering, dropdown generation, and related row behavior so Broker is no longer the owner of the update logic.
- Keeps Broker responsible for global lifecycle/state initialization while the extracted helpers safely guard against nil table cases and legacy call paths.
- Improves maintainability by reducing Broker coupling and keeping row update behavior grouped in one place.